### PR TITLE
Allow overriding eth.radicle.seed.host record

### DIFF
--- a/src/Form.svelte
+++ b/src/Form.svelte
@@ -1,7 +1,7 @@
 <script context="module" lang="ts">
   export interface Field {
     name: string;
-    value: string | null;
+    value?: string;
     label?: string;
     validate?: string;
     placeholder?: string;
@@ -62,7 +62,7 @@
     });
   };
 
-  const cleanup = (fields: Field[]): { name: string; value: string | null }[] => {
+  const cleanup = (fields: Field[]): { name: string; value?: string }[] => {
     return fields.filter(field => field.editable).map(field => {
       return {
         name: field.name,

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,7 +5,7 @@ export async function get(
   params: Record<string, any>,
   config: Config
 ): Promise<any> {
-  if (! config.seed.host) {
+  if (! config.seed.api.host) {
     throw new Error("Seed host unavailable");
   }
 
@@ -14,7 +14,7 @@ export async function get(
     query[key] = val.toString();
   }
 
-  const base = config.seed.host;
+  const base = config.seed.api.host;
   const port = config.seed.api.port;
   const search = new URLSearchParams(query).toString();
   const baseUrl = `https://${base}:${port}/v1/${path}`;

--- a/src/base/projects/Browser.svelte
+++ b/src/base/projects/Browser.svelte
@@ -321,30 +321,34 @@
           {/await}
         {/if}
       </div>
-      {#if config.seed.host}
+      {#if config.seed.git.host}
         <span>
           <div class="clone" on:click={() => cloneDropdown = !cloneDropdown}>
             Clone
           </div>
           <div class="dropdown clone-dropdown" class:clone-dropdown-visible={cloneDropdown}>
-            <input readonly name="clone-url" value="https://{config.seed.host}/{utils.parseRadicleId(urn)}"/>
+            <input readonly name="clone-url" value="https://{config.seed.git.host}/{utils.parseRadicleId(urn)}"/>
             <label for="clone-url">Use Git to clone this repository from the URL above.</label>
           </div>
         </span>
-        <span>
-          <div class="stat seed" on:click={() => seedDropdown = !seedDropdown} title="Project data is fetched from this seed">
-            <span>{config.seed.host}</span>
-          </div>
-          <div class="dropdown seed-dropdown" class:seed-dropdown-visible={seedDropdown}>
-            {#if config.seed.id}
-              <input readonly name="clone-url" value={utils.formatSeedAddress(config.seed.id, config.seed.host, config)}/>
-              <label for="seed-url">Bootstrap your Radicle node with this seed.</label>
-            {:else if profile}
-              <label for="#">Seed ID is not set for {profile.name}.</label>
-            {/if}
-          </div>
-        </span>
       {/if}
+      <span>
+        {#if config.seed.api.host}
+          <div class="stat seed" on:click={() => seedDropdown = !seedDropdown} title="Project data is fetched from this seed">
+            <span>{config.seed.api.host}</span>
+          </div>
+        {/if}
+        <div class="dropdown seed-dropdown" class:seed-dropdown-visible={seedDropdown}>
+          {#if config.seed.link.id && config.seed.link.host}
+            <input readonly
+              name="clone-url"
+              value={utils.formatSeedAddress(config.seed.link.id, config.seed.link.host, config)}/>
+            <label for="seed-url">Bootstrap your Radicle node with this seed.</label>
+          {:else if profile}
+            <label for="#">Seed ID is not set for {profile.name}.</label>
+          {/if}
+        </div>
+      </span>
       <div class="stat">
         <strong>{tree.stats.commits}</strong> commit(s)
       </div>

--- a/src/base/projects/View.svelte
+++ b/src/base/projects/View.svelte
@@ -32,9 +32,8 @@
       resolve(null);
     }
   }).then(async (profile) => {
-    const seedHost = profile?.seedHost;
-    const seedId = profile?.seedId || undefined;
-    const cfg = seedHost ? config.withSeed(seedHost, seedId) : config;
+    const seed = profile?.seed;
+    const cfg = seed ? config.withSeed(seed) : config;
     const info = await proj.getInfo(urn, cfg);
 
     projectInfo = info;

--- a/src/base/registrations/View.svelte
+++ b/src/base/registrations/View.svelte
@@ -82,10 +82,10 @@
           description: "The seed host address. " +
             "Only domain names with TLS are supported. " +
             `HTTP(S) API requests use port ${config.seed.api.port}.`,
-          value: r.profile.seedHost, editable: true },
+          value: r.profile.seed.host, editable: true },
         { name: "seed.id", label: "Seed ID", validate: "id", placeholder: "hynkyndc6w3p8urucakobzncqny7xxtw88...",
           description: "The Device ID of a Radicle Link node that hosts entities associated with this name.",
-          value: r.profile.seedId, editable: true },
+          value: r.profile.seed.id, editable: true },
         { name: "anchors", label: "Anchors", validate: "URN", placeholder: "URN, eg. eip155:1:0x4a9cf21...",
           description: "URN under which associated project anchors can be found. "
             + "To point to a Radicle org on Ethereum, use the CAIP-10 ID, eg. *eip155:1:0x4a9cf21...*",

--- a/src/base/registrations/resolver.ts
+++ b/src/base/registrations/resolver.ts
@@ -36,6 +36,8 @@ export async function setRecords(name: string, records: EnsRecord[], resolver: E
         break;
       case "seed.id":
       case "seed.host":
+      case "seed.git":
+      case "seed.api":
       case "anchors":
         calls.push(
           iface.encodeFunctionData("setText", [node, "eth.radicle." + r.name, r.value])

--- a/src/config.json
+++ b/src/config.json
@@ -75,7 +75,8 @@
     "seed": {
       "host": "0.0.0.0",
       "api": { "port": 8777 },
-      "link": { "port": 8776 }
+      "link": { "port": 8776 },
+      "git": { "port": 80 }
     }
   },
   "ipfs": { "gateway": "https://ipfs.io/ipfs/" },

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ import { Core } from '@self.id/core';
 import WalletConnect from "@walletconnect/client";
 import config from "@app/config.json";
 import { WalletConnectSigner } from "./WalletConnectSigner";
+import type { Seed } from "@app/base/registrations/registrar";
 
 declare global {
   interface Window {
@@ -56,10 +57,9 @@ export class Config {
   };
   abi: { [contract: string]: string[] };
   seed: {
-    host?: string;
-    id?: string;
-    api: { port: number };
-    link: { port: number };
+    api: { host?: string; port: number };
+    git: { host?: string; port: number };
+    link: { host?: string; id?: string; port: number };
   };
   ceramic: {
    client: Core;
@@ -138,14 +138,20 @@ export class Config {
   }
 
   // Return the config with an overwritten seed URL.
-  withSeed(seedHost: string, seedId?: string): Config {
+  withSeed(seed: Seed): Config {
     const cfg = {} as Config;
     Object.assign(cfg, this);
-    cfg.seed.host = seedHost;
 
-    if (seedId) {
-      cfg.seed.id = seedId;
-    }
+    // The `git` and `api` keys being more specific take
+    // precedence over the `host`, if available.
+    const api = seed.api ?? seed.host;
+    const git = seed.git ?? seed.host;
+
+    cfg.seed.api.host = api;
+    cfg.seed.git.host = git;
+    cfg.seed.link.host = seed.host;
+    cfg.seed.link.id = seed.id;
+
     return cfg;
   }
 

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -1,4 +1,4 @@
-import type { EnsProfile } from "@app/base/registrations/registrar";
+import type { EnsProfile, Seed } from "@app/base/registrations/registrar";
 import type { BasicProfile } from '@datamodels/identity-profile-basic';
 import {
   isAddress, formatCAIP10Address, formatIpfsFile, resolveEnsProfile, resolveIdxProfile, parseUsername, parseEnsLabel
@@ -39,52 +39,48 @@ export class Profile {
     return this.profile.idx;
   }
 
-  // Using undefined as return type if nothing to be returned since it works better with <a href> links
   get github(): string | undefined {
     if (this.profile?.ens?.github) return parseUsername(this.profile.ens.github);
     else if (this.profile?.idx?.affiliations) return this.profile.idx?.affiliations.find(item => item === "github");
     else return undefined;
   }
 
-  // Using undefined as return type if nothing to be returned since it works better with <a href> links
   get twitter(): string | undefined {
     if (this.profile?.ens?.twitter) return parseUsername(this.profile.ens.twitter);
     else if (this.profile?.idx?.affiliations) return this.profile.idx.affiliations.find(item => item === "twitter");
     else return undefined;
   }
 
-  // Using undefined as return type if nothing to be returned since it works better with <a href> links
   get url(): string | undefined {
     if (this.profile?.ens?.url) return this.profile.ens.url;
     else if (this.profile?.idx?.url) return this.profile.idx.url;
     else return undefined;
   }
 
-  // Using undefined as return type if nothing to be returned since it works better with <a href> links
   get name(): string | undefined {
     if (this.profile?.ens?.name) return this.profile.ens.name;
     else if (this.profile?.idx?.name) return this.profile.idx.name;
     else return undefined;
   }
 
-  // Using undefined as return type if nothing to be returned since it works better with <a href> links
   get avatar(): string | undefined {
     if (this.profile?.ens?.avatar) return this.profile.ens.avatar;
     else if (this.profile?.idx?.image?.original?.src) return formatIpfsFile(this.profile.idx.image.original.src);
     else return undefined;
   }
 
-  // Using undefined as return type if nothing to be returned since it works better with <a href> links
   get seedHost(): string | undefined {
-    return this.profile?.ens?.seedHost ?? undefined;
+    return this.profile?.ens?.seed?.host;
   }
 
-  // Using undefined as return type if nothing to be returned since it works better with <a href> links
   get seedId(): string | undefined {
-    return this.profile?.ens?.seedId ?? undefined;
+    return this.profile?.ens?.seed.id;
   }
 
-  // Using undefined as return type if nothing to be returned since it works better with <a href> links
+  get seed(): Seed | undefined {
+    return this.profile?.ens?.seed;
+  }
+
   get anchorsAccount(): string | undefined {
     const addr = this.profile?.ens?.anchorsAccount;
 
@@ -111,8 +107,8 @@ export class Profile {
   // Return the profile-specific config. This sets various URLs in the config,
   // based on profile data.
   config(config: Config): Config {
-    if (this.seedHost) {
-      return config.withSeed(this.seedHost, this.seedId);
+    if (this.seed) {
+      return config.withSeed(this.seed);
     }
     return config;
   }
@@ -152,7 +148,7 @@ export class Profile {
         return { address, idx: idx ?? undefined };
       } catch (e) {
         // Look for the No DID found for error by the resolveIdxProfile fn and send it to console.debug
-        if (e.message.match("No DID found for")) console.debug(e);
+        if (e.message.match("No DID found for")) console.debug(e.message);
         else console.error(e);
 
         return { address };


### PR DESCRIPTION
Adds two new records:

* eth.radicle.seed.api
* eth.radicle.seed.git

When specified, these override `eth.radicle.seed.host` for Git
and the HTTP API, respectively.