### PR TITLE
Fix avatar aspect ratio

### DIFF
--- a/src/Avatar.svelte
+++ b/src/Avatar.svelte
@@ -33,6 +33,8 @@
     min-width: 1rem;
     min-height: 1rem;
     height: 100%;
+    width: inherit;
+    object-fit: cover;
     background-size: cover;
     background-repeat: no-repeat;
   }


### PR DESCRIPTION
This PR uses the `object-fit` attribute to the Avatar component, so that the avatars fill their container, if they are not perfectly square. Which in most cases should keep it the same but in some cases maintains the form factor of the Avatars

Closes #155