### PR TITLE
Allow users set reverse records

### DIFF
--- a/src/base/users/Routes.svelte
+++ b/src/base/users/Routes.svelte
@@ -2,10 +2,11 @@
   import { Route } from "svelte-routing";
   import View from '@app/base/users/View.svelte';
   import type { Config } from '@app/config';
+  import { getSearchParam } from '@app/utils';
 
   export let config: Config;
 </script>
 
-<Route path="/users/:address" let:params>
-  <View {config} addressOrName={params.address}/>
+<Route path="/users/:address" let:params let:location>
+  <View {config} addressOrName={params.address} action={getSearchParam("action", location)} />
 </Route>

--- a/src/base/users/User.ts
+++ b/src/base/users/User.ts
@@ -20,6 +20,6 @@ export class User {
       config.abi.reverseRegistrar,
       config.signer
     );
-    return reverseRegistrar.setName(name, this.address);
+    return reverseRegistrar.setName(name);
   }
 }

--- a/src/ens/SetName.svelte
+++ b/src/ens/SetName.svelte
@@ -21,6 +21,8 @@
     ? entity as Org
     : null;
 
+  const label = org ? "org" : "profile";
+
   enum State {
     Idle,
     Checking,
@@ -138,14 +140,14 @@
       {:else if state == State.Pending}
         Waiting for transaction to be processed...
       {:else if state == State.Proposing && org}
-        Proposal is being submitted to the safe
+        Proposal is being submitted
         <strong>{formatAddress(org.owner)}</strong>,
         please sign the transaction in your wallet.
       {:else}
         Set an ENS name for <strong>{formatAddress(entity.address)}</strong>
         to associate a profile.
-        ENS profiles provide human-identifiable data to your org, such as a
-        unique name, avatar and URL, and help make your org more discoverable.
+        ENS profiles provide human-identifiable data to your {label}, such as a
+        unique name, avatar and URL, and help make your {label} more discoverable.
       {/if}
     </div>
 


### PR DESCRIPTION
This PR closes #42 

It uses the already working `SetName` component for orgs and implements it for users, to allow a fast reverse record setting after registering their subdomain