### PR TITLE
Add projects to user profile

### DIFF
--- a/src/base/orgs/Org.ts
+++ b/src/base/orgs/Org.ts
@@ -216,6 +216,14 @@ export class Org {
     }
   }
 
+  // Return only Orgs that have a specific user as owner
+  static async getOrgsByOwner(owner: string, config: Config): Promise<Org[]> {
+    const orgsResult = await utils.querySubgraph(config.orgs.subgraph, GetOrgsByOwner, { owners: [owner] });
+    return orgsResult.orgs.map((o: { id: string; owner: string }) => {
+      return new Org(o.id, o.owner);
+    });
+  }
+
   static async getOrgsByMember(memberAddr: string, config: Config): Promise<Org[]> {
     const safeResult = await utils.querySubgraph(
       config.safe.subgraph, GetSafes, { owners: [memberAddr] }

--- a/src/base/users/View.svelte
+++ b/src/base/users/View.svelte
@@ -84,7 +84,7 @@
       </div>
     </header>
       <div class="projects">
-        {#await Org.getOrgsByMember(address, config)}
+        {#await Org.getOrgsByOwner(address, config)}
           <Loading center fadeIn />
         {:then orgs}
           {#each orgs as org}

--- a/src/base/users/View.svelte
+++ b/src/base/users/View.svelte
@@ -5,6 +5,9 @@
   import Avatar from '@app/Avatar.svelte';
   import { Profile } from '@app/profile';
   import Loading from '@app/Loading.svelte';
+  import { Org } from '@app/base/orgs/Org';
+  import Message from '@app/Message.svelte';
+  import Project from '@app/base/projects/Widget.svelte';
 
   export let address: string;
   export let config: Config;
@@ -45,6 +48,12 @@
     display: flex; /* Ensures correct vertical positioning of icons */
     margin-right: 1rem;
   }
+  .projects {
+    margin-top: 2rem;
+  }
+  .projects .project {
+    margin-bottom: 1rem;
+  }
 </style>
 
 {#await Profile.get(address, config)}
@@ -74,5 +83,24 @@
         </div>
       </div>
     </header>
+      <div class="projects">
+        {#await Org.getOrgsByMember(address, config)}
+          <Loading center fadeIn />
+        {:then orgs}
+          {#each orgs as org}
+            {#await org.getProjects(config) then projects}
+              {#each projects as project}
+                <div class="project">
+                  <Project {project} org={org.address} {config} seed={profile.seed} />
+                </div>
+              {/each}
+            {:catch err}
+              <Message error>
+                <strong>Error: </strong> failed to load projects: {err.message}.
+              </Message>
+            {/await}
+          {/each}
+        {/await}
+      </div>
   </main>
 {/await}


### PR DESCRIPTION
This PR works on #54 

It works the same way as the project listing on the Orgs View in: https://github.com/radicle-dev/radicle-interface/blob/b30c5f75ec979dbce4bb98e20a0084e5d082dc51/src/base/orgs/View.svelte#L217

But instead of getting the org by address it gets all the orgs where the user is owner and fetches all projects of each org..

Eventual improvements: We could eventually generate a `getOrgsProjectsByMember` that would work as a wrapper for the former so we don't need to fetch first all the Orgs and then all Projects.