### PR TITLE
Add setOwner safe tx proposal creation

### DIFF
--- a/src/base/orgs/Org.ts
+++ b/src/base/orgs/Org.ts
@@ -133,6 +133,35 @@ export class Org {
     return org.setOwner(address);
   }
 
+  async setOwnerMultisig(owner: string, config: Config): Promise<void> {
+    assert(config.signer);
+    assert(config.safe.client);
+
+    const safeAddress = ethers.utils.getAddress(this.owner);
+    const orgAddress = ethers.utils.getAddress(this.address);
+    const org = new ethers.Contract(
+      this.address,
+      config.abi.org,
+      config.signer
+    );
+    const unsignedTx = await org.populateTransaction.setOwner(
+      owner
+    );
+
+    const txData = unsignedTx.data;
+    if (! txData) {
+      throw new Error("Org::setOwnerMultisig: Could not generate transaction for `setOwner` call");
+    }
+
+    const safeTx = {
+      to: orgAddress,
+      value: ethers.constants.Zero.toString(),
+      data: txData,
+      operation: OperationType.Call,
+    };
+    await utils.proposeSafeTransaction(safeTx, safeAddress, config);
+  }
+
   async getMembers(config: Config): Promise<Array<string>> {
     const safe = await utils.getSafe(this.owner, config);
     if (safe) {

--- a/src/base/orgs/View.svelte
+++ b/src/base/orgs/View.svelte
@@ -63,6 +63,7 @@
       }
     }
   };
+  $: account = $session && $session.address;
   $: isOwner = (org: Org): boolean => $session
     ? utils.isAddressEqual(org.owner, $session.address)
     : false;
@@ -220,7 +221,7 @@
           <div class="label">Owner</div>
           <div><Address resolve {config} address={org.owner} /></div>
           <div>
-            {#if isOwner(org)}
+            {#if isOwner(org) || (account && org.isMember(account, config))}
               <button class="tiny secondary" on:click={transferOwnership}>
                 Transfer
               </button>


### PR DESCRIPTION
This PR closes #35 

- Implements a new function called `setOwnerMultisig` in `Org.ts`, similar to `setNameMultisig`
- Adds Multisig proposal behaviour to `TransferOwnership.svelte`
- Checks if `session.address` is a member of the shown Org before allowing the transfer of ownership