### PR TITLE
Add commitment progress bar

### DIFF
--- a/src/BlockTimer.svelte
+++ b/src/BlockTimer.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import type { Config } from "@app/config";
+
+  export let config: Config;
+  export let startBlock: number;
+  export let duration: number;
+
+  let currentBlock: number = startBlock;
+
+  config.provider.on("block", (latestBlock: number) => {
+    if (startBlock + duration > currentBlock) currentBlock = latestBlock;
+  });
+</script>
+
+<style>
+  .parent {
+    text-align: center;
+    height: 20px;
+    width: 290px;
+    border-radius: 5px;
+    background-color: var(--color-secondary-background);
+  }
+  .loader {
+    color: #fff;
+    height: 20px;
+    width: 0px;
+    border-radius: 5px;
+    background-color: var(--color-secondary);
+  }
+</style>
+
+<div class="parent">
+  <div class="loader" style="width: {(currentBlock - startBlock) * 10}%" />
+</div>


### PR DESCRIPTION
This PR solves #33

It implements a new component called `BlockTimer` that could eventually be used in other use cases where one has to wait for a specific quantity of blocks to be mined.
It takes a starting block number and the number of blocks it needs to fill up to 100%.

To implement it in the registration process I did some changes to the `Connection` type to implement the `commitmentBlock` and `minAge`, and avoid refetching it later.

P.S. For some reason the `tx` object in the `commit` fn in `registrar.ts` did not include blockNumber or hash, thats why I'm feching the tx receipt to obtain the `commitmentBlock`