### PR TITLE
Add registry method to Profile

### DIFF
--- a/src/base/orgs/View.svelte
+++ b/src/base/orgs/View.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import type { SvelteComponent } from 'svelte';
-  import Link from '@app/Link.svelte';
   import type { Config } from '@app/config';
-  import { formatName, parseEnsLabel, explorerLink } from '@app/utils';
+  import { formatName, explorerLink } from '@app/utils';
   import { session } from '@app/session';
   import Loading from '@app/Loading.svelte';
   import Modal from '@app/Modal.svelte';
@@ -196,7 +195,7 @@
           {#if utils.isAddressEqual(profile.address, org.address)}
             <div>
               {#if profile.name}
-                <Link to={`/registrations/${parseEnsLabel(profile.name, config)}`}>{profile.name}</Link>
+                <a href={profile.registry(config)} class="link" target="_blank">{profile.name}</a>
               {:else}
                 <span class="subtle">Not set</span>
               {/if}

--- a/src/base/users/View.svelte
+++ b/src/base/users/View.svelte
@@ -8,8 +8,6 @@
   import { Org } from '@app/base/orgs/Org';
   import Message from '@app/Message.svelte';
   import Project from '@app/base/projects/Widget.svelte';
-  import Link from '@app/Link.svelte';
-  import { parseEnsLabel } from '@app/utils';
 
   export let address: string;
   export let config: Config;
@@ -112,7 +110,7 @@
         <div class="label">Profile</div>
         <div>
           {#if profile.name}
-            <Link to={`/registrations/${parseEnsLabel(profile.name, config)}`}>{profile.name}</Link>
+            <a href={profile.registry(config)} class="link" target="_blank">{profile.name}</a>
           {:else}
             <span class="subtle">Not set</span>
           {/if}

--- a/src/config.json
+++ b/src/config.json
@@ -49,7 +49,10 @@
     "tokens": []
   },
   "walletConnect": { "bridge": "https://radicle.bridge.walletconnect.org" },
-  "ceramic": { "api": "https://gateway.ceramic.network" },
+  "ceramic": {
+    "api": "https://gateway.ceramic.network",
+    "registry": "https://self.id/"
+  },
   "radicle": {
     "seed": {
       "host": "0.0.0.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,7 +62,10 @@ export class Config {
     link: { port: number };
   };
   idx: { client: IDX };
-  ceramic: { client: CeramicClient };
+  ceramic: {
+   client: CeramicClient;
+   registry: string;
+  };
   tokens: string[];
   token: ethers.Contract;
 
@@ -116,7 +119,10 @@ export class Config {
     this.gasLimits = gasLimits;
     this.abi = config.abi;
     this.idx = { client: idx };
-    this.ceramic = { client: ceramic };
+    this.ceramic = {
+      client: ceramic,
+      registry: config.ceramic.registry
+    };
     this.tokens = cfg.tokens;
     this.token = new ethers.Contract(
       this.radToken.address,

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -1,7 +1,7 @@
 import type { EnsProfile } from "@app/base/registrations/registrar";
 import type { BasicProfile } from "@ceramicstudio/idx-constants";
 import {
-  isAddress, formatCAIP10Address, formatIpfsFile, resolveEnsProfile, resolveIdxProfile, parseUsername,
+  isAddress, formatCAIP10Address, formatIpfsFile, resolveEnsProfile, resolveIdxProfile, parseUsername, parseEnsLabel
 } from "@app/utils";
 import type { Config } from "@app/config";
 
@@ -96,6 +96,13 @@ export class Profile {
       return config.withSeed(this.seedHost, this.seedId);
     }
     return config;
+  }
+
+  // Returns the corresponding registration form to edit a user profile.
+  // We are not interested in a non-existant registry link, since we check before hand if the name exists.
+  registry(config: Config): string {
+    if (this.profile?.ens) return `/registrations/${parseEnsLabel(this.profile.ens.name, config)}`;
+    else return `${config.ceramic.registry}${formatCAIP10Address(this.profile.address, "eip155", config.network.chainId)}`;
   }
 
   // Keeping this function private since the desired entrypoint is .get()


### PR DESCRIPTION
This PR is the continuation of #80 

It adds a `registry(config: Config)` to the `Profile` class, which returns either a link to the client registration form or in case of IDX to the https://self.id webapp.