### PR TITLE
Reduce calls to IDX profile streams

### DIFF
--- a/src/profile.ts
+++ b/src/profile.ts
@@ -100,13 +100,10 @@ export class Profile {
     }
 
     try {
-      const [ens, idx] = await Promise.allSettled([
-        resolveEnsProfile(address, profileType, config),
-        resolveIdxProfile(formatCAIP10Address(address, "eip155", config.network.chainId), config)
-      ]);
-
-      if (ens.status == "fulfilled") profile.ens = ens.value;
-      if (idx.status == "fulfilled") profile.idx = idx.value;
+      profile.ens = await resolveEnsProfile(address, profileType, config);
+      if (!profile.ens) {
+        profile.idx = await resolveIdxProfile(formatCAIP10Address(address, "eip155", config.network.chainId), config);
+      }
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
I think we can safely reduce the calls to the IDX, if we only call it after checking that the ENS profile came back `null`
Since every call to IDX took about 400ms+ it makes some pages more responsive.