### PR TITLE
Fix Org Treasury token balances

### DIFF
--- a/src/base/orgs/View.svelte
+++ b/src/base/orgs/View.svelte
@@ -242,7 +242,7 @@
               <div class="label">Treasury</div>
               <div>
                 {#each tokens as token}
-                  {` ${utils.formatBalance(token.balance)} ${token.symbol} `}
+                  {` ${utils.formatBalance(token.balance, token.decimals)} ${token.symbol} `}
                 {/each}
               </div>
               <div class="desktop" />

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -88,8 +88,8 @@ export function formatRadicleUrn(id: string): string {
     + id.substring(id.length - 6, id.length);
 }
 
-export function formatBalance(n: BigNumber): string {
-  return ethers.utils.commify(parseFloat(ethers.utils.formatUnits(n)).toFixed(2));
+export function formatBalance(n: BigNumber, decimals?: number): string {
+  return ethers.utils.commify(parseFloat(ethers.utils.formatUnits(n, decimals)).toFixed(2));
 }
 
 export function formatCAIP10Address(address: string, protocol: string, impl: number): string {


### PR DESCRIPTION
Passes the `decimals` property from Alchemy to `ethers.utils.formatUnits`, if `formatBalance` is used without decimals it defaults to convert wei to ether
`ethers.utils.formatUnits( value [ , unit = "ether" ] ) ⇒ string`