### PR TITLE
Retry on Graph query failure

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -155,6 +155,7 @@ export async function querySubgraph(
   url: string,
   query: string,
   variables: Record<string, any>,
+  retries = 3
 ): Promise<null | any> {
   const response = await fetch(url, {
     method: 'POST',
@@ -172,7 +173,8 @@ export async function querySubgraph(
     for (const e of json.errors) {
       console.error("querySubgraph:", e.message);
     }
-    return null;
+    if (retries > 0) querySubgraph(url, query, variables, retries - 1);
+    else return null;
   }
 
   return json.data;


### PR DESCRIPTION
This PR works on #74

In case that the Graph query for querying orgs and projects, returns with a `errors` array, the `querySubgraph` function retries 4 times in total before it returns null, and a error gets shown where this function fails.

I could only test it by changing the API key to something wrong and received an error `Unknown API key` eventually we'll have to see in the long run which errors can show up.
For that reason I avoided to create a new type of error and forcing it onto the views and components, since for the most part they manage their errors well.