### PR TITLE
Validate network and reloads on change

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -36,8 +36,8 @@ export class Config {
   ) {
     let cfg = (<Record<string, any>> config)[network.name];
     
-    if(!config.hasOwnProperty(network.name.toLowerCase())) {
-      throw `Network ${network.name} is not supported`
+    if (!cfg) {
+      throw `Network ${network.name} is not supported`;
     }
 
     this.network = network;

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,10 @@ export class Config {
     signer: ethers.Signer & TypedDataSigner | null,
   ) {
     let cfg = (<Record<string, any>> config)[network.name];
+    
+    if(!config.hasOwnProperty(network.name.toLowerCase())) {
+      throw `Network ${network.name} is not supported`
+    }
 
     this.network = network;
     this.registrar = cfg.registrar;

--- a/src/session.ts
+++ b/src/session.ts
@@ -164,6 +164,8 @@ export const session = derived(state, s => {
   return null;
 });
 
+window.ethereum?.on('chainChanged', () => location.reload());
+
 // Updates state when user changes accounts
 window.ethereum?.on("accountsChanged", state.setChangedAccount);
 


### PR DESCRIPTION
This PR closes #10 

It uses the `window.ethereum.on('chainChanged')` event from Metamask, and in the `config.ts` constructor checks if the network is supported.

Eventually we could disable the connect button if the network is not supported instead of the fullscreen error, or change the current fullscreen `<Modal>` error with the `<Error>` component used by failed transactions.
Please let me know what you think @cloudhead 