### PR TITLE
Show orgs in user profile

### DIFF
--- a/src/base/orgs/Org.ts
+++ b/src/base/orgs/Org.ts
@@ -32,7 +32,7 @@ const GetOrgs = `
 `;
 
 const GetSafesByOwners = `
-  query GetSafesByOwner($owners: [String!]!) {
+  query GetSafesByOwners($owners: [String!]!) {
     safes(where: { owners_contains: $owners }) {
       id
       owners

--- a/src/base/users/View.svelte
+++ b/src/base/users/View.svelte
@@ -66,6 +66,24 @@
   .projects .project {
     margin-bottom: 1rem;
   }
+  .members {
+    margin-top: 2rem;
+    align-items: center;
+    display: flex;
+  }
+  .members .member {
+    display: flex;
+    align-items: center;
+    margin-right: 2rem;
+  }
+  .members .member:last-child {
+    margin-right: 0;
+  }
+  .members .member-icon {
+    width: 2rem;
+    height: 2rem;
+    margin-right: 1rem;
+  }
 </style>
 
 <svelte:head>
@@ -122,6 +140,27 @@
           {/if}
         </div>
       </div>
+      {#await Org.getOrgsByMember(profile.address, config)}
+        <Loading center />
+      {:then orgs}
+        {#if orgs.length > 0}
+          <div class="members">
+            {#each orgs as org}
+              {#await Org.getProfile(org.address, ProfileType.Minimal, config)}
+                <Loading/>
+              {:then profile}
+                <div class="member">
+                  <div class="member-icon">
+                    <Avatar source={profile.avatar ?? profile.address} address={profile.address} />
+                  </div>
+                  <Address address={profile.address} compact
+                    resolve noBadge noAvatar {profile} {config} />
+                </div>
+              {/await}
+            {/each}
+          </div>
+        {/if}
+      {/await}
       <div class="projects">
         {#if profile.anchorsAccount}
           {#await Org.get(profile.anchorsAccount, config)}


### PR DESCRIPTION
This PR closes #98 

It adds a listing equal to the org member listing, to show which orgs a user is member of, and allows
It uses multiple static functions of the Org class to get the information and lets the visitor jump directly to a specific org.