### PR TITLE
Reduce number of requests for profiles

### DIFF
--- a/src/Address.svelte
+++ b/src/Address.svelte
@@ -3,7 +3,7 @@
   import { link } from 'svelte-routing';
   import { ethers } from 'ethers';
   import { safeLink, explorerLink, identifyAddress, formatAddress, AddressType, parseEnsLabel } from '@app/utils';
-  import { Profile } from '@app/profile';
+  import { Profile, ProfileType } from '@app/profile';
   import Loading from '@app/Loading.svelte';
   import Avatar from "@app/Avatar.svelte";
   import type { Config } from '@app/config';
@@ -25,7 +25,7 @@
   onMount(async () => {
     identifyAddress(address, config).then((t: AddressType) => addressType = t);
     if (resolve && !profile) {
-      Profile.get(address, config).then(p => profile = p);
+      Profile.get(address, ProfileType.Minimal, config).then(p => profile = p);
     }
   });
   $: addressLabel = profile?.name ? compact ? parseEnsLabel(profile.name, config) : profile.name : checksumAddress;

--- a/src/Header.svelte
+++ b/src/Header.svelte
@@ -8,7 +8,7 @@
   import Logo from '@app/Logo.svelte';
   import Connect from '@app/Connect.svelte';
   import type { Config } from '@app/config';
-  import { Profile } from "@app/profile";
+  import { Profile, ProfileType } from "@app/profile";
   import Avatar from "./Avatar.svelte";
 
   export let session: Session | null;
@@ -154,7 +154,7 @@
         on:mouseout={() => sessionButtonHover = false}
         on:blur={() => sessionButtonHover = false}
       >
