### PR TITLE
Add User View Route

### DIFF
--- a/src/Address.svelte
+++ b/src/Address.svelte
@@ -1,12 +1,10 @@
 <script lang="typescript">
   import { onMount } from 'svelte';
-  import { navigate } from 'svelte-routing';
   import { link } from 'svelte-routing';
   import { ethers } from 'ethers';
   import { safeLink, identifyAddress, formatAddress, AddressType } from '@app/utils';
   import Loading from '@app/Loading.svelte';
   import Avatar from "@app/Avatar.svelte";
-  import Error from '@app/Error.svelte';
   import type { Config } from '@app/config';
   import type { Registration } from '@app/base/registrations/registrar';
   import { getRegistration } from '@app/base/registrations/registrar';
@@ -23,13 +21,13 @@
     : ethers.utils.getAddress(address);
   let addressType: AddressType | null = null;
   let addressName: string | null = null;
-  let getInfo: Promise<Registration | null>;
+  let info: Registration | null;
 
   onMount(async () => {
     identifyAddress(address, config).then((t: AddressType) => addressType = t);
     if (resolve) {
       addressName = await config.provider.lookupAddress(address);
-      getInfo = getRegistration(addressName, config);
+      info = await getRegistration(addressName, config);
     }
   });
   $: addressLabel = addressName ?? checksumAddress;
@@ -56,28 +54,22 @@
   }
 </style>
 
