### PR TITLE
Add Gnosis Safe Mainnet to config

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -16,7 +16,7 @@
     },
     "safe": {
       "api": "https://safe-transaction.gnosis.io",
-      "subgraph": null,
+      "subgraph": "https://api.thegraph.com/subgraphs/name/radicle-dev/gnosis-safe",
       "viewer": "https://gnosis-safe.io/app/#/safes"
     },
     "tokens": []


### PR DESCRIPTION
This PR fixes #47 with adding the mainnet gnosis safe to the `config.json` file.