### PR TITLE
Add peer id to project api routes

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -95,7 +95,7 @@ export async function getTree(
   if (path === "/") {
     path = "";
   }
-  return api.get(`projects/${urn}/tree/${commit}/${path}`, {}, config);
+  return api.get(`projects/${urn}/tree/${config.seed.link.id}/${commit}/${path}`, {}, config);
 }
 
 export async function getBlob(
@@ -105,7 +105,7 @@ export async function getBlob(
   options: { highlight: boolean },
   config: Config
 ): Promise<Blob> {
-  return api.get(`projects/${urn}/blob/${commit}/${path}`, options, config);
+  return api.get(`projects/${urn}/blob/${config.seed.link.id}/${commit}/${path}`, options, config);
 }
 
 export async function getReadme(
@@ -113,7 +113,7 @@ export async function getReadme(
   commit: string,
   config: Config
 ): Promise<Blob> {
-  return api.get(`projects/${urn}/readme/${commit}`, {}, config);
+  return api.get(`projects/${urn}/readme/${config.seed.link.id}/${commit}`, {}, config);
 }
 
 export function path(


### PR DESCRIPTION
This PR adds the peer id of the seed to the project blob, readme and tree routes.

It breaks the current http-apis and require an update by the maintainers to keep seeing projects in the web client