### PR TITLE
Implement code formatter

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,32 @@
+module.exports = {
+  env: {
+    browser: true,
+    node: true,
+  },
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: 12,
+    sourceType: "module",
+  },
+  plugins: [
+    "svelte3",
+    "@typescript-eslint"
+  ],
+  overrides: [
+    {
+      files: ["*.svelte"],
+      processor: "svelte3/svelte3",
+    }
+  ],
+  rules: {
+    "@typescript-eslint/no-explicit-any": "off",
+    indent: ["error", 2, { "SwitchCase": 1 }]
+  },
+  settings: {
+    "svelte3/typescript": true, 
+  },
+};

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -1,0 +1,12 @@
+name: check-format
+on: [push]
+
+jobs:
+  check-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - run: npm ci
+      - run: ./scripts/check-format
+        shell: bash

--- a/scripts/check-format
+++ b/scripts/check-format
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Checks local /node_modules,
+# if not found will download that package and execute it.
+# Does not modify files, informs bad code format
+npx eslint .


### PR DESCRIPTION
This PR closes #6 

I used `prettier` and `prettier-plugin-svelte` to implement a code formatter.
The configuration is pretty simple and originally from `radicle-upstream` with some minor changes for this repo.

To be able to use GitHub CI I created a very bare GitHub Action, and the core is in the shell script `scripts/format`

Let us discuss here which format options are the correct ones for this repo
https://prettier.io/docs/en/options.html

