### PR TITLE
Add READABLE_STREAM process env

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,10 @@ const config: UserConfig = {
       "stream": path.resolve("./src/polyfills/stream.ts"),
     },
   },
+  define: {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    "process.env": { READABLE_STREAM: "disable" }
+  },
   build: {
     outDir: "build",
     sourcemap: true


### PR DESCRIPTION
This PR fixes the issue with gnosis safe trying to read `process.env` in the browser and forces it to use our stream polyfill.