### PR TITLE
Remove org owner fallback in getProfile

### DIFF
--- a/src/base/orgs/Org.ts
+++ b/src/base/orgs/Org.ts
@@ -3,7 +3,6 @@ import type { TransactionResponse } from '@ethersproject/providers';
 import type { ContractReceipt } from '@ethersproject/contracts';
 import { OperationType } from "@gnosis.pm/safe-core-sdk-types";
 
-import { Profile, ProfileType } from '@app/profile';
 import { assert } from '@app/error';
 import * as utils from '@app/utils';
 import type { Safe } from '@app/utils';
@@ -174,14 +173,6 @@ export class Org {
     return projects;
   }
 
-  async getProfile(profileType: ProfileType, config: Config): Promise<Profile> {
-    return Org.getProfile(this.name ?? this.address, profileType, config);
-  }
-
-  static async getProjectProfile(addrOrName: string, config: Config): Promise<Profile> {
-    return Org.getProfile(addrOrName, ProfileType.Project, config);
-  }
-
   static async getAnchor(orgAddr: string, urn: string, config: Config): Promise<string | null> {
     const org = new ethers.Contract(
       orgAddr,
@@ -262,26 +253,6 @@ export class Org {
       console.error(e);
       return null;
     }
-  }
-
-  // Return the org profile if there is one, otherwise try to get the profile
-  // of its owner.
-  static async getProfile(addressOrName: string, profileType: ProfileType, config: Config): Promise<Profile> {
-    const profile = await Profile.get(addressOrName, profileType, config);
-
-    if (profile.ens) { // Orgs only use ENS for profile information.
-      return profile;
-    }
-    const org = await Org.get(addressOrName, config);
-
-    if (org) {
-      const ownerProfile = await Profile.get(org.owner, profileType, config);
-
-      if (ownerProfile.ens || ownerProfile.idx) {
-        return ownerProfile;
-      }
-    }
-    return profile;
   }
 
   static async getOrgsByMember(owner: string, config: Config): Promise<Org[]> {

--- a/src/base/orgs/View.svelte
+++ b/src/base/orgs/View.svelte
@@ -173,7 +173,7 @@
 {:then org}
   {#if org}
     <main>
-      {#await org.getProfile(ProfileType.Full, config)}
+      {#await Profile.get(org.name ?? org.address, ProfileType.Full, config)}
         <div class="off-centered">
           <Loading center />
         </div>

--- a/src/base/projects/View.svelte
+++ b/src/base/projects/View.svelte
@@ -5,7 +5,6 @@
   import Loading from '@app/Loading.svelte';
   import Modal from '@app/Modal.svelte';
   import Avatar from '@app/Avatar.svelte';
-  import { Org } from '@app/base/orgs/Org';
   import { Profile, ProfileType } from '@app/profile';
   import type { Info } from '@app/project';
   import { formatOrg } from '@app/utils';
@@ -25,7 +24,7 @@
   let projectRoot = proj.path({ urn, user, org, commit });
   let getProject = new Promise<Profile | null>(resolve => {
     if (org) {
-      Org.getProjectProfile(org, config).then(p => resolve(p));
+      Profile.get(org, ProfileType.Project, config).then(p => resolve(p));
     } else if (user) {
       Profile.get(user, ProfileType.Project, config).then(p => resolve(p));
     } else {

--- a/src/base/users/View.svelte
+++ b/src/base/users/View.svelte
@@ -146,7 +146,7 @@
         {#if orgs.length > 0}
           <div class="members">
             {#each orgs as org}
-              {#await Org.getProfile(org.address, ProfileType.Minimal, config)}
+              {#await Profile.get(org.address, ProfileType.Minimal, config)}
                 <Loading small margins />
               {:then profile}
                 <div class="member">


### PR DESCRIPTION
Removes also some `getProfile` functions that were only used once or twice.