### PR TITLE
Validate RAD balance before commit tx

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -9,6 +9,7 @@ export interface Err {
 export enum Failure {
   TransactionFailed = 1,
   NotAuthenticated = 2,
+  InsufficientBalance = 3,
 }
 
 export const error = writable<Err | null>(null);


### PR DESCRIPTION
Hi @cloudhead,

Sorry for the consecutive PRs but I wanted to build upon the ABIs refactoring with this PR, and I don't like to propose changes of different kind in the same PR.

Trying to register my name yesterday I spend fee for a tx without having enough RAD tokens, so the idea is to stop the user that he has not enough RAD to register a name before he spends ETH in the tx.

I'm also thinking about writing some kind of util function for the construction of the `ethers.Contract` instance

Cheers