### PR TITLE
Add await to isSafe check

### DIFF
--- a/src/ens/SetName.svelte
+++ b/src/ens/SetName.svelte
@@ -44,7 +44,7 @@
 
     if (resolved && isAddressEqual(resolved, org.address)) {
       try {
-        if (utils.isSafe(org.owner, config)) {
+        if (await utils.isSafe(org.owner, config)) {
           state = State.Proposing;
           await org.setNameMultisig(domain, config);
           state = State.Proposed;


### PR DESCRIPTION
Trying to set a name for a newly created single owner org I found that checking if the org address was a safe it failed.
After a little debugging session, I found the `isSafe` function that returns a promise was not being awaited in the `SetName` component.

Let me know if you want me to squash this commit somewhere, or if you want to commit it with other changes.

I created the PR to implement this fix asap