### PR TITLE
Manage anchor proposals

### DIFF
--- a/src/Avatar.svelte
+++ b/src/Avatar.svelte
@@ -49,4 +49,4 @@
 </style>
 
 <!-- svelte-ignore a11y-missing-attribute -->
-<img class="avatar" class:inline src={source} on:error={handleMissingFile} class:glowOnHover />
+<img class="avatar" class:inline src={source} title={address} on:error={handleMissingFile} class:glowOnHover />

--- a/src/base/orgs/View.svelte
+++ b/src/base/orgs/View.svelte
@@ -8,15 +8,14 @@
   import Error from '@app/Error.svelte';
   import Icon from '@app/Icon.svelte';
   import SetName from '@app/ens/SetName.svelte';
-  import Project from '@app/base/projects/Widget.svelte';
   import Address from '@app/Address.svelte';
   import Avatar from '@app/Avatar.svelte';
-  import Message from '@app/Message.svelte';
   import * as utils from '@app/utils';
 
   import { Org } from '@app/base/orgs/Org';
   import TransferOwnership from '@app/base/orgs/TransferOwnership.svelte';
   import { Profile, ProfileType } from '@app/profile';
+  import Projects from './View/Projects.svelte';
 
   export let addressOrName: string;
   export let config: Config;
@@ -136,12 +135,6 @@
   .seed-icon {
     width: 1rem;
     margin-right: 0.5rem;
-  }
-  .projects {
-    margin-top: 2rem;
-  }
-  .projects .project {
-    margin-bottom: 1rem;
   }
   .members {
     margin-top: 2rem;
@@ -326,21 +319,7 @@
           {/if}
         {/await}
 
-        <div class="projects">
-          {#await org.getProjects(config)}
-            <Loading center />
-          {:then projects}
-            {#each projects as project}
-              <div class="project">
-                <Project {project} org={profile.nameOrAddress} config={profile.config(config)} />
-              </div>
-            {/each}
-          {:catch err}
-            <Message error>
-              <strong>Error: </strong> failed to load projects: {err.message}.
-            </Message>
-          {/await}
-        </div>
+        <Projects {org} {config} />
       {/await}
     </main>
   {:else}

--- a/src/base/orgs/View/Anchor.svelte
+++ b/src/base/orgs/View/Anchor.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+  import { ethers } from "ethers";
+  import type { Safe } from "@app/utils";
+  import type { PendingProject } from "@app/project";
+  import type { Config } from "@app/config";
+  import * as utils from "@app/utils";
+  import Modal from "@app/Modal.svelte";
+  import Avatar from "@app/Avatar.svelte";
+  import { createEventDispatcher } from 'svelte';
+
+  export let safe: Safe;
+  export let project: PendingProject;
+  export let account: string;
+  export let config: Config;
+
+  enum State {
+    Idle,
+    Confirm,
+    Signing,
+    Submitting,
+    Success,
+    Execute,
+    Failed,
+  }
+
+  enum Action {
+    Sign,
+    Execute,
+  }
+
+  const dispatch = createEventDispatcher();
+  let state = State.Idle;
+  let action: null | Action = null;
+  const isSigned = project.confirmations.includes(
+    ethers.utils.getAddress(account)
+  );
+  const close = () => {
+    action = null;
+    state = State.Idle;
+    // Could eventually be a separate function if we want to handle a Cancel event differently.
+    dispatch("success");
+  };
+  const pending = safe.threshold - project.confirmations.length;
+  const executeTransaction = async (safeTxHash: string) => {
+    try {
+      action = Action.Execute;
+      state = State.Confirm;
+      const txResult = await utils.executeSignedSafeTransaction(safe.address, safeTxHash, config);
+
+      state = State.Submitting;
+      await txResult.transactionResponse?.wait();
+
+      state = State.Success;
+    } catch (err) {
+      console.error(err);
+    }
+  };
+  const confirmAnchor = async (safeTxHash: string) => {
+    try {
+      action = Action.Sign;
+      state = State.Signing;
+      const signature = await utils.signSafeTransaction(safe.address, safeTxHash, config);
+
+      state = State.Submitting;
+      await config.safe.client?.confirmTransaction(safeTxHash, signature.data);
+
+      state = State.Success;
+    } catch (err) {
+      console.error(err);
+      state = State.Failed;
+    }
+  };
+</script>
+
+<style>
+  .confirmations {
+    margin-right: 0.5rem;
+  }
+  .table {
+    display: grid;
+    grid-template-columns: 5rem 4fr;
+    grid-gap: 1rem;
+    text-align: left;
+  }
+  .table > *:nth-child(odd) { /* Labels */
+    color: var(--color-secondary);
+  }
+  .table > *:nth-child(even) { /* Values */
+    display: flex;
+    align-items: center;
+    justify-content: left;
+  }
+  .avatars {
+    display: flex;
+  }
+</style>
+
+<span class="confirmations">
+  {#if pending > 0}
+    <strong>{pending}</strong> signature(s) pending
+  {/if}
+</span>
+
+<div class="avatars">
+  {#each project.confirmations as signee}
+    <Avatar inline source={signee} address={signee} glowOnHover />
+  {/each}
+</div>
+
+<!-- Check whether the threshold has been matched or passed -->
+{#if pending <= 0}
+  <button on:click|stopPropagation={() => {
+    action = Action.Execute;
+    state = State.Confirm;
+  }} class="tiny">
+    Execute
+  </button>
+  <!-- Check whether or not we've signed this proposal -->
+{:else if isSigned}
+  <span class="badge safe no-margin">✓ signed</span>
+{:else}
+  <button on:click|stopPropagation={() => {
+    action = Action.Sign;
+    state = State.Confirm;
+    }} class="tiny">
+    Confirm
+  </button>
+{/if}
+
+<!-- We've initiated an action -->
+{#if state !== State.Idle && action === Action.Sign}
+  <Modal floating>
+    <span slot="title">
+      <div>⚓</div>
+      <div>Anchor project</div>
+    </span>
+
+    <span slot="subtitle">
+      {#if state == State.Confirm}
+        <span>Initiate the transaction...</span>
+      {:else if state == State.Signing}
+        <span>Sign the transaction in your wallet...</span>
+      {:else if state == State.Submitting}
+        <span>Transaction is being confirmed...</span>
+      {:else if state == State.Success}
+        <span>Transaction confirmed.</span>
+      {/if}
+    </span>
+
+    <span slot="body">
+      {#if state == State.Confirm}
+        <div class="table">
+          <div>Project</div><code>{project.id}</code>
+          <div>Hash</div><code>{project.anchor.stateHash}</code>
+        </div>
+      {/if}
+    </span>
+
+    <span slot="actions">
+      {#if state == State.Confirm}
+        <button class="primary" on:click={() => confirmAnchor(project.safeTxHash)}>
+          Confirm
+        </button>
+        <button class="text" on:click={close}>
+          Cancel
+        </button>
+      {:else if state == State.Success}
+        <button on:click={close}>Done</button>
+      {/if}
+    </span>
+  </Modal>
+{:else if state !== State.Idle && action === Action.Execute}
+  <Modal floating>
+    <span slot="title">
+      <div>⚡</div>
+      <div>Execute Safe Transaction</div>
+    </span>
+
+    <span slot="subtitle">
+      {#if state == State.Confirm}
+        <span>Sign the transaction in your wallet...</span>
+      {:else if state == State.Submitting}
+        <span>Transaction is being confirmed...</span>
+      {:else if state == State.Success}
+        <span>Transaction confirmed.</span>
+      {/if}
+    </span>
+
+    <span slot="body">
+      {#if state == State.Confirm}
+        <div class="table">
+          <div>TxHash</div><code>{utils.formatHash(project.safeTxHash)}</code>
+          <div>Quorum</div><code>{project.confirmations.length} of {safe.threshold}</code>
+        </div>
+      {/if}
+    </span>
+
+    <span slot="actions">
+      {#if state == State.Confirm}
+        <button class="primary" on:click={() => executeTransaction(project.safeTxHash)}>
+          Confirm
+        </button>
+        <button class="text" on:click={close}>
+          Cancel
+        </button>
+      {:else if state == State.Success}
+        <button on:click={() => close}>Done</button>
+      {/if}
+    </span>
+  </Modal>
+{/if}

--- a/src/base/orgs/View/Projects.svelte
+++ b/src/base/orgs/View/Projects.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import type { Config } from "@app/config";
+  import type { Org } from "@app/base/orgs/Org";
+  import type { PendingProject, Project } from "@app/project";
+  import { session } from '@app/session';
+  import Loading from "@app/Loading.svelte";
+  import Message from "@app/Message.svelte";
+  import Widget from '@app/base/projects/Widget.svelte';
+  import Anchor from './Anchor.svelte';
+
+  export let org: Org;
+  export let config: Config;
+
+  let getProjects = queryProjects;
+
+  function updateRecords() {
+    getProjects = queryProjects;
+  }
+
+  async function queryProjects(): Promise<(Project | PendingProject)[]> {
+    if ($session) {
+      const result = await org.isMember($session.address, config);
+      return result ? org.getAllProjects(config) : org.getProjects(config);
+    }
+    return org.getProjects(config);
+  }
+</script>
+
+<style>
+  .projects {
+    margin-top: 2rem;
+  }
+  .projects .project {
+    margin-bottom: 1rem;
+  }
+  .anchor {
+    display: flex;
+    align-items: center;
+  }
+</style>
+
+<div class="projects">
+  {#await getProjects()}
+    <Loading center />
+  {:then projects}
+    {#each projects as project}
+      <div class="project">
+        {#if "safeTxHash" in project} <!-- Pending project -->
+          <Widget {project} org={org.address} {config} faded>
+            <span class="anchor" slot="actions">
+              {#if org.safe && $session}
+                <Anchor {project} safe={org.safe} on:success={() => updateRecords()} account={$session.address} {config} />
+                <button on:click={() => updateRecords()}>Update projects</button>
+              {/if}
+            </span>
+          </Widget>
+        {:else} <!-- Anchored project -->
+          <Widget {project} org={org.address} {config} />
+        {/if}
+      </div>
+    {/each}
+  {:catch err}
+    <Message error>
+      <strong>Error: </strong> failed to load projects: {err.message}.
+    </Message>
+  {/await}
+</div>

--- a/src/base/projects/Widget.svelte
+++ b/src/base/projects/Widget.svelte
@@ -17,6 +17,7 @@
   export let config: Config;
   export let org: string | undefined = undefined;
   export let user: string | undefined = undefined;
+  export let faded = false;
 
   let state: State = { status: Status.Loading };
   let info: proj.Info | null = null;
@@ -27,6 +28,7 @@
       state = { status: Status.Loaded };
       info = result;
     } catch (err) {
+      console.error(err.message);
       state = { status: Status.Error, error: err.message };
     }
   });
@@ -55,8 +57,15 @@
   article.has-info {
     cursor: pointer;
   }
+  article.project-faded {
+    border: 1px dashed var(--color-foreground-subtle);
+    cursor: not-allowed;
+  }
   article.has-info:hover {
     border-color: var(--color-secondary);
+  }
+  article.project-faded.has-info:hover {
+    border-color: var(--color-foreground-faded);
   }
   article .id {
     font-size: 1rem;
@@ -64,13 +73,21 @@
     margin-bottom: 0.5rem;
   }
   article .description {
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.25rem;
     font-size: 0.75rem;
   }
   article .anchor {
     color: var(--color-secondary);
     font-size: 0.75rem;
+    min-height: 2rem;
+    display: flex;
+    align-items: center;
+  }
+  article .commit, article .actions {
     font-family: var(--font-family-monospace);
+  }
+  article.project-faded .anchor {
+    color: var(--color-foreground-faded);
   }
   article .id, article .anchor {
     display: flex;
@@ -97,20 +114,22 @@
   }
 </style>
 
-<article on:click={onClick} class:has-info={info}>
+<article on:click={onClick} class:has-info={info} class:project-faded={faded}>
   {#if info}
     <div class="id">
       <span class="name">{info.meta.name}</span><span class="urn">{project.id}</span>
     </div>
     <div class="description">{info.meta.description}</div>
     <div class="anchor">
-      <span>commit {project.anchor.stateHash}</span>
-      <span>
-        {#each info.meta.maintainers as urn}
-          <span class="avatar">
-            <Blockies address={urn} />
-          </span>
-        {/each}
+      <span class="commit">commit {project.anchor.stateHash}</span>
+      <span class="actions">
+        <slot name="actions">
+          {#each info.meta.maintainers as urn}
+            <span class="avatar">
+              <Blockies address={urn} />
+            </span>
+          {/each}
+        </slot>
       </span>
     </div>
   {:else}
@@ -120,6 +139,12 @@
         <Loading small />
       {/if}
     </div>
-    <div class="anchor">commit {project.anchor.stateHash}</div>
+    <div class="anchor">
+      <span class="commit">commit {project.anchor.stateHash}</span>
+      <span class="actions">
+        <slot name="actions">
+        </slot>
+      </span>
+    </div>
   {/if}
 </article>

--- a/src/config.json
+++ b/src/config.json
@@ -116,6 +116,7 @@
     "org": [
       "function owner() view returns (address)",
       "function anchors(bytes32) view returns (uint32, bytes)",
+      "function anchor(bytes32, uint32, bytes)",
       "function setOwner(address)",
       "function setName(string, address) returns (bytes32)"
     ],

--- a/src/project.ts
+++ b/src/project.ts
@@ -10,6 +10,11 @@ export interface Project {
   };
 }
 
+export interface PendingProject extends Project {
+  safeTxHash: string; // Safe transaction hash.
+  confirmations: string[]; // Owner addresses who have confirmed.
+}
+
 export interface Info {
   head: string;
   meta: Meta;


### PR DESCRIPTION
This PR closes #39 

It allows the signing and execution of anchor proposals for gnosis safe orgs.

**Some interesting points:**
- At the moment a pending project requires at least the required confirmations, once received the threshold, we don't accept more confirmations, but allow to execute the safe transaction.
- The owners that signed the proposal, show up as blockies, we could eventually show the profile avatar or show something entirely different, IMO the blockies maintain the design of the rest of the page.