### PR TITLE
Improve support for non-radicle ENS domains

### DIFF
--- a/src/Form.svelte
+++ b/src/Form.svelte
@@ -80,7 +80,8 @@
     return fields.filter(field => field.editable).map(field => {
       return {
         name: field.name,
-        value: field.value && field.value.trim(),
+        // We only allow to have a trueish value or an empty string.
+        value: field.value ? field.value.trim() : "",
       };
     });
   };
@@ -179,7 +180,7 @@
     <div>
       {#if field.editable && editable}
         <input name={field.name} class="field" placeholder={field.placeholder}
-               on:change={validate} value={field.value} type="text" {disabled} />
+               on:change={validate} value={field.value || ""} type="text" {disabled} />
       {:else}
         <span class="field">
           {#if field.value}

--- a/src/base/registrations/New.svelte
+++ b/src/base/registrations/New.svelte
@@ -20,11 +20,11 @@
   }
 
   export let config: Config;
-  export let subdomain: string;
+  export let name: string;
   export let owner: string | null;
 
   // We only support lower-case names.
-  subdomain = subdomain.toLowerCase();
+  name = name.toLowerCase();
 
   let fee: string;
   let state = State.CheckingAvailability;
@@ -32,7 +32,7 @@
   $: registrationOwner = owner || ($session && $session.address);
 
   function begin() {
-    navigate(`/registrations/${subdomain}/submit?${
+    navigate(`/registrations/${name}/submit?${
       registrationOwner ? new URLSearchParams({ owner: registrationOwner }) : ''
     }`);
   }
@@ -41,7 +41,7 @@
     try {
       const [_fee, isAvailable] = await Promise.all([
         registrationFee(config),
-        registrar(config).available(subdomain),
+        registrar(config).available(name),
       ]);
 
       fee = formatBalance(_fee);
@@ -59,7 +59,7 @@
 </script>
 
 <svelte:head>
-  <title>Radicle: Register {subdomain}</title>
+  <title>Radicle: Register {name}</title>
 </svelte:head>
 
 <Modal narrow>
@@ -69,17 +69,17 @@
   </span>
 
   <span slot="subtitle">
-    {subdomain}.{config.registrar.domain}
+    {name}.{config.registrar.domain}
   </span>
 
   <span slot="body">
     {#if state === State.NameAvailable}
       {#if registrationOwner}
-        The name <strong>{subdomain}</strong> is available for registration
+        The name <strong>{name}</strong> is available for registration
         under account <strong>{formatAddress(registrationOwner)}</strong>
         for <strong>{fee} RAD</strong>.
       {:else}
-        The name <strong>{subdomain}</strong> is available
+        The name <strong>{name}</strong> is available
         for <strong>{fee} RAD</strong>.
       {/if}
     {:else if state === State.NameUnavailable}

--- a/src/base/registrations/Routes.svelte
+++ b/src/base/registrations/Routes.svelte
@@ -18,12 +18,12 @@
 </Route>
 
 <Route path="registrations/:name/form" let:params let:location>
-  <New {config} subdomain={params.name} owner={getSearchParam("owner", location)} />
+  <New {config} name={params.name} owner={getSearchParam("owner", location)} />
 </Route>
 
 <Route path="registrations/:name/submit" let:params let:location>
   {#if session}
-    <Submit {config} subdomain={params.name} owner={getSearchParam("owner", location)} {session} />
+    <Submit {config} name={params.name} owner={getSearchParam("owner", location)} {session} />
   {:else}
     <Error
       message={"You must connect your wallet to register"}
@@ -32,6 +32,6 @@
   {/if}
 </Route>
 
-<Route path="registrations/:name" let:params>
-  <View {config} subdomain={params.name} />
+<Route path="registrations/:domain" let:params>
+  <View {config} domain={params.domain} />
 </Route>

--- a/src/base/registrations/Submit.svelte
+++ b/src/base/registrations/Submit.svelte
@@ -13,18 +13,18 @@
   import { registerName, State, state } from './registrar';
 
   export let config: Config;
-  export let subdomain: string;
+  export let name: string;
   export let owner: string | null;
   export let session: Session;
 
   let error: Error | null = null;
   let registrationOwner = owner || session.address;
 
-  const view = () => navigate(`/registrations/${subdomain}`, { state: { retry: true } });
+  const view = () => navigate(`/registrations/${name}`, { state: { retry: true } });
 
   onMount(async () => {
     try {
-      await registerName(subdomain, registrationOwner, config);
+      await registerName(name, registrationOwner, config);
     } catch (e: any) {
       console.error("Error", e);
 
@@ -43,7 +43,7 @@
 </style>
 
 <svelte:head>
-  <title>{subdomain}</title>
+  <title>{name}</title>
 </svelte:head>
 
 {#if error}
@@ -60,7 +60,7 @@
       {:else}
         <div>🌐</div>
       {/if}
-      {subdomain}.{config.registrar.domain}
+      {name}.{config.registrar.domain}
     </span>
 
     <span slot="subtitle">
@@ -69,7 +69,7 @@
       {:else if $state.connection === State.SigningPermit}
         Approving registration fee. Please confirm in your wallet.
       {:else if $state.connection === State.SigningCommit}
-        Committing to <strong>{subdomain}</strong>. Please confirm transaction in your wallet.
+        Committing to <strong>{name}</strong>. Please confirm transaction in your wallet.
       {:else if $state.connection === State.Committing}
         Waiting for <strong>commit</strong> transaction to be processed&hellip;
       {:else if $state.connection === State.WaitingToRegister && $state.commitmentBlock}

--- a/src/base/registrations/Update.svelte
+++ b/src/base/registrations/Update.svelte
@@ -8,7 +8,7 @@
   import Modal from '@app/Modal.svelte';
   import { Status, State } from "@app/utils";
 
-  export let subdomain: string;
+  export let domain: string;
   export let config: Config;
   export let records: EnsRecord[];
   export let registration: Registration;
@@ -20,7 +20,7 @@
   onMount(async () => {
     try {
       state.status = Status.Signing;
-      const tx = await setRecords(subdomain, records, registration.resolver, config);
+      const tx = await setRecords(domain, records, registration.resolver, config);
       state.status = Status.Pending;
       await tx.wait();
       state.status = Status.Success;

--- a/src/base/registrations/View.svelte
+++ b/src/base/registrations/View.svelte
@@ -39,7 +39,6 @@
   let state: State = { status: Status.Loading };
   let editable = false;
   let fields: Field[] = [];
-  let name = `${subdomain}.${config.registrar.domain}`;
   let updateRecords: EnsRecord[] | null = null;
   let retries = 3;
   let resolver: ethers.providers.EnsResolver | undefined = undefined;
@@ -48,9 +47,9 @@
     if (r) {
       let reverseRecord = false;
       if (r.profile.address) {
-        reverseRecord = await isReverseRecordSet(r.profile.address, name, config);
+        reverseRecord = await isReverseRecordSet(r.profile.address, subdomain, config);
       }
-      const owner = await getOwner(name, config);
+      const owner = await getOwner(subdomain, config);
       resolver = r.resolver;
 
       fields = [
@@ -60,7 +59,7 @@
         { name: "address", validate: "address", placeholder: "Ethereum address, eg. 0x4a9cf21...bc91",
           description: "The address this name resolves to. " + (
             reverseRecord
-              ? `The reverse record for this address is set to **${name}**`
+              ? `The reverse record for this address is set to **${subdomain}**`
               : "The reverse record for this address is **not set**. "
               + "For this name to be correctly associated with the address, "
               + "a reverse record should be set."
@@ -101,7 +100,7 @@
   }
 
   onMount(() => {
-    getRegistration(name, config, resolver)
+    getRegistration(subdomain, config, resolver)
       .then(parseRecords).catch(err => {
         state = { status: Status.Failed, error: err };
       });
@@ -118,7 +117,7 @@
   };
 
   $: if (window.history.state?.retry && state.status === Status.NotFound && retries > 0) {
-    getRegistration(name, config, resolver).then(parseRecords).catch(err => {
+    getRegistration(subdomain, config, resolver).then(parseRecords).catch(err => {
       state = { status: Status.Failed, error: err };
     });
   }
@@ -151,7 +150,7 @@
 </style>
 
 <svelte:head>
-  <title>{subdomain}.{config.registrar.domain}</title>
+  <title>{subdomain}</title>
 </svelte:head>
 
 {#if state.status === Status.Loading}
@@ -164,7 +163,7 @@
   <Modal subtle>
     <span slot="title" class="secondary">
       <div>🍄</div>
-      {subdomain}.{config.registrar.domain}
+      {subdomain}
     </span>
 
     <span slot="body">
@@ -178,7 +177,7 @@
 {:else if state.status === Status.Found}
   <main>
     <header>
-      <h1 class="bold">{subdomain}.{config.registrar.domain}</h1>
+      <h1 class="bold">{subdomain}</h1>
       <button
         style="min-width: 60px;"
         class="tiny primary" class:active={editable} disabled={!isOwner(state.owner)}

--- a/src/base/registrations/View.svelte
+++ b/src/base/registrations/View.svelte
@@ -31,10 +31,10 @@
     | { status: Status.Found; registration: Registration; owner: string }
     | { status: Status.Failed; error: string };
 
-  export let subdomain: string;
+  export let domain: string;
   export let config: Config;
 
-  subdomain = subdomain.toLowerCase();
+  domain = domain.toLowerCase();
 
   let state: State = { status: Status.Loading };
   let editable = false;
@@ -47,9 +47,9 @@
     if (r) {
       let reverseRecord = false;
       if (r.profile.address) {
-        reverseRecord = await isReverseRecordSet(r.profile.address, subdomain, config);
+        reverseRecord = await isReverseRecordSet(r.profile.address, domain, config);
       }
-      const owner = await getOwner(subdomain, config);
+      const owner = await getOwner(domain, config);
       resolver = r.resolver;
 
       fields = [
@@ -59,7 +59,7 @@
         { name: "address", validate: "address", placeholder: "Ethereum address, eg. 0x4a9cf21...bc91",
           description: "The address this name resolves to. " + (
             reverseRecord
-              ? `The reverse record for this address is set to **${subdomain}**`
+              ? `The reverse record for this address is set to **${domain}**`
               : "The reverse record for this address is **not set**. "
               + "For this name to be correctly associated with the address, "
               + "a reverse record should be set."
@@ -100,7 +100,7 @@
   }
 
   onMount(() => {
-    getRegistration(subdomain, config, resolver)
+    getRegistration(domain, config, resolver)
       .then(parseRecords).catch(err => {
         state = { status: Status.Failed, error: err };
       });
@@ -117,7 +117,7 @@
   };
 
   $: if (window.history.state?.retry && state.status === Status.NotFound && retries > 0) {
-    getRegistration(subdomain, config, resolver).then(parseRecords).catch(err => {
+    getRegistration(domain, config, resolver).then(parseRecords).catch(err => {
       state = { status: Status.Failed, error: err };
     });
   }
@@ -150,7 +150,7 @@
 </style>
 
 <svelte:head>
-  <title>{subdomain}</title>
+  <title>{domain}</title>
 </svelte:head>
 
 {#if state.status === Status.Loading}
@@ -163,21 +163,21 @@
   <Modal subtle>
     <span slot="title" class="secondary">
       <div>🍄</div>
-      {subdomain}
+      {domain}
     </span>
 
     <span slot="body">
-      <p>The name <strong>{subdomain}</strong> is not registered.</p>
+      <p>The name <strong>{domain}</strong> is not registered.</p>
     </span>
 
     <span slot="actions">
-      <Link to={`/registrations/${subdomain}/form`} primary>Register &rarr;</Link>
+      <Link to={`/registrations/${domain}/form`} primary>Register &rarr;</Link>
     </span>
   </Modal>
 {:else if state.status === Status.Found}
   <main>
     <header>
-      <h1 class="bold">{subdomain}</h1>
+      <h1 class="bold">{domain}</h1>
       <button
         style="min-width: 60px;"
         class="tiny primary" class:active={editable} disabled={!isOwner(state.owner)}
@@ -192,7 +192,7 @@
   </main>
 
   {#if updateRecords}
-    <Update {config} {subdomain} on:close={() => updateRecords = null}
+    <Update {config} {domain} on:close={() => updateRecords = null}
             registration={state.registration} records={updateRecords} />
   {/if}
 {/if}

--- a/src/base/registrations/resolver.ts
+++ b/src/base/registrations/resolver.ts
@@ -10,7 +10,7 @@ export async function setRecords(name: string, records: EnsRecord[], resolver: E
   assert(config.signer, "no signer available");
 
   const resolverContract = new ethers.Contract(resolver.address, config.abi.resolver, config.signer);
-  const node = ethers.utils.namehash(`${name}.${config.registrar.domain}`);
+  const node = ethers.utils.namehash(`${name}`);
 
   const calls = [];
   const iface = new ethers.utils.Interface(config.abi.resolver);

--- a/src/base/registrations/resolver.ts
+++ b/src/base/registrations/resolver.ts
@@ -10,7 +10,7 @@ export async function setRecords(name: string, records: EnsRecord[], resolver: E
   assert(config.signer, "no signer available");
 
   const resolverContract = new ethers.Contract(resolver.address, config.abi.resolver, config.signer);
-  const node = ethers.utils.namehash(`${name}`);
+  const node = ethers.utils.namehash(name);
 
   const calls = [];
   const iface = new ethers.utils.Interface(config.abi.resolver);

--- a/src/base/resolver/Query.svelte
+++ b/src/base/resolver/Query.svelte
@@ -23,19 +23,14 @@
         // Go to Radicle project.
         navigate(`/projects/${query}`, { replace: true });
       } else {
-        let label = utils.parseEnsLabel(query, config);
-        if (label.includes(".")) {
-          error = true;
+        // Jump straight to org, if the ENS entry points to an org. Otherwise it checks if the
+        // address type is an EOA and jumps to the user page else it just goes to the registration.
+        const address = await utils.resolveLabel(query, config);
+        const addressType = address && await utils.identifyAddress(address, config);
+        if (addressType === utils.AddressType.Org || addressType === utils.AddressType.EOA) {
+          navigate(`/${address}`, { replace: true });
         } else {
-          // Jump straight to org, if the ENS entry points to an org. Otherwise it checks if the
-          // address type is an EOA and jumps to the user page else it just goes to the registration.
-          const address = await utils.resolveLabel(label, config);
-          const addressType = address && await utils.identifyAddress(address, config);
-          if (addressType === utils.AddressType.Org || addressType === utils.AddressType.EOA) {
-            navigate(`/${address}`, { replace: true });
-          } else {
-            navigate(`/registrations/${label}`, { replace: true });
-          }
+          navigate(`/registrations/${query}`, { replace: true });
         }
       }
     } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -312,7 +312,7 @@ export async function identifyAddress(address: string, config: Config): Promise<
 
 // Resolve a label under the radicle domain.
 export async function resolveLabel(label: string | undefined, config: Config): Promise<string | null> {
-  if (label) return config.provider.resolveName(`${label}.${config.registrar.domain}`);
+  if (label) return config.provider.resolveName(`${label}`);
   return null;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -312,7 +312,7 @@ export async function identifyAddress(address: string, config: Config): Promise<
 
 // Resolve a label under the radicle domain.
 export async function resolveLabel(label: string | undefined, config: Config): Promise<string | null> {
-  if (label) return config.provider.resolveName(`${label}`);
+  if (label) return config.provider.resolveName(label);
   return null;
 }
 


### PR DESCRIPTION
This PR allows user to open non-radicle ENS domains in registration form and also edit them.
It also fixes an issue that wasn't allowing editing ENS information, due to passing `undefined` values for empty input fields, we now cast `undefined` to an empty string.

Closes #190, #167