### PR TITLE
Fix commit teaser overflow

### DIFF
--- a/src/base/projects/Commit/CommitTeaser.svelte
+++ b/src/base/projects/Commit/CommitTeaser.svelte
@@ -21,6 +21,7 @@
   }
   .author {
     margin-right: 0.5rem;
+    white-space: nowrap;
   }
   .commit {
     display: flex;
@@ -34,8 +35,15 @@
     align-items: center;
     gap: 0.5rem;
   }
+  .summary {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    padding-right: 1rem;
+  }
   .time {
     margin-right: 0.5rem;
+    white-space: nowrap;
   }
 
   @media (max-width: 960px) {
@@ -49,7 +57,7 @@
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
-      width: 100%;
+      padding-right: 1rem;
     }
   }
 </style>


### PR DESCRIPTION
This PR fixes commit teaser overflow by adding some `overflow: hidden` and some `text-overflow: ellipsis` in some needed places
Closes #188