### PR TITLE
Extract contract abis to config.json

### DIFF
--- a/src/base/orgs/Org.ts
+++ b/src/base/orgs/Org.ts
@@ -26,18 +26,6 @@ const GetOrgs = `
   }
 `;
 
-const orgFactoryAbi = [
-  "function createOrg(address) returns (address)",
-  "function createOrg(address[], uint256) returns (address)",
-  "event OrgCreated(address, address)",
-];
-
-const orgAbi = [
-  "function owner() view returns (address)",
-  "function setOwner(address)",
-  "function setName(string, address) returns (bytes32)",
-];
-
 export class Org {
   address: string
   safe: string
@@ -58,7 +46,7 @@ export class Org {
 
     const org = new ethers.Contract(
       this.address,
-      orgAbi,
+      config.abi.org,
       config.signer
     );
     return org.setName(name, config.provider.network.ensAddress,
@@ -70,7 +58,7 @@ export class Org {
 
     const org = new ethers.Contract(
       this.address,
-      orgAbi,
+      config.abi.org,
       config.signer
     );
     return org.setOwner(address);
@@ -136,7 +124,7 @@ export class Org {
   ): Promise<Org | null> {
     const org = new ethers.Contract(
       address,
-      orgAbi,
+      config.abi.org,
       config.provider
     );
 
@@ -159,7 +147,7 @@ export class Org {
 
     const orgFactory = new ethers.Contract(
       config.orgFactory.address,
-      orgFactoryAbi,
+      config.abi.orgFactory,
       config.signer
     );
 
@@ -176,7 +164,7 @@ export class Org {
 
     const orgFactory = new ethers.Contract(
       config.orgFactory.address,
-      orgFactoryAbi,
+      config.abi.orgFactory,
       config.signer
     );
 

--- a/src/base/registrations/registrar.ts
+++ b/src/base/registrations/registrar.ts
@@ -10,17 +10,6 @@ import type { Config } from '@app/config';
 import { unixTime } from '@app/utils';
 import { assert } from '@app/error';
 
-const registrarAbi = [
-  'function rad() view returns (address)',
-  'function radNode() view returns (bytes32)',
-  'function minCommitmentAge() view returns (uint256)',
-  'function registrationFeeRad() view returns (uint256)',
-  'function commitWithPermit(bytes32, address, uint256, uint256, uint8, bytes32, bytes32)',
-  'function register(string, address, uint256)',
-  'function valid(string) pure returns (bool)',
-  'function available(string) view returns (bool)',
-];
-
 export interface Registration {
   name: string
   owner: string
@@ -75,7 +64,7 @@ export async function getRegistration(name: string, config: Config): Promise<Reg
 }
 
 export function registrar(config: Config) {
-  return new ethers.Contract(config.registrar.address, registrarAbi, config.provider);
+  return new ethers.Contract(config.registrar.address, config.abi.registrar, config.provider);
 }
 
 export async function registrationFee(config: Config) {
@@ -213,16 +202,12 @@ function makeCommitment(name: string, owner: string, salt: Uint8Array): string {
 }
 
 async function getOwner(name: string, config: Config): Promise<string> {
-  const ensAbi = [
-    "function owner(bytes32 node) view returns (address)"
-  ];
-
   let ensAddr = config.provider.network.ensAddress;
   if (! ensAddr) {
     throw new Error("ENS address is not defined");
   }
 
-  let registry = new ethers.Contract(ensAddr, ensAbi, config.provider);
+  let registry = new ethers.Contract(ensAddr, config.abi.ens, config.provider);
   let owner = await registry.owner(ethers.utils.namehash(name));
 
   return owner;

--- a/src/base/registrations/resolver.ts
+++ b/src/base/registrations/resolver.ts
@@ -4,22 +4,16 @@ import { ethers } from 'ethers';
 import type { Config } from '@app/config';
 import { assert } from '@app/error';
 
-const resolverAbi = [
-  "function multicall(bytes[] calldata data) returns(bytes[] memory results)",
-  "function setAddr(bytes32 node, address addr)",
-  "function setText(bytes32 node, string calldata key, string calldata value)",
-];
-
 export type EnsRecord = { name: string, value: string };
 
 export async function setRecords(name: string, records: EnsRecord[], resolver: EnsResolver, config: Config): Promise<TransactionResponse> {
   assert(config.signer);
 
-  const resolverContract = new ethers.Contract(resolver.address, resolverAbi, config.signer);
+  const resolverContract = new ethers.Contract(resolver.address, config.abi.resolver, config.signer);
   const node = ethers.utils.namehash(`${name}.${config.registrar.domain}`);
 
   let calls = [];
-  const iface = new ethers.utils.Interface(resolverAbi);
+  const iface = new ethers.utils.Interface(config.abi.resolver);
 
   for (let r of records) {
     switch (r.name) {

--- a/src/base/vesting/vesting.ts
+++ b/src/base/vesting/vesting.ts
@@ -4,22 +4,6 @@ import * as session from "@app/session";
 import { State, state } from "./state";
 import type { Config } from "@app/config";
 
-const abi = [
-  "function token() view returns (address)",
-  "function totalVestingAmount() view returns (uint256)",
-  "function vestingStartTime() view returns (uint256)",
-  "function vestingPeriod() view returns (uint256)",
-  "function cliffPeriod() view returns (uint256)",
-  "function beneficiary() view returns (address)",
-  "function interrupted() view returns (bool)",
-  "function withdrawn() view returns (uint256)",
-  "function withdrawableBalance() view returns (uint256)",
-  "function withdrawVested()",
-];
-
-const tokenAbi = [
-  "function symbol() view returns (string)",
-];
 
 export interface VestingInfo {
   token: string,
@@ -31,7 +15,7 @@ export interface VestingInfo {
 }
 
 export async function withdrawVested(address: string, config: Config) {
-  const contract = new ethers.Contract(address, abi, config.provider);
+  const contract = new ethers.Contract(address, config.abi.vesting, config.provider);
   const signer = config.provider.getSigner();
 
   state.set(State.WithdrawingSign);
@@ -45,7 +29,7 @@ export async function withdrawVested(address: string, config: Config) {
 }
 
 export async function getInfo(address: string, config: Config): Promise<VestingInfo> {
-  const contract = new ethers.Contract(address, abi, config.provider);
+  const contract = new ethers.Contract(address, config.abi.vesting, config.provider);
   const signer = config.provider.getSigner();
 
   const token = await contract.token();
@@ -54,7 +38,7 @@ export async function getInfo(address: string, config: Config): Promise<VestingI
   const withdrawn = await contract.withdrawn();
   const total = await contract.totalVestingAmount();
 
-  const tokenContract = new ethers.Contract(token, tokenAbi, config.provider);
+  const tokenContract = new ethers.Contract(token, config.abi.token, config.provider);
   const symbol = await tokenContract.symbol();
 
   return {

--- a/src/config.json
+++ b/src/config.json
@@ -57,5 +57,53 @@
   },
   "seed": {
     "url": "https://sprout.radicle.xyz"
+  },
+  "abi": {
+    "registrar": [
+      "function rad() view returns (address)",
+      "function radNode() view returns (bytes32)",
+      "function minCommitmentAge() view returns (uint256)",
+      "function registrationFeeRad() view returns (uint256)",
+      "function commitWithPermit(bytes32, address, uint256, uint256, uint8, bytes32, bytes32)",
+      "function register(string, address, uint256)",
+      "function valid(string) pure returns (bool)",
+      "function available(string) view returns (bool)"
+    ],
+    "token": [
+      "function balanceOf(address) view returns (uint256)",
+      "function approve(address, uint256) returns (bool)",
+      "function allowance(address, address) view returns (uint256)",
+      "function DOMAIN_SEPARATOR() view returns (bytes32)",
+      "function name() pure returns (string)",
+      "function nonces(address) view returns (uint256)"
+    ],
+    "resolver": [
+      "function multicall(bytes[] calldata data) returns(bytes[] memory results)",
+      "function setAddr(bytes32 node, address addr)",
+      "function setText(bytes32 node, string calldata key, string calldata value)"
+    ],
+    "orgFactory": [
+      "function createOrg(address) returns (address)",
+      "function createOrg(address[], uint256) returns (address)",
+      "event OrgCreated(address, address)"
+    ],
+    "org": [
+      "function owner() view returns (address)",
+      "function setOwner(address)",
+      "function setName(string, address) returns (bytes32)"
+    ],
+    "vesting": [
+      "function token() view returns (address)",
+      "function totalVestingAmount() view returns (uint256)",
+      "function vestingStartTime() view returns (uint256)",
+      "function vestingPeriod() view returns (uint256)",
+      "function cliffPeriod() view returns (uint256)",
+      "function beneficiary() view returns (address)",
+      "function interrupted() view returns (bool)",
+      "function withdrawn() view returns (uint256)",
+      "function withdrawableBalance() view returns (uint256)",
+      "function withdrawVested()"
+    ],
+    "ens": ["function owner(bytes32 node) view returns (address)"]
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,7 @@ export class Config {
   signer: ethers.Signer & TypedDataSigner | null;
   seed: { url: string };
   safe: { api: string | null, viewer: string | null };
+  abi: { [contract:string]: string[] }
 
   constructor(
     network: { name: string, chainId: number },
@@ -50,6 +51,7 @@ export class Config {
     this.signer = signer;
     this.gasLimits = gasLimits;
     this.seed = config.seed;
+    this.abi = config.abi;
   }
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -47,7 +47,7 @@ export const createState = (initial: State) => {
         console.error(e);
       }
 
-      const token = new ethers.Contract(config.radToken.address, tokenAbi, config.provider);
+      const token = new ethers.Contract(config.radToken.address, config.abi.token, config.provider);
       const signer = config.provider.getSigner();
       const address = await signer.getAddress();
 
@@ -76,7 +76,7 @@ export const createState = (initial: State) => {
       const addr = state.session.address;
 
       try {
-        const token = new ethers.Contract(config.radToken.address, tokenAbi, config.provider);
+        const token = new ethers.Contract(config.radToken.address, config.abi.token, config.provider);
         const tokenBalance = await token.balanceOf(addr);
 
         state.session.tokenBalance = tokenBalance;
@@ -171,17 +171,8 @@ state.subscribe(s => {
   console.log("session.state", s);
 });
 
-const tokenAbi = [
-  "function balanceOf(address) view returns (uint256)",
-  "function approve(address, uint256) returns (bool)",
-  "function allowance(address, address) view returns (uint256)",
-  "function DOMAIN_SEPARATOR() view returns (bytes32)",
-  "function name() pure returns (string)",
-  "function nonces(address) view returns (uint256)",
-];
-
 export async function approveSpender(spender: string, amount: BigNumber, config: Config) {
-  const token = new ethers.Contract(config.radToken.address, tokenAbi, config.provider);
+  const token = new ethers.Contract(config.radToken.address, config.abi.token, config.provider);
   const signer = config.provider.getSigner();
   const addr = await signer.getAddress();
 
@@ -194,7 +185,7 @@ export async function approveSpender(spender: string, amount: BigNumber, config:
 }
 
 export function token(config: Config): ethers.Contract {
-  return new ethers.Contract(config.radToken.address, tokenAbi, config.provider);
+  return new ethers.Contract(config.radToken.address, config.abi.token, config.provider);
 }
 
 export function disconnectWallet() {


### PR DESCRIPTION
Hello @cloudhead,

I was looking into the registration workflow and thought it would be a good idea to check the users RAD balance to be higher than the`registrar.registrationFeeRad` before sending the tx, looking into this I started to extract all the contract ABIs into the `config.json` file.

IMHO the code gets cleaner and it reduces code duplication.
Please let me know what you think.

Cheers