-        {#await Profile.get(address, config)}
+        {#await Profile.get(address, ProfileType.Minimal, config)}
           <Loading small center />
         {:then profile}
           {#if sessionButtonHover}

--- a/src/base/orgs/Org.ts
+++ b/src/base/orgs/Org.ts
@@ -3,7 +3,7 @@ import type { TransactionResponse } from '@ethersproject/providers';
 import type { ContractReceipt } from '@ethersproject/contracts';
 import { OperationType } from "@gnosis.pm/safe-core-sdk-types";
 
-import { Profile } from '@app/profile';
+import { Profile, ProfileType } from '@app/profile';
 import { assert } from '@app/error';
 import * as utils from '@app/utils';
 import type { Config } from '@app/config';
@@ -142,8 +142,12 @@ export class Org {
     return projects;
   }
 
-  async getProfile(config: Config): Promise<Profile> {
-    return Org.getProfile(this.address, config);
+  async getProfile(profileType: ProfileType, config: Config): Promise<Profile> {
+    return Org.getProfile(this.address, profileType, config);
+  }
+
+  static async getProjectProfile(addr: string, config: Config): Promise<Profile> {
+    return Org.getProfile(addr, ProfileType.Project, config);
   }
 
   static async getAnchor(orgAddr: string, urn: string, config: Config): Promise<string | null> {
@@ -214,8 +218,8 @@ export class Org {
 
   // Return the org profile if there is one, otherwise try to get the profile
   // of its owner.
-  static async getProfile(address: string, config: Config): Promise<Profile> {
-    const profile = await Profile.get(address, config);
+  static async getProfile(address: string, profileType: ProfileType, config: Config): Promise<Profile> {
+    const profile = await Profile.get(address, profileType, config);
 
     if (profile.ens) { // Orgs only use ENS for profile information.
       return profile;
@@ -223,7 +227,7 @@ export class Org {
     const org = await Org.get(address, config);
 
     if (org) {
-      const ownerProfile = await Profile.get(org.owner, config);
+      const ownerProfile = await Profile.get(org.owner, profileType, config);
 
       if (ownerProfile.ens || ownerProfile.idx) {
         return ownerProfile;

--- a/src/base/orgs/View.svelte
+++ b/src/base/orgs/View.svelte
@@ -17,7 +17,7 @@
 
   import { Org } from '@app/base/orgs/Org';
   import TransferOwnership from '@app/base/orgs/TransferOwnership.svelte';
-  import { Profile } from '@app/profile';
+  import { Profile, ProfileType } from '@app/profile';
 
   export let address: string;
   export let config: Config;
@@ -133,7 +133,7 @@
 {:then org}
   {#if org}
     <main>
-      {#await org.getProfile(config)}
+      {#await org.getProfile(ProfileType.Full, config)}
         <div class="centered">
           <Loading center />
         </div>
@@ -230,7 +230,7 @@
           {#if members.length > 0}
             <div class="members">
               {#each members as address}
-                {#await Profile.get(address, config)}
+                {#await Profile.get(address, ProfileType.Minimal, config)}
                   <Loading small />
                 {:then profile}
                   <div class="member">

--- a/src/base/projects/View.svelte
+++ b/src/base/projects/View.svelte
@@ -6,6 +6,7 @@
   import Modal from '@app/Modal.svelte';
   import Avatar from '@app/Avatar.svelte';
   import { Org } from '@app/base/orgs/Org';
+  import type { Profile } from '@app/profile';
 
   import Browser from './Browser.svelte';
 
@@ -16,16 +17,17 @@
   export let path: string;
 
   let projectRoot = proj.path({ urn, org, commit });
-  let getProject = new Promise<string | null>(resolve => {
+  let getProject = new Promise<Profile | null>(resolve => {
     if (org) {
-      Org.getProfile(org, config).then(p => resolve(p?.seed || null));
+      Org.getProjectProfile(org, config).then(p => resolve(p));
     } else {
       resolve(null);
     }
-  }).then(async (seed) => {
+  }).then(async (orgProfile) => {
+    const seed = orgProfile?.seed;
     const cfg = seed ? config.withSeed(seed) : config;
     const info = await proj.getInfo(urn, cfg);
-    return { project: info, config: cfg };
+    return { project: info, config: cfg, org: orgProfile };
   });
 
   const back = () => window.history.back();
@@ -96,7 +98,7 @@
       <div class="urn">{urn}</div>
       <div class="description">{result.project.meta.description}</div>
     </header>
-    <Browser {urn} {org} {path}
+    <Browser {urn} org={result.org} {path}
       commit={commit || result.project.head}
       config={result.config} />
   {:catch}

--- a/src/base/registrations/View.svelte
+++ b/src/base/registrations/View.svelte
@@ -46,8 +46,8 @@
       .then(async r => {
         if (r) {
           let reverseRecord = false;
-          if (r.address) {
-            reverseRecord = await isReverseRecordSet(r.address, name, config);
+          if (r.profile.address) {
+            reverseRecord = await isReverseRecordSet(r.profile.address, name, config);
           }
 
           fields = [
@@ -62,25 +62,25 @@
                   + "For this name to be correctly associated with the address, "
                   + "a reverse record should be set."
               ),
-              value: r.address, editable: true },
+              value: r.profile.address, editable: true },
             { name: "url", label: "URL", validate: "url", placeholder: "https://acme.org",
               description: "A homepage or other URL associated with this name.",
-              value: r.url,editable: true },
+              value: r.profile.url,editable: true },
             { name: "avatar", validate: "url", placeholder: "https://acme.org/avatar.png",
               description: "An avatar or square image associated with this name.",
-              value: r.avatar, editable: true },
+              value: r.profile.avatar, editable: true },
             { name: "twitter", validate: "handle", placeholder: "Twitter username, eg. 'acme'",
               description: "The Twitter handle associated with this name.",
-              value: r.twitter, editable: true },
+              value: r.profile.twitter, editable: true },
             { name: "github", validate: "handle", label: "GitHub", placeholder: "GitHub username, eg. 'acme'",
               description: "The GitHub username associated with this name.",
-              value: r.github, editable: true },
+              value: r.profile.github, editable: true },
             { name: "seed.id", label: "Seed ID", placeholder: "hynkyn...3nrzc@seed.acme.org:8887",
               description: "The ID of a Radicle Link node that hosts entities associated with this name.",
-              value: r.seedId, editable: true },
+              value: r.profile.seedId, editable: true },
             { name: "seed.api", label: "Seed API", validate: "url", placeholder: "https://seed.acme.org:8888",
               description: "The HTTP address of a node that serves Radicle entities over HTTP.",
-              value: r.seedApi, editable: true },
+              value: r.profile.seedApi, editable: true },
           ];
           state = { status: Status.Found, registration: r };
         } else {

--- a/src/base/registrations/registrar.ts
+++ b/src/base/registrations/registrar.ts
@@ -10,8 +10,14 @@ import { unixTime } from '@app/utils';
 import { assert } from '@app/error';
 
 export interface Registration {
-  name: string;
   owner: string;
+  profile: EnsProfile;
+  resolver: EnsResolver;
+}
+
+export interface EnsProfile {
+  name: string;
+  owner?: string;
   address: string | null;
   seedId: string | null;
   seedApi: string | null;
@@ -19,7 +25,6 @@ export interface Registration {
   avatar: string | null;
   twitter: string | null;
   github: string | null;
-  resolver: EnsResolver;
 }
 
 export enum State {
@@ -76,17 +81,39 @@ export async function getRegistration(name: string, config: Config): Promise<Reg
     meta.map(r => r.status == "fulfilled" ? r.value : null);
 
   return {
-    name,
-    url,
-    avatar,
-    seedId,
-    seedApi,
     owner,
-    address,
-    twitter,
-    github,
     resolver,
+    profile: {
+      name,
+      url,
+      avatar,
+      seedId,
+      seedApi,
+      address,
+      twitter,
+      github,
+    },
   };
+}
+
+export async function getAvatar(name: string, config: Config): Promise<string | null> {
+  name = name.toLowerCase();
+
+  const resolver = await config.provider.getResolver(name);
+  if (! resolver) {
+    return null;
+  }
+  return resolver.getText('avatar');
+}
+
+export async function getSeed(name: string, config: Config): Promise<string | null> {
+  name = name.toLowerCase();
+
+  const resolver = await config.provider.getResolver(name);
+  if (! resolver) {
+    return null;
+  }
+  return resolver.getText('eth.radicle.seed.api');
 }
 
 export function registrar(config: Config): ethers.Contract {

--- a/src/base/users/View.svelte
+++ b/src/base/users/View.svelte
@@ -3,7 +3,7 @@
   import Icon from '@app/Icon.svelte';
   import Address from '@app/Address.svelte';
   import Avatar from '@app/Avatar.svelte';
-  import { Profile } from '@app/profile';
+  import { ProfileType, Profile } from '@app/profile';
   import Loading from '@app/Loading.svelte';
   import { Org } from '@app/base/orgs/Org';
   import Message from '@app/Message.svelte';
@@ -57,7 +57,7 @@
   }
 </style>
 
-{#await Profile.get(address, config)}
+{#await Profile.get(address, ProfileType.Full, config)}
   <Loading fadeIn />
 {:then profile}
   <main>


### PR DESCRIPTION
Introduce two types of profile: a 'full' and a 'minimal'.
The minimal is used when only the avatar is required, which
is in most places. Requests for an org view is reduced by 3x.

Closes #72 