-{#await getInfo}
-  <Loading fadeIn />
-{:then info}
-  <div class="address" title={address} class:no-badge={noBadge}>
-    {#if !noAvatar}
-      <Avatar inline source={info?.avatar ?? address} />
-    {/if}
-    {#if addressType === AddressType.Org}
-      <a use:link href={`/orgs/${address}`}>{addressLabel}</a>
-      <span class="badge">org</span>
-    {:else if addressType === AddressType.Safe}
-      <a href={safeLink(address, config)} target="_blank">{addressLabel}</a>
-      <span class="badge safe">safe</span>
-    {:else if addressType === AddressType.Contract}
-      <a href={`/orgs/${address}`} target="_blank">{addressLabel}</a>
-      <span class="badge">contract</span>
-    {:else if addressType === AddressType.EOA}
-      <a href={`/users/${address}`} target="_blank">{addressLabel}</a>
-    {:else if !noBadge}
-      <div class="loading"><Loading small /></div>
-    {/if}
-  </div>
-{:catch error}
-  <Error {error} title="Address could not be loaded" on:close={() => navigate('/')} />
-{/await}
+<div class="address" title={address} class:no-badge={noBadge}>
+  {#if !noAvatar}
+    <Avatar inline source={info?.avatar ?? address} />
+  {/if}
+  {#if addressType === AddressType.Org}
+    <a use:link href={`/orgs/${address}`}>{addressLabel}</a>
+    <span class="badge">org</span>
+  {:else if addressType === AddressType.Safe}
+    <a href={safeLink(address, config)} target="_blank">{addressLabel}</a>
+    <span class="badge safe">safe</span>
+  {:else if addressType === AddressType.Contract}
+    <a href={`/orgs/${address}`} target="_blank">{addressLabel}</a>
+    <span class="badge">contract</span>
+  {:else if addressType === AddressType.EOA}
+    <a href={`/users/${address}`} target="_blank">{addressLabel}</a>
+  {:else if !noBadge}
+    <div class="loading"><Loading small /></div>
+  {/if}
+</div>

--- a/src/Address.svelte
+++ b/src/Address.svelte
@@ -59,26 +59,25 @@
 {#await getInfo}
   <Loading fadeIn />
 {:then info}
-<div class="address" title={address} class:no-badge={noBadge}>
-  {#if !noAvatar}
+  <div class="address" title={address} class:no-badge={noBadge}>
+    {#if !noAvatar}
       <Avatar inline source={info?.avatar ?? address} />
-  {/if}
-  {#if addressType === AddressType.Org}
-    <a use:link href={`/orgs/${address}`}>{addressLabel}</a>
-    <span class="badge">org</span>
-  {:else if addressType === AddressType.Safe}
-    <a href={safeLink(address, config)} target="_blank">{addressLabel}</a>
-    <span class="badge safe">safe</span>
-  {:else}
-    <a href={`/users/${address}`} target="_blank">{addressLabel}</a>
-    {#if addressType === AddressType.Contract}
+    {/if}
+    {#if addressType === AddressType.Org}
+      <a use:link href={`/orgs/${address}`}>{addressLabel}</a>
+      <span class="badge">org</span>
+    {:else if addressType === AddressType.Safe}
+      <a href={safeLink(address, config)} target="_blank">{addressLabel}</a>
+      <span class="badge safe">safe</span>
+    {:else if addressType === AddressType.Contract}
+      <a href={`/orgs/${address}`} target="_blank">{addressLabel}</a>
       <span class="badge">contract</span>
     {:else if addressType === AddressType.EOA}
-      <!-- Don't show anything for EOAs -->
+      <a href={`/users/${address}`} target="_blank">{addressLabel}</a>
     {:else if !noBadge}
       <div class="loading"><Loading small /></div>
     {/if}
-</div>
+  </div>
 {:catch error}
   <Error {error} title="Address could not be loaded" on:close={() => navigate('/')} />
 {/await}

--- a/src/Address.svelte
+++ b/src/Address.svelte
@@ -6,6 +6,7 @@
   import Loading from '@app/Loading.svelte';
   import type { Config } from '@app/config';
   import type { Registration } from '@app/base/registrations/registrar';
+  import Avatar from "@app/Avatar.svelte";
   import { getRegistration } from '@app/base/registrations/registrar';
   import { identifyAddress, formatAddress, AddressType } from '@app/utils';
 
@@ -13,6 +14,7 @@
   export let config: Config;
   export let resolve = false;
   export let noBadge = false;
+  export let noAvatar = false;
   export let compact = false;
 
   let checksumAddress = compact
@@ -39,6 +41,7 @@
   .address {
     display: flex;
     align-items: center;
+    height: 100%;
   }
   .address.no-badge .badge {
     display: none;
@@ -59,6 +62,9 @@
   <Loading fadeIn/>
 {:else}
 <div class="address" title={address} class:no-badge={noBadge}>
+  {#if !noAvatar}
+    <Avatar source={registration?.avatar ?? address} />
+  {/if}
   {#if addressType === AddressType.Org}
     <a use:link href={`/orgs/${address}`}>{addressLabel}</a>
     <span class="badge">org</span>

--- a/src/Address.svelte
+++ b/src/Address.svelte
@@ -5,6 +5,8 @@
   import { safeLink } from '@app/utils';
   import Loading from '@app/Loading.svelte';
   import type { Config } from '@app/config';
+  import type { Registration } from '@app/base/registrations/registrar';
+  import { getRegistration } from '@app/base/registrations/registrar';
   import { identifyAddress, formatAddress, AddressType } from '@app/utils';
 
   export let address: string;
@@ -17,12 +19,14 @@
     ? formatAddress(address)
     : ethers.utils.getAddress(address);
   let loading: boolean = true;
+  let registration: Registration | null = null;
   let addressType: AddressType | null = null;
   let addressName: string | null = null;
 
   onMount(async () => {
     if (resolve) {
       addressName = await config.provider.lookupAddress(address);
+      if (addressName) registration = await getRegistration(addressName, config);
     }
     addressType = await identifyAddress(address, config);
     loading = false;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -7,6 +7,7 @@
   import Vesting from '@app/base/vesting/Index.svelte';
   import Registrations from '@app/base/registrations/Routes.svelte';
   import Orgs from '@app/base/orgs/Routes.svelte';
+  import Users from '@app/base/users/Routes.svelte';
   import Projects from '@app/base/projects/Routes.svelte';
   import Resolver from '@app/base/resolver/Routes.svelte';
   import Header from '@app/Header.svelte';
@@ -61,6 +62,7 @@
         </Route>
         <Registrations {config} session={$session} />
         <Orgs {config} />
+        <Users {config} />
         <Projects {config} />
         <Resolver {config} />
       </Router>

--- a/src/Avatar.svelte
+++ b/src/Avatar.svelte
@@ -1,0 +1,50 @@
+<script lang="typescript">
+  import { onMount } from 'svelte';
+  import { createIcon } from '@app/blockies';
+  import { isAddress } from './utils';
+  
+  export let source: string;
+  export let icon: boolean = true;
+  export let glowOnHover = false;
+
+  let container: HTMLElement;
+
+  onMount(() => {
+    if(isAddress(source)) {
+      const seed = source.toLowerCase();
+      const avatar = createIcon({
+        seed,
+        size: 8,
+        scale: 16,
+      });
+      container.style.backgroundImage = `url(${avatar.toDataURL()})`;
+    }
+  });
+</script>
+
+<style>
+  .avatar {
+    border-radius: 50%;
+    min-width: 1rem;
+    min-height: 1rem;
+    width: 100%;
+    height: 100%;
+    background-size: cover;
+    background-repeat: no-repeat;
+  }
+  .avatar.glowOnHover:hover {
+    box-shadow: 0 0 3rem var(--color-secondary);
+  }
+  .icon {
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    margin-right: 0.5rem;
+  }
+</style>
+
+{#if isAddress(source)}
+  <div class="avatar" class:icon bind:this={container} class:glowOnHover title={source}/>
+{:else}
+  <img class="avatar" class:icon src={source} class:glowOnHover alt="avatar"/>
+{/if}

--- a/src/Avatar.svelte
+++ b/src/Avatar.svelte
@@ -1,16 +1,16 @@
 <script lang="typescript">
   import { onMount } from 'svelte';
   import { createIcon } from '@app/blockies';
-  import { isAddress } from './utils';
+  import { isAddress } from '@app/utils';
   
   export let source: string;
-  export let icon: boolean = true;
+  export let inline = false;
   export let glowOnHover = false;
 
   let container: HTMLElement;
 
   onMount(() => {
-    if(isAddress(source)) {
+    if (isAddress(source)) {
       const seed = source.toLowerCase();
       const avatar = createIcon({
         seed,
@@ -35,7 +35,7 @@
   .avatar.glowOnHover:hover {
     box-shadow: 0 0 3rem var(--color-secondary);
   }
-  .icon {
+  .inline {
     display: inline-block;
     width: 1rem;
     height: 1rem;
@@ -44,7 +44,7 @@
 </style>
 
 {#if isAddress(source)}
-  <div class="avatar" class:icon bind:this={container} class:glowOnHover title={source}/>
+  <div class="avatar" class:inline bind:this={container} class:glowOnHover title={source}/>
 {:else}
-  <img class="avatar" class:icon src={source} class:glowOnHover alt="avatar"/>
+  <img class="avatar" class:inline src={source} class:glowOnHover alt="avatar"/>
 {/if}

--- a/src/base/users/Routes.svelte
+++ b/src/base/users/Routes.svelte
@@ -1,0 +1,11 @@
+<script lang="typescript">
+  import { Route } from "svelte-routing";
+  import View from '@app/base/users/View.svelte';
+  import type { Config } from '@app/config';
+
+  export let config: Config;
+</script>
+
+<Route path="/users/:address" let:params>
+  <View {config} address={params.address}/>
+</Route>

--- a/src/base/users/View.svelte
+++ b/src/base/users/View.svelte
@@ -1,0 +1,99 @@
+<script lang="typescript">
+  import { onMount } from 'svelte';
+  import type { Config } from '@app/config';
+  import type { Registration } from '@app/base/registrations/registrar';
+  import { getRegistration } from '@app/base/registrations/registrar';
+  import Icon from '@app/Icon.svelte';
+  import Blockies from '@app/Blockies.svelte';
+  import Loading from '@app/Loading.svelte';
+  import Address from '@app/Address.svelte';
+
+  export let address: string;
+  export let config: Config;
+
+  let loading: boolean = true;
+  let registration: Registration | null = null;
+  let name: string | null = null;
+
+  onMount(async () => {
+    name = await config.provider.lookupAddress(address);
+    if (name) registration = await getRegistration(name, config);
+    loading = false;
+  });
+</script>
+
+<style>
+  main {
+    padding: 5rem 0;
+  }
+  main > header {
+    display: flex;
+    align-items: center;
+    justify-content: left;
+    margin-bottom: 2rem;
+  }
+  main > header > * {
+    margin: 0 1rem 0 0;
+  }
+  .info {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: left;
+  }
+  .info a {
+    border: none;
+  }
+  .avatar {
+    width: 64px;
+    height: 64px;
+  }
+  .avatar img {
+    border-radius: 50%; /* Allowing to maintain the circular design of the avatars */
+  }
+  .links {
+    display: flex;
+    align-items: center;
+    justify-content: left;
+  }
+  .url {
+    display: flex; /* Ensures correct vertical positioning of icons */
+    margin-right: 1rem;
+  }
+</style>
+
+{#if loading}
+  <Loading fadeIn />
+{:else}
+  <main>
+    <header>
+      <div class="avatar">
+        {#if registration && registration.avatar}
+          <img class="avatar" src={registration.avatar} alt="avatar" />
+        {:else}
+          <Blockies {address} />
+        {/if}
+      </div>
+      <div class="info">
+        <span class="title bold"><Address {address} {config} resolve/></span>
+        <div class="links">
+          {#if registration}
+            {#if registration.url}
+              <a class="url" href={registration.url}>{registration.url}</a>
+            {/if}
+            {#if registration.twitter}
+              <a class="url" href={registration.twitter}>
+                <Icon name="twitter" />
+              </a>
+            {/if}
+            {#if registration.github}
+              <a class="url" href={registration.github}>
+                <Icon name="github" />
+              </a>
+            {/if}
+          {/if}
+        </div>
+      </div>
+    </header>
+  </main>
+{/if}

--- a/src/base/users/View.svelte
+++ b/src/base/users/View.svelte
@@ -1,24 +1,21 @@
 <script lang="typescript">
   import { onMount } from 'svelte';
-  import { navigate } from 'svelte-routing';
   import type { Config } from '@app/config';
   import type { Registration } from '@app/base/registrations/registrar';
   import { getRegistration } from '@app/base/registrations/registrar';
   import Icon from '@app/Icon.svelte';
-  import Loading from '@app/Loading.svelte';
   import Address from '@app/Address.svelte';
   import Avatar from '@app/Avatar.svelte';
-  import Error from '@app/Error.svelte';
 
   export let address: string;
   export let config: Config;
   
   let addressName: string | null = null;
-  let getInfo: Promise<Registration | null>;
+  let info: Registration | null;
   
   onMount(async () => {
     addressName = await config.provider.lookupAddress(address);
-    getInfo = getRegistration(addressName, config);
+    info = await getRegistration(addressName, config);
   });
 </script>
 
@@ -59,16 +56,13 @@
   }
 </style>
 
-{#await getInfo}
-  <Loading fadeIn />
-{:then info}
-  <main>
-    <header>
-      <div class="avatar">
-        <Avatar source={info?.avatar ?? address} />
-      </div> 
-      <div class="info">
-        <span class="title bold"><Address noAvatar {address} {config} resolve/></span>
+<main>
+  <header>
+    <div class="avatar">
+      <Avatar source={info?.avatar ?? address} />
+    </div> 
+    <div class="info">
+      <span class="title bold"><Address noAvatar {address} {config} resolve/></span>
         <div class="links">
           {#if info?.url}
             <a class="url" href={info.url}>{info.url}</a>
@@ -87,6 +81,3 @@
       </div>
     </header> 
   </main>
-{:catch error}
-  <Error {error} title="User could not be loaded" on:close={() => navigate('/')} />
-{/await}

--- a/src/base/users/View.svelte
+++ b/src/base/users/View.svelte
@@ -7,6 +7,7 @@
   import Blockies from '@app/Blockies.svelte';
   import Loading from '@app/Loading.svelte';
   import Address from '@app/Address.svelte';
+  import Avatar from '@app/Avatar.svelte';
 
   export let address: string;
   export let config: Config;
@@ -48,9 +49,6 @@
     width: 64px;
     height: 64px;
   }
-  .avatar img {
-    border-radius: 50%; /* Allowing to maintain the circular design of the avatars */
-  }
   .links {
     display: flex;
     align-items: center;
@@ -68,11 +66,7 @@
   <main>
     <header>
       <div class="avatar">
-        {#if registration && registration.avatar}
-          <img class="avatar" src={registration.avatar} alt="avatar" />
-        {:else}
-          <Blockies {address} />
-        {/if}
+        <Avatar icon={false} source={state.registration?.avatar ?? address} />
       </div>
       <div class="info">
         <span class="title bold"><Address {address} {config} resolve/></span>


### PR DESCRIPTION
This PR works on #17

- It implements a new User route `/users/:address` which shows a user profile, with avatar or blockies as a fallback and the profile links.
- Adds a loading flag to show only the final state of the profile
- If one access the route with a contract address it also shows the stored information on ENS.
- Removes the Blockies from the Address component, so it can be decided by each page if it wants to show.

To test the implementation you could use the address `0xef1B2D659F4662f6a1e4a1B4791A1B4cEFF8FbA1` for sebastinez.rad.eth