### PR TITLE
Change asset paths to be relative

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ const config: UserConfig = {
   optimizeDeps: {
     exclude: ['svelte-routing', '@pedrouid/environment', '@pedrouid/iso-crypto']
   },
+  base: "",
   plugins: [svelte(), rewriteAll()],
   resolve: {
     alias: {


### PR DESCRIPTION
This PR adds the `base` property to the `vite.config.ts` this allows the assets to be defined from a relative path in `index.html`.
https://github.com/vitejs/vite/issues/762#issuecomment-711167905

This is necessary for a proper implementation of issue #40 which has issues with absolute paths when serving the UI from a IPFS gateway.

I did also run the E2E Cypress test suite after this change to verify that we won't have issues by running it outside of IPFS.