### PR TITLE
Improve loading of Cards component

### DIFF
--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -5,7 +5,11 @@
   import type { Config } from '@app/config';
   import { formatName, formatAddress } from '@app/utils';
 
-  export let profile: Profile;
+  export let profile: Profile | {
+    address: string;
+    avatar?: string;
+    name?: string;
+  } ;
   export let config: Config;
   export let path: string;
   export let members: string[] = [];

--- a/src/Cards.svelte
+++ b/src/Cards.svelte
@@ -1,23 +1,20 @@
 <script lang="ts">
-  import { ethers } from 'ethers';
   import { onMount } from 'svelte';
-  import type { Org } from '@app/base/orgs/Org';
-  import { Profile } from '@app/profile';
-  import type { Config } from '@app/config';
-  import Loading from '@app/Loading.svelte';
+  import { Profile, ProfileType } from '@app/profile';
   import Card from '@app/Card.svelte';
+  import type { Org } from '@app/base/orgs/Org';
+  import type { Config } from '@app/config';
 
   export let config: Config;
   export let orgs: Org[] = [];
   export let profiles: Profile[] = [];
 
   const orgMembers: Record<string, string[]> = {};
-  const getOrgProfiles = Profile.getMulti(orgs.map(o => o.name ?? o.address), config);
 
   onMount(async () => {
     const promises = orgs.map(org => {
       org.getMembers(config).then(members => {
-        orgMembers[ethers.utils.getAddress(org.address)] = members;
+        orgMembers[org.address] = members;
       });
     });
 
@@ -31,31 +28,26 @@
     flex-direction: row;
     flex-wrap: wrap;
   }
-  .loading {
-    padding: 3rem 0;
-  }
 </style>
 
-{#await getOrgProfiles}
-  <div class="loading">
-    <Loading center />
-  </div>
-{:then orgProfiles}
   <div class="list">
-    {#each orgProfiles as profile}
-      {#if orgMembers[profile.address]?.length}
-        <Card {profile} {config} path={`/orgs/${profile.nameOrAddress}`} members={orgMembers[profile.address]} />
-      {:else}
-        <Card {profile} {config} path={`/orgs/${profile.nameOrAddress}`} />
-      {/if}
+    {#each orgs as org}
+      {#await Profile.get(org.name ?? org.address, ProfileType.Minimal, config)}
+        <Card profile={{ address: org.address }} {config} path={`/orgs/${org.address}`} />
+      {:then profile}
+        {#if orgMembers[profile.address]?.length}
+          <Card {profile} {config} path={`/orgs/${profile.nameOrAddress}`} members={orgMembers[profile.address]} />
+        {:else}
+          <Card {profile} {config} path={`/orgs/${profile.nameOrAddress}`} />
+        {/if}
+      {/await}
     {/each}
 
     {#each profiles as profile}
       <Card {profile} {config} path={`/users/${profile.nameOrAddress}`} />
     {/each}
 
-    {#if !orgProfiles.length && !profiles.length}
+    {#if !orgs.length && !profiles.length}
       <slot />
     {/if}
   </div>
-{/await}

--- a/src/WalletConnectSigner.ts
+++ b/src/WalletConnectSigner.ts
@@ -33,8 +33,10 @@ export class WalletConnectSigner extends ethers.Signer {
 
   async _signTypedData(domain: TypedDataDomain, types: Record<string, Array<TypedDataField>>, value: Record<string, any>): Promise<string> {
     // Populate any ENS names (in-place)
-    const populated = await _TypedDataEncoder.resolveNames(domain, types, value, (name: string) => {
-      return this.provider.resolveName(name);
+    const populated = await _TypedDataEncoder.resolveNames(domain, types, value, async (name: string) => {
+      const address = await this.provider.resolveName(name);
+      if (address === null) throw Error("resolver or addr is not configured for ENS name");
+      return address;
     });
 
     const address = await this.getAddress();

--- a/src/base/home/Index.svelte
+++ b/src/base/home/Index.svelte
@@ -18,7 +18,7 @@
     : Promise.resolve([]);
 
   const getEntities = Promise.all([getUsers, getOrgs]).then(([users, orgs]) => {
-    return { users: users, orgs: orgs };
+    return { users, orgs };
   });
 
   const viewMore = () => {

--- a/src/base/registrations/registrar.ts
+++ b/src/base/registrations/registrar.ts
@@ -58,7 +58,7 @@ state.subscribe((s: Connection) => {
   console.log("register.state", s);
 });
 
-export async function getRegistration(name: string, config: Config, resolver?: EnsResolver): Promise<Registration | null> {
+export async function getRegistration(name: string, config: Config, resolver?: EnsResolver | null): Promise<Registration | null> {
   name = name.toLowerCase();
 
   if (! resolver) {
@@ -99,7 +99,7 @@ export async function getRegistration(name: string, config: Config, resolver?: E
   };
 }
 
-export async function getAvatar(name: string, config: Config, resolver?: EnsResolver): Promise<string | null> {
+export async function getAvatar(name: string, config: Config, resolver?: EnsResolver | null): Promise<string | null> {
   name = name.toLowerCase();
 
   resolver = resolver ?? await config.provider.getResolver(name);
@@ -109,7 +109,7 @@ export async function getAvatar(name: string, config: Config, resolver?: EnsReso
   return resolver.getText('avatar');
 }
 
-export async function getSeedHost(name: string, config: Config, resolver?: EnsResolver): Promise<string | null> {
+export async function getSeedHost(name: string, config: Config, resolver?: EnsResolver | null): Promise<string | null> {
   name = name.toLowerCase();
 
   resolver = resolver ?? await config.provider.getResolver(name);
@@ -119,7 +119,7 @@ export async function getSeedHost(name: string, config: Config, resolver?: EnsRe
   return resolver.getText('eth.radicle.seed.host');
 }
 
-export async function getSeedId(name: string, config: Config, resolver?: EnsResolver): Promise<string | null> {
+export async function getSeedId(name: string, config: Config, resolver?: EnsResolver | null): Promise<string | null> {
   name = name.toLowerCase();
 
   resolver = resolver ?? await config.provider.getResolver(name);
@@ -129,7 +129,7 @@ export async function getSeedId(name: string, config: Config, resolver?: EnsReso
   return resolver.getText('eth.radicle.seed.id');
 }
 
-export async function getAnchorsAccount(name: string, config: Config, resolver?: EnsResolver): Promise<string | null> {
+export async function getAnchorsAccount(name: string, config: Config, resolver?: EnsResolver | null): Promise<string | null> {
   name = name.toLowerCase();
 
   resolver = resolver ?? await config.provider.getResolver(name);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,6 +89,7 @@ export function formatCAIP10Address(address: string, protocol: string, impl: num
   return `${address.toLowerCase()}@${protocol}:${impl.toString()}`;
 }
 
+// Returns a checksummed, shortened, without 0x prefix Ethereum address
 export function formatAddress(input: string): string {
   const addr = ethers.utils.getAddress(input).replace(/^0x/, "");
 
@@ -326,6 +327,7 @@ export async function resolveEnsProfile(addressOrName: string, profileType: Prof
 
       const project = await Promise.allSettled(promises);
       const [avatar, address, seedHost, seedId, anchorsAccount] =
+        // Just checking for r.value equal null and casting to undefined, since resolver functions return null
         project.map(r => r.status == "fulfilled" ? r.value : null);
 
       return {


### PR DESCRIPTION
This PR closes #113 

It does so by showing a simplified `Card` while loading the `Profile` details like avatar, name, etc.
```svelte
{#await Profile.get(org.name ?? org.address, ProfileType.Minimal, config)}
  <Card profile={{ address: org.address }} {config} path={`/orgs/${org.address}`} />
{:then profile}
  {#if orgMembers[profile.address]?.length}
    <Card {profile} {config} path={`/orgs/${profile.nameOrAddress}`} members={orgMembers[profile.address]} />
  {:else}
    <Card {profile} {config} path={`/orgs/${profile.address}`} />
  {/if}
{/await}
```

It also implements some fixes to `null | undefined` as arguments and return values.
We should eventually conform in the entire codebase to one of the two null types and try to cast them to the corresponding one where needed from third party libraries (looking at ethers.js :eyes: ).

To avoid mismatches between addresses this PR also introduces the usage of lowercase addresses in the codebase and uses checksummed address only for display purposes.