### PR TITLE
Handle WalletConnect network change

### DIFF
--- a/src/components/Modal/ConnectWallet.svelte
+++ b/src/components/Modal/ConnectWallet.svelte
@@ -53,7 +53,7 @@
     <div slot="subtitle">
       <div class="text-small">
         WalletConnect<br/>
-        <a href="https://walletconnect.org/wallets" class="link">
+        <a href="https://walletconnect.com/registry/wallets" class="link">
           View compatible wallets
         </a>
       </div>

--- a/src/config.json
+++ b/src/config.json
@@ -63,7 +63,8 @@
     "reverseRegistrar": {
       "address": "0x6F628b68b30Dc3c17f345c9dbBb1E483c2b7aE5c"
     },
-    "tokens": []
+    "tokens": [],
+    "alchemy": { "key": "1T6h-0rxu7SRzKEtmukIoxaJOXazLDNs" }
   },
   "walletConnect": { "bridge": "https://radicle.bridge.walletconnect.org" },
   "ceramic": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -220,8 +220,8 @@ function getProvider(
   config: Record<string, any>,
   metamask: ethers.providers.JsonRpcProvider | null,
 ): ethers.providers.JsonRpcProvider {
-  // Use Alchemy in production, on mainnet. Otherwise use Metamask if installed.
-  if (network.name === "homestead" && import.meta.env.PROD) {
+  // Use Alchemy in production. Otherwise use Metamask if installed.
+  if (import.meta.env.PROD) {
     return new ethers.providers.AlchemyWebSocketProvider(network.name, config.alchemy.key);
   } else if (metamask) {
     return metamask;

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ import { Core } from '@self.id/core';
 import WalletConnect from "@walletconnect/client";
 import config from "@app/config.json";
 import { WalletConnectSigner } from "./WalletConnectSigner";
+import { disconnectWallet } from "./session";
 
 declare global {
   interface Window {
@@ -129,6 +130,10 @@ export class Config {
     );
   }
 
+  changeNetwork(chainId: number): void {
+    this.network = ethers.providers.getNetwork(chainId);
+  }
+
   setSigner(signer: ethers.Signer & TypedDataSigner | WalletConnectSigner): void {
     this.signer = signer;
   }
@@ -210,7 +215,7 @@ export class Config {
   }
 }
 
-function isMetamaskInstalled(): boolean {
+export function isMetamaskInstalled(): boolean {
   const { ethereum } = window;
   return Boolean(ethereum && ethereum.isMetaMask);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,6 @@ import { Core } from '@self.id/core';
 import WalletConnect from "@walletconnect/client";
 import config from "@app/config.json";
 import { WalletConnectSigner } from "./WalletConnectSigner";
-import { disconnectWallet } from "./session";
 
 declare global {
   interface Window {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,15 +107,6 @@ export function formatHash(hash: string): string {
     + hash.substring(hash.length - 4, hash.length);
 }
 
-export function formatNetwork(input: { name: string }): string {
-  let name = input.name;
-
-  if (name === "homestead") {
-    name = "mainnet";
-  }
-  return capitalize(name);
-}
-
 export function formatOrg(input: string, config: Config): string {
   if (isAddress(input)) {
     return ethers.utils.getAddress(input);


### PR DESCRIPTION
This PR fixes #66 

## Features
- Starts using Alchemy as Rinkeby provider, leaves Metamask as signer and for dev environment.
- Allows changing accounts and network through WalletConnect on the go, no need to manually refresh the page
  - In case of using Metamask, the UI requests Metamask for a network change, which the user has to confirm (**Does not work with Brave Wallets, only with Metamask**)
- In case of a network mismatch, forces the UI to change to the network of the linked WalletConnect app

## Smaller fixes
- Updates the available wallets link

As always feel free to drop your thoughts :smile: 