### PR TITLE
Project url support and branch browsing

### DIFF
--- a/src/base/projects/BranchSelector.svelte
+++ b/src/base/projects/BranchSelector.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import { Info, getOid } from "@app/project";
+  import { formatCommit, isOid } from "@app/utils";
+  import { createEventDispatcher } from "svelte";
+
+  export let branches: [string, string][];
+  export let project: Info;
+  export let revision: string;
+
+  const dispatch = createEventDispatcher();
+
+  let branchesDropdown = false;
+  const switchBranch = (name: string) => {
+    dispatch("revisionChanged", name);
+  };
+
+  // Sort branches array alphabetically
+  const sortBranches = ([firstBranchName,]: [string, string], [secondBranchName,]: [string, string]) => {
+    if (firstBranchName < secondBranchName) return -1;
+    if (firstBranchName > secondBranchName) return 1;
+    return 0;
+  };
+
+  branches = branches.sort(sortBranches);
+
+  // Casting commit to string, since the commit will always be defined here
+  $: commit = getOid(project.head, revision, branches);
+</script>
+
+<style>
+  .commit {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-family-monospace);
+  }
+  .commit .branch {
+    cursor: pointer;
+    padding: 0.5rem 0.75rem;
+    color: var(--color-secondary);
+    background-color: var(--color-secondary-background);
+    border-radius: 0.25rem 0 0 0.25rem;
+  }
+  .commit .branch.not-allowed {
+    cursor: not-allowed;
+  }
+  .branch:hover {
+    background-color: var(--color-foreground-background-lighter);
+  }
+  .commit .hash {
+    display: inline-block;
+    color: var(--color-secondary);
+    background-color: var(--color-secondary-background-darker);
+    padding: 0.5rem 0.75rem;
+    border-radius: inherit;
+  }
+  .item {
+    cursor: pointer;
+    padding: 0.3rem;
+  }
+  .item:hover {
+    background-color: var(--color-foreground-background-lighter);
+  }
+  .dropdown {
+    background-color: var(--color-foreground-background);
+    padding: 1rem;
+    margin-top: 0.5rem;
+    border-radius: 0.25rem;
+    display: none;
+    position: absolute;
+  }
+  .branch-dropdown.branch-dropdown-visible {
+    display: block;
+  }
+  .stat {
+    font-family: var(--font-family-monospace);
+    padding: 0.5rem 0.75rem;
+    background: var(--color-foreground-background);
+  }
+  @media (max-width: 720px) {
+    .dropdown {
+      left: 32px;
+      z-index: 10;
+    }
+  }
+</style>
+
+<div class="commit">
+  <!-- Check for branches listing feature -->
+  {#if branches.length > 0}
+    <span>
+      <div on:click={() => branchesDropdown = !branchesDropdown} class="stat branch" class:not-allowed={!branches}>
+        {#if commit === project.head}
+          {project.meta.defaultBranch}
+        <!-- If commit is no sha1 commit show branch or tag name -->
+        {:else if !isOid(revision)}
+          {revision}
+        {:else}
+          Browse...
+        {/if}
+      </div>
+      <div
+        class="dropdown branch-dropdown"
+        class:branch-dropdown-visible={branchesDropdown}
+      >
+        {#each branches as [name,]}
+          <div class="item" on:click={() => switchBranch(name)}>{name}</div>
+        {/each}
+      </div>
+    </span>
+    {#if commit === project.head || !isOid(revision)}
+      <div class="hash">
+        {formatCommit(commit)}
+      </div>
+    {:else}
+      <div class="hash desktop">
+        {commit}
+      </div>
+      <div class="hash mobile">
+        {formatCommit(commit)}
+      </div>
+    {/if}
+  <!-- If there is no branch listing available, show default branch name if commit is head and else show entire commit -->
+  {:else if commit === project.head}
+    <div class="stat branch not-allowed">
+      {project.meta.defaultBranch}
+    </div>
+    <div class="hash">
+      {formatCommit(commit)}
+    </div>
+  {:else}
+    <div class="hash desktop">
+      {commit}
+    </div>
+    <div class="hash mobile">
+      {formatCommit(commit)}
+    </div>
+  {/if}
+</div>

--- a/src/base/projects/Commit/History.svelte
+++ b/src/base/projects/Commit/History.svelte
@@ -1,18 +1,26 @@
 <script lang="ts">
+  import { createEventDispatcher, onMount } from "svelte";
   import CommitTeaser from "./CommitTeaser.svelte";
-  import { getCommits } from "@app/project";
+  import { getCommits, Info, getOid, ProjectContent } from "@app/project";
   import type { Config } from "@app/config";
   import Loading from "@app/Loading.svelte";
   import { groupCommitHistory, GroupedCommitsHistory } from "./lib";
 
-  export let commit: string;
+  export let revision: string;
   export let urn: string;
   export let config: Config;
+  export let project: Info;
+  export let branches: [string, string][];
 
   async function fetchCommits(): Promise<GroupedCommitsHistory> {
-    const commitsQuery = await getCommits(urn, commit, config);
+    const commitsQuery = await getCommits(urn, getOid(project.head, revision, branches), config);
     return groupCommitHistory(commitsQuery);
   }
+
+  const dispatch = createEventDispatcher();
+  onMount(() => {
+    dispatch("routeParamsChange", { content: ProjectContent.History, revision, path: "/" });
+  });
 </script>
 
 <style>
@@ -31,7 +39,7 @@
   .commit {
     padding: 0.25rem 0;
   }
-  @media (max-width: 720px) {
+  @media (max-width: 960px) {
     .history {
       padding-left: 2rem;
     }

--- a/src/base/projects/ProjectContentRoutes.svelte
+++ b/src/base/projects/ProjectContentRoutes.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import type { Config } from "@app/config";
+  import type { Info, Tree } from "@app/project";
+  import { Route, Router } from "svelte-routing";
+  import Browser from "./Browser.svelte";
+  import History from "./Commit/History.svelte";
+
+  export let urn: string;
+  export let project: Info;
+  export let config: Config;
+  export let org: string;
+  export let tree: Tree;
+  export let path: string;
+  export let user: string;
+  export let branches: [string, string][];
+
+  const dispatch = createEventDispatcher();
+
+  function forwardRouteParams({ detail: newParams }: { detail: any }) {
+    dispatch("routeParamsChange", newParams);
+  }
+</script>
+
+<Router>
+  <!-- The default action is to render Browser with the default branch head -->
+  <Route path="/">
+    <Browser {urn} {org} {user} {config} {tree} {project} {branches}
+      path={"/"}
+      revision={project.head}
+      on:routeParamsChange={forwardRouteParams} />
+  </Route>
+  <Route path="/tree">
+    <Browser {urn} {org} {user} {config} {tree} {project} {branches}
+      path={"/"}
+      revision={project.head}
+      on:routeParamsChange={forwardRouteParams} />
+  </Route>
+  <Route path="/tree/*" let:params>
+    <Browser {urn} {org} {user} {config} {tree} {project} {branches} {path}
+      revision={params["*"]}
+      on:routeParamsChange={forwardRouteParams} />
+  </Route>
+  <Route path="/history">
+    <History {urn} revision={project.head} {config} {project} {branches}
+      on:routeParamsChange={forwardRouteParams} />
+  </Route>
+  <Route path="/history/*" let:params>
+    <History {urn} revision={params["*"]} {config} {project} {branches}
+      on:routeParamsChange={forwardRouteParams} />
+  </Route>
+</Router>

--- a/src/base/projects/Routes.svelte
+++ b/src/base/projects/Routes.svelte
@@ -4,44 +4,21 @@
   import type { Config } from '@app/config';
 
   export let config: Config;
+
 </script>
 
-<Route path="/projects/:urn/head/*" let:params>
-  <View {config} urn={params.urn} path={params['*'] || "/"} />
-</Route>
-
-<Route path="/projects/:urn/:commit/*" let:params>
-  <View {config} urn={params.urn} commit={params.commit} path={params['*'] || "/"} />
-</Route>
-
-<Route path="/projects/:urn" let:params>
-  <View {config} urn={params.urn} path="/" />
+<Route path="/projects/:urn/*" let:params>
+  <View {config} urn={params.urn} />
 </Route>
 
 <!-- With an Org context -->
 
-<Route path="/orgs/:org/projects/:urn/head/*" let:params>
-  <View {config} org={params.org} urn={params.urn} path={params['*'] || "/"} />
-</Route>
-
-<Route path="/orgs/:org/projects/:urn/:commit/*" let:params>
-  <View {config} org={params.org} urn={params.urn} commit={params.commit} path={params["*"] || "/"} />
-</Route>
-
-<Route path="/orgs/:org/projects/:urn" let:params>
-  <View {config} org={params.org} urn={params.urn} path="/" />
+<Route path="/orgs/:org/projects/:urn/*" let:params>
+  <View {config} org={params.org} urn={params.urn} />
 </Route>
 
 <!-- With a User context -->
 
-<Route path="/users/:user/projects/:urn/head/*" let:params>
-  <View {config} user={params.user} urn={params.urn} path={params['*'] || "/"} />
-</Route>
-
-<Route path="/users/:user/projects/:urn/:commit/*" let:params>
-  <View {config} user={params.user} urn={params.urn} commit={params.commit} path={params["*"] || "/"} />
-</Route>
-
-<Route path="/users/:user/projects/:urn" let:params>
-  <View {config} user={params.user} urn={params.urn} path="/" />
+<Route path="/users/:user/projects/:urn/*" let:params>
+  <View {config} user={params.user} urn={params.urn} />
 </Route>

--- a/src/base/projects/Widget.svelte
+++ b/src/base/projects/Widget.svelte
@@ -41,7 +41,7 @@
           urn: project.id,
           org,
           user,
-          commit: project.anchor?.stateHash,
+          revision: project.anchor?.stateHash,
         })
       );
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,10 +28,10 @@ export interface Safe {
 }
 
 export interface SafeTransaction {
-    to: string;
-    value: string;
-    data: string;
-    operation: number;
+  to: string;
+  value: string;
+  data: string;
+  operation: number;
 }
 
 export interface Token {
@@ -43,17 +43,17 @@ export interface Token {
 }
 
 export enum Status {
-    Signing,
-    Pending,
-    Success,
-    Failed,
-  }
+  Signing,
+  Pending,
+  Success,
+  Failed,
+}
 
 export type State =
-      { status: Status.Signing }
-    | { status: Status.Pending }
-    | { status: Status.Success }
-    | { status: Status.Failed; error: string };
+    { status: Status.Signing }
+  | { status: Status.Pending }
+  | { status: Status.Success }
+  | { status: Status.Failed; error: string };
 
 export async function isReverseRecordSet(address: string, domain: string, config: Config): Promise<boolean> {
   const name = await config.provider.lookupAddress(address);
@@ -173,6 +173,11 @@ export function unixTime(): number {
 // Check whether the input is a Radicle ID.
 export function isRadicleId(input: string): boolean {
   return /^rad:[a-z]+:[a-zA-Z0-9]+$/.test(input);
+}
+
+// Check whether the input is a SHA1 commit.
+export function isOid(input: string): boolean {
+  return /^[a-fA-F0-9]{40}$/.test(input);
 }
 
 // Check whether the input is a URL.


### PR DESCRIPTION
This PR provides:

- Adds URL support for project routes:
  - For commit listing under `/users/:user/projects/:urn/history/:commit`
  - The tree view you'll find under `/users/:user/projects/:urn/tree/:commit`
  - and as fallback we show the tree view
  - Adds branches selector to the `Header` that allows selecting the different head commits wrt to the selected branch