### PR TITLE
Change Gnosis Safe calls to Subgraph

### DIFF
--- a/src/profile.ts
+++ b/src/profile.ts
@@ -147,7 +147,10 @@ export class Profile {
         );
         return { address, ens: null, idx };
       } catch (e) {
-        console.error(e);
+        // Look for the No DID found for error by the resolveIdxProfile fn and send it to console.debug
+        if (e.message.match("No DID found for")) console.debug(e);
+        else console.error(e);
+
         return { address, ens: null, idx: null };
       }
     }


### PR DESCRIPTION
This PR allows us to reduce the amount of API calls we do to the Gnosis Safe API and use the new introduced Subgraph Schema were we index the safes of a org.

There is a small caveat that we need to query for org owners and org members separately in the `getOrgsByMember` function since we can't do a OR query for one or the other, left a `TODO` there if this gets implemented in the future.

It also moves the console errors filling IDX errors to a much less invasive `console.debug`

This PR depends on the PR on the `radicle-subgraph` repo so we should wait with merging until the subgraph got updated.
https://github.com/radicle-dev/radicle-subgraph/pull/4