### PR TITLE
Fix Org static getter method and improve pending anchors

### DIFF
--- a/src/base/orgs/Org.ts
+++ b/src/base/orgs/Org.ts
@@ -313,12 +313,10 @@ export class Org {
       const safe = await utils.getSafe(owner, config);
       // If what is resolved is not the same as the input, it's because we
       // were given a name.
-      if (utils.isAddressEqual(addressOrName, resolved) && safe) {
+      if (utils.isAddressEqual(addressOrName, resolved)) {
         return new Org(resolved, owner, null, safe);
-      } else if (safe === null) {
-        return new Org(resolved, owner);
       } else {
-        return new Org(resolved, owner, addressOrName);
+        return new Org(resolved, owner, addressOrName, safe);
       }
     } catch (e) {
       console.error(e);

--- a/src/base/orgs/View.svelte
+++ b/src/base/orgs/View.svelte
@@ -331,7 +331,7 @@
           </Message>
         {/await}
 
-        <Projects {org} config={profile.seed ? config.withSeed(profile.seed) : config} />
+        <Projects {org} {account} config={profile.seed ? config.withSeed(profile.seed) : config} />
       {/await}
     </main>
   {:else}

--- a/src/base/orgs/View/Projects.svelte
+++ b/src/base/orgs/View/Projects.svelte
@@ -2,7 +2,6 @@
   import type { Config } from "@app/config";
   import type { Org } from "@app/base/orgs/Org";
   import type { PendingProject, Project } from "@app/project";
-  import { session } from '@app/session';
   import Loading from "@app/Loading.svelte";
   import Message from "@app/Message.svelte";
   import Widget from '@app/base/projects/Widget.svelte';
@@ -11,20 +10,20 @@
 
   export let org: Org;
   export let config: Config;
+  export let account: string | null;
 
-  let getProjects = queryProjects;
-
-  function updateRecords() {
+  const updateRecords = () => {
     getProjects = queryProjects;
-  }
+  };
 
-  async function queryProjects(): Promise<(Project | PendingProject)[]> {
-    if ($session) {
-      const result = await org.isMember($session.address, config);
+  $: queryProjects = async (): Promise<(Project | PendingProject)[]> => {
+    if (account) {
+      const result = await org.isMember(account, config);
       return result ? org.getAllProjects(config) : org.getProjects(config);
     }
     return org.getProjects(config);
-  }
+  };
+  $: getProjects = queryProjects;
 </script>
 
 <style>
@@ -53,9 +52,8 @@
               <span class="desktop">commit {project.anchor.stateHash}</span>
             </span>
             <span class="anchor" slot="actions">
-              {#if org.safe && $session}
-                <Anchor {project} safe={org.safe} on:success={() => updateRecords()} account={$session.address} {config} />
-                <button on:click={() => updateRecords()}>Update projects</button>
+              {#if org.safe && account}
+                <Anchor {project} safe={org.safe} on:success={() => updateRecords()} {account} {config} />
               {/if}
             </span>
           </Widget>


### PR DESCRIPTION
This PR fixes the workings of `Org.get` which was broken if the resolved address and the owner address mismatched. Which was in most cases.

And the pending anchor proposals were in need of a bit better UX and reactivity to user changes.