### PR TITLE
Adds content param to project urls

### DIFF
--- a/src/base/projects/Header.svelte
+++ b/src/base/projects/Header.svelte
@@ -23,7 +23,7 @@
 
   // Switches between the browser and commit view
   const switchContent = () => {
-    content = content == ProjectContent.Browser ? ProjectContent.Commits : ProjectContent.Browser;
+    content = content == ProjectContent.Tree ? ProjectContent.History : ProjectContent.Tree;
   };
 
   const GetAllAnchors = `
@@ -47,7 +47,6 @@
     const unpadded = utils.decodeRadicleId(urn);
     const id = ethers.utils.hexZeroPad(unpadded, 32);
     const allAnchors = await utils.querySubgraph(config.orgs.subgraph, GetAllAnchors, { project: id, org: anchors });
-    console.log(allAnchors);
     return allAnchors.anchors
       .map((anchor: AnchorObject) => utils.formatProjectHash(ethers.utils.arrayify(anchor.multihash)));
   }
@@ -330,7 +329,7 @@
       {/if}
     </div>
   </span>
-  <div class="stat commit-count" class:active={content == ProjectContent.Commits} on:click={switchContent}>
+  <div class="stat commit-count" class:active={content == ProjectContent.History} on:click={switchContent}>
     <strong>{tree.stats.commits}</strong> commit(s)
   </div>
   <div class="stat">

--- a/src/base/projects/Routes.svelte
+++ b/src/base/projects/Routes.svelte
@@ -2,16 +2,21 @@
   import { Route } from "svelte-routing";
   import View from '@app/base/projects/View.svelte';
   import type { Config } from '@app/config';
+  import { ProjectContent } from "@app/project";
 
   export let config: Config;
+
+  function parseContent(content: string): ProjectContent {
+    return content == "history" ? ProjectContent.History : ProjectContent.Tree;
+  }
 </script>
 
-<Route path="/projects/:urn/head/*" let:params>
-  <View {config} urn={params.urn} path={params['*'] || "/"} />
+<Route path="/projects/:urn/:content/head/*" let:params>
+  <View {config} urn={params.urn} content={parseContent(params.content)} path={params['*'] || "/"} />
 </Route>
 
-<Route path="/projects/:urn/:commit/*" let:params>
-  <View {config} urn={params.urn} commit={params.commit} path={params['*'] || "/"} />
+<Route path="/projects/:urn/:content/:commit/*" let:params>
+  <View {config} urn={params.urn} content={parseContent(params.content)} commit={params.commit} path={params['*'] || "/"} />
 </Route>
 
 <Route path="/projects/:urn" let:params>
@@ -20,12 +25,12 @@
 
 <!-- With an Org context -->
 
-<Route path="/orgs/:org/projects/:urn/head/*" let:params>
-  <View {config} org={params.org} urn={params.urn} path={params['*'] || "/"} />
+<Route path="/orgs/:org/projects/:urn/:content/head/*" let:params>
+  <View {config} org={params.org} urn={params.urn} content={parseContent(params.content)} path={params['*'] || "/"} />
 </Route>
 
-<Route path="/orgs/:org/projects/:urn/:commit/*" let:params>
-  <View {config} org={params.org} urn={params.urn} commit={params.commit} path={params["*"] || "/"} />
+<Route path="/orgs/:org/projects/:urn/:content/:commit/*" let:params>
+  <View {config} org={params.org} urn={params.urn} content={parseContent(params.content)} commit={params.commit} path={params["*"] || "/"} />
 </Route>
 
 <Route path="/orgs/:org/projects/:urn" let:params>
@@ -34,12 +39,12 @@
 
 <!-- With a User context -->
 
-<Route path="/users/:user/projects/:urn/head/*" let:params>
-  <View {config} user={params.user} urn={params.urn} path={params['*'] || "/"} />
+<Route path="/users/:user/projects/:urn/:content/head/*" let:params>
+  <View {config} user={params.user} urn={params.urn} content={parseContent(params.content)} path={params['*'] || "/"} />
 </Route>
 
-<Route path="/users/:user/projects/:urn/:commit/*" let:params>
-  <View {config} user={params.user} urn={params.urn} commit={params.commit} path={params["*"] || "/"} />
+<Route path="/users/:user/projects/:urn/:content/:commit/*" let:params>
+  <View {config} user={params.user} urn={params.urn} content={parseContent(params.content)} commit={params.commit} path={params["*"] || "/"} />
 </Route>
 
 <Route path="/users/:user/projects/:urn" let:params>

--- a/src/base/projects/View.svelte
+++ b/src/base/projects/View.svelte
@@ -19,8 +19,8 @@
   export let commit = "";
   export let config: Config;
   export let path: string;
+  export let content: proj.ProjectContent = proj.ProjectContent.Tree;
 
-  let content = proj.ProjectContent.Browser;
   let parentName = formatOrg(org || user, config);
   let pageTitle = parentName ? `${parentName}/${urn}` : urn;
   let projectInfo: Info | null = null;
@@ -64,8 +64,8 @@
   const back = () => window.history.back();
   // React to changes to the project commit. We have to manually
   // set the URL as well, to match the current commit.
-  $: projectRoot = proj.path({ urn, user, org, commit });
-  $: navigate(proj.path({ urn, user, org, commit, path }));
+  $: projectRoot = proj.path({ urn, user, content: proj.ProjectContent.Tree, org, commit });
+  $: navigate(proj.path({ urn, user, org, content, commit, path }));
 </script>
 
 <style>
@@ -159,11 +159,11 @@
         bind:commit={commit}
         bind:content={content}
       />
-      {#if content == proj.ProjectContent.Browser}
+      {#if content == proj.ProjectContent.Tree}
         <Browser {urn} {org} {user} {path} {tree}
           commit={commit}
           config={result.config} />
-      {:else if content == proj.ProjectContent.Commits}
+      {:else if content == proj.ProjectContent.History}
         <History {urn} config={result.config} bind:commit={commit}  />
       {/if}
     {:catch err}

--- a/src/base/projects/Widget.svelte
+++ b/src/base/projects/Widget.svelte
@@ -40,6 +40,7 @@
         proj.path({
           urn: project.id,
           org,
+          content: proj.ProjectContent.Tree,
           user,
           commit: project.anchor?.stateHash,
         })

--- a/src/project.ts
+++ b/src/project.ts
@@ -18,8 +18,8 @@ export interface PendingProject extends Project {
 
 // Enumerates the space below the Header component in the projects View component
 export enum ProjectContent {
-  Browser,
-  Commits,
+  Tree,
+  History,
 }
 
 export interface Info {
@@ -128,9 +128,9 @@ export async function getReadme(
 }
 
 export function path(
-  opts: { urn: string; org?: string; user?: string; commit?: string; path?: string }
+  opts: { urn: string; org?: string; content?: ProjectContent; user?: string; commit?: string; path?: string }
 ): string {
-  const { urn, org, user, commit, path } = opts;
+  const { urn, org, user, content, commit, path } = opts;
   const result = [];
 
   if (org) {
@@ -139,6 +139,12 @@ export function path(
     result.push("users", user);
   }
   result.push("projects", urn);
+
+  if (content == ProjectContent.History) {
+    result.push("history");
+  } else {
+    result.push("tree");
+  }
 
   if (commit) {
     result.push(commit);


### PR DESCRIPTION
By adding a content param to the project urls and use the Browser content as default, we are able to control better the url shown in the project views as well in the future implement other views, eg. commit detail view, etc.

With this commit we have full URL support thus allowing navigation with:

- Back button
- Clicking on project name
- Clicking again on commit count

For future improvements we could allow to pass any string as `content` and parse it to an available view to match, and if not found return 404.

**Some thoughts on the why:**
To use `navigate` for pushing history state and avoid a re rendering by svelte-routing, we have to avoid route switching i.e.
If we are on the URL
`/users/<user>/projects/<urn>/<sha>` and switch to `/users/<user>/projects/<urn>/commits/<sha>` we are adding a route param `commits` which makes `svelte-routing` jump between Routes and thus re render. If we define a `content` param which changes its value based on interaction with the component and we pass that to the component or update it inside the component, we can avoid re rendering the entire component.