### PR TITLE
Anchors refactor

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -388,6 +388,12 @@ span.small, .text-xsmall {
 .text-small {
 	font-size: 0.875rem;
 }
+.text-medium {
+	font-size: 1.25rem;
+}
+.text-big {
+	font-size: 1.5rem;
+}
 
 button.error:hover {
 	background-color: var(--color-negative);

--- a/scripts/test
+++ b/scripts/test
@@ -1,5 +1,3 @@
 #!/bin/sh
-# For now we only check the Svelte files.
 
-npm test
-npx nyc report
+npm test && npx nyc report

--- a/src/NotFound.svelte
+++ b/src/NotFound.svelte
@@ -10,7 +10,7 @@
 <Modal subtle>
   <span slot="title">🏜️</span>
   <span slot="body">
-    <p class="highlight"><strong>{title}</strong></p>
+    <p class="highlight text-medium"><strong>{title}</strong></p>
     <p>{subtitle}</p>
   </span>
   <span slot="actions">

--- a/src/Profile.svelte
+++ b/src/Profile.svelte
@@ -133,6 +133,7 @@
   }
   .members {
     margin-top: 2rem;
+    padding-bottom: 1rem;
     align-items: center;
     display: flex;
     flex-wrap: wrap;
@@ -141,7 +142,6 @@
     display: flex;
     align-items: center;
     margin-right: 2rem;
-    margin-bottom: 1rem;
   }
   .members .member:last-child {
     margin-right: 0;

--- a/src/SeedAddress.spec.ts
+++ b/src/SeedAddress.spec.ts
@@ -6,8 +6,10 @@ describe('SeedAddress', function () {
   it("Renders correctly", () => {
     mount(SeedAddress, {
       props: {
-        id: "hydkkkf5ksbe5fuszdhpqhytu3q36gwagj874wxwpo5a8ti8coygh1",
-        host: "seed.cloudhead.io",
+        seed: {
+          id: "hydkkkf5ksbe5fuszdhpqhytu3q36gwagj874wxwpo5a8ti8coygh1",
+          host: "seed.cloudhead.io",
+        },
         port: 8776
       }
     }, styles);

--- a/src/anchors.ts
+++ b/src/anchors.ts
@@ -16,13 +16,11 @@ interface AnchorObject {
   multihash: string;
 }
 
-export async function getAllAnchors(config: Config, urn: string, anchors?: string | null): Promise<string[]> {
-  if (! anchors) {
-    return [];
-  }
+export async function getProjectAnchors(urn: string, anchorsStorage: string, config: Config): Promise<string[]> {
   const unpadded = decodeRadicleId(urn);
   const id = ethers.utils.hexZeroPad(unpadded, 32);
-  const allAnchors = await querySubgraph(config.orgs.subgraph, GetAllAnchors, { project: id, org: anchors });
+  const allAnchors = await querySubgraph(config.orgs.subgraph, GetAllAnchors, { project: id, org: anchorsStorage });
+
   return allAnchors.anchors
     .map((anchor: AnchorObject) => formatProjectHash(ethers.utils.arrayify(anchor.multihash)));
 }

--- a/src/base/orgs/View/Projects.svelte
+++ b/src/base/orgs/View/Projects.svelte
@@ -55,29 +55,31 @@
 </style>
 
 <div class="projects">
-  {#await Seed.getProjects(config)}
-    <Loading center />
-  {:then projects}
-    {#each projects as project}
-      {@const anchor = anchors[project.urn]}
-      {@const pendingAnchor = pendingAnchors[project.urn]}
-      <div class="project">
-        <Widget {project} {anchor} on:click={() => onClick(project)}>
-          <span class="actions" slot="actions">
-            {#if profile.org?.safe && account && anchor}
-              {#if pendingAnchor} <!-- Pending anchor -->
-                <AnchorActions
-                  {account} {config} anchor={pendingAnchor} safe={profile.org.safe}
-                  on:success={() => loadAnchors()} />
+  {#if config.seed.api.host}
+    {#await Seed.getProjects(config)}
+      <Loading center />
+    {:then projects}
+      {#each projects as project}
+        {@const anchor = anchors[project.urn]}
+        {@const pendingAnchor = pendingAnchors[project.urn]}
+        <div class="project">
+          <Widget {project} {anchor} on:click={() => onClick(project)}>
+            <span class="actions" slot="actions">
+              {#if profile.org?.safe && account && anchor}
+                {#if pendingAnchor} <!-- Pending anchor -->
+                  <AnchorActions
+                    {account} {config} anchor={pendingAnchor} safe={profile.org.safe}
+                    on:success={() => loadAnchors()} />
+                {/if}
               {/if}
-            {/if}
-          </span>
-        </Widget>
-      </div>
-    {/each}
-  {:catch err}
-    <Message error>
-      <strong>Error: </strong> failed to load projects: {err.message}.
-    </Message>
-  {/await}
+            </span>
+          </Widget>
+        </div>
+      {/each}
+    {:catch err}
+      <Message error>
+        <strong>Error: </strong> failed to load projects: {err.message}.
+      </Message>
+    {/await}
+  {/if}
 </div>

--- a/src/base/orgs/View/Projects.svelte
+++ b/src/base/orgs/View/Projects.svelte
@@ -1,32 +1,44 @@
 <script lang="ts">
+  import { navigate } from "svelte-routing";
+  import { onMount } from "svelte";
   import type { Config } from "@app/config";
-  import { Org } from "@app/base/orgs/Org";
-  import type * as proj from "@app/project";
+  import * as proj from "@app/project";
   import Loading from "@app/Loading.svelte";
   import Message from "@app/Message.svelte";
   import Widget from '@app/base/projects/Widget.svelte';
-  import Anchor from './Anchor.svelte';
-  import { formatCommit } from "@app/utils";
   import type { Profile } from "@app/profile";
+  import type { ProjectInfo, Anchor, PendingAnchor } from "@app/project";
+  import { Seed } from "@app/base/seeds/Seed";
+  import AnchorActions from "@app/base/profiles/AnchorActions.svelte";
 
   export let profile: Profile;
   export let config: Config;
   export let account: string | null;
 
-  const updateRecords = () => {
-    getProjects = queryProjects;
+  let anchors: Record<string, Anchor> = {};
+  let pendingAnchors: Record<string, PendingAnchor> = {};
+
+  const loadAnchors = async () => {
+    const [pending, confirmed] = await Promise.all([
+      profile.pendingAnchors(config),
+      profile.confirmedAnchors(config),
+    ]);
+
+    anchors = confirmed;
+    pendingAnchors = pending;
   };
 
-  $: queryProjects = async (): Promise<(proj.Project | proj.PendingProject)[]> => {
-    if (profile.org) {
-      if (account) {
-        const result = await profile.org.isMember(account, config);
-        return result ? profile.org.getAllProjects(config) : profile.org.getProjects(config);
-      }
-    }
-    return [];
+  const onClick = (project: ProjectInfo) => {
+    navigate(
+      proj.path({
+        urn: project.urn,
+        addressOrName: profile.name ?? profile.address,
+        revision: project.head,
+      })
+    );
   };
-  $: getProjects = queryProjects;
+
+  onMount(loadAnchors);
 </script>
 
 <style>
@@ -36,72 +48,36 @@
   .projects .project {
     margin-bottom: 1rem;
   }
-  .anchor {
+  .actions {
     display: flex;
     align-items: center;
   }
 </style>
 
 <div class="projects">
-  {#if profile.org}
-    {#await getProjects()}
-      <Loading center />
-    {:then projects}
-      {#each projects as project}
-        <div class="project">
-          {#if "safeTxHash" in project} <!-- Pending project -->
-            <Widget {project} addressOrName={profile.name ?? profile.address} {config} faded>
-              <span slot="stateHash">
-                <span class="mobile">commit {formatCommit(project.anchor.stateHash)}</span>
-                <span class="desktop">commit {project.anchor.stateHash}</span>
-              </span>
-              <span class="anchor" slot="actions">
-                {#if profile.org.safe && account}
-                  <Anchor {project} safe={profile.org.safe} on:success={() => updateRecords()} {account} {config} />
-                {/if}
-              </span>
-            </Widget>
-          {:else} <!-- Anchored project -->
-            <Widget {project} addressOrName={profile.name ?? profile.address} {config}>
-              <span slot="stateHash">
-                <span class="mobile">commit {formatCommit(project.anchor.stateHash)}</span>
-                <span class="desktop">commit {project.anchor.stateHash}</span>
-              </span>
-            </Widget>
-          {/if}
-        </div>
-      {/each}
-    {:catch err}
-      <Message error>
-        <strong>Error: </strong> failed to load anchored projects: {err.message}.
-      </Message>
-    {/await}
-  {:else}
-    <div class="projects">
-      {#if profile.anchorsAccount}
-        {#await Org.get(profile.anchorsAccount, config)}
-          <Loading center fadeIn />
-        {:then org}
-          {#if org}
-            {#await org.getProjects(config) then projects}
-              {#each projects as project}
-                <div class="project">
-                  <Widget {project} addressOrName={profile.name ?? profile.address} {config}>
-                    <span slot="stateHash">
-                      <span class="mobile">commit {formatCommit(project.anchor.stateHash)}</span>
-                      <span class="desktop">commit {project.anchor.stateHash}</span>
-                    </span>
-                  </Widget>
-                </div>
-              {/each}
-            {:catch err}
-              <Message error>
-                <strong>Error: </strong> failed to load projects: {err.message}.
-              </Message>
-            {/await}
-          {/if}
-        {/await}
-      {/if}
-    </div>
-  {/if}
+  {#await Seed.getProjects(config)}
+    <Loading center />
+  {:then projects}
+    {#each projects as project}
+      {@const anchor = anchors[project.urn]}
+      {@const pendingAnchor = pendingAnchors[project.urn]}
+      <div class="project">
+        <Widget {project} {anchor} on:click={() => onClick(project)}>
+          <span class="actions" slot="actions">
+            {#if profile.org?.safe && account && anchor}
+              {#if pendingAnchor} <!-- Pending anchor -->
+                <AnchorActions
+                  {account} {config} anchor={pendingAnchor} safe={profile.org.safe}
+                  on:success={() => loadAnchors()} />
+              {/if}
+            {/if}
+          </span>
+        </Widget>
+      </div>
+    {/each}
+  {:catch err}
+    <Message error>
+      <strong>Error: </strong> failed to load projects: {err.message}.
+    </Message>
+  {/await}
 </div>

--- a/src/base/profiles/AnchorActions.svelte
+++ b/src/base/profiles/AnchorActions.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { ethers } from "ethers";
   import type { Safe } from "@app/utils";
-  import type { PendingProject } from "@app/project";
+  import type { PendingAnchor } from "@app/project";
   import type { Config } from "@app/config";
   import * as utils from "@app/utils";
   import Modal from "@app/Modal.svelte";
@@ -9,7 +9,7 @@
   import { createEventDispatcher } from 'svelte';
 
   export let safe: Safe;
-  export let project: PendingProject;
+  export let anchor: PendingAnchor;
   export let account: string;
   export let config: Config;
 
@@ -38,7 +38,7 @@
     state = State.Idle;
   };
 
-  const pending = safe.threshold - project.confirmations.length;
+  const pending = safe.threshold - anchor.confirmations.length;
   const executeTransaction = async (safeTxHash: string) => {
     try {
       action = Action.Execute;
@@ -73,7 +73,7 @@
     }
   };
 
-  $: isSigned = project.confirmations.includes(
+  $: isSigned = anchor.confirmations.includes(
     ethers.utils.getAddress(account)
   );
 </script>
@@ -108,7 +108,7 @@
 </span>
 
 <div class="avatars">
-  {#each project.confirmations as signee}
+  {#each anchor.confirmations as signee}
     <Avatar inline source={signee} address={signee} glowOnHover />
   {/each}
 </div>
@@ -158,8 +158,8 @@
     <span slot="body">
       {#if state == State.Confirm}
         <div class="table">
-          <div>Project</div><code>{project.id}</code>
-          <div>Hash</div><code>{project.anchor.stateHash}</code>
+          <div>Project</div><code>{anchor.id}</code>
+          <div>Hash</div><code>{anchor.anchor.stateHash}</code>
         </div>
       {:else if state == State.Failed}
         <div>{error}</div>
@@ -168,7 +168,7 @@
 
     <span slot="actions">
       {#if state == State.Confirm}
-        <button class="primary" on:click={() => confirmAnchor(project.safeTxHash)}>
+        <button class="primary" on:click={() => confirmAnchor(anchor.safeTxHash)}>
           Confirm
         </button>
         <button class="text" on:click={close}>
@@ -206,8 +206,8 @@
     <span slot="body">
       {#if state == State.Confirm}
         <div class="table">
-          <div>TxHash</div><code>{utils.formatHash(project.safeTxHash)}</code>
-          <div>Quorum</div><code>{project.confirmations.length} of {safe.threshold}</code>
+          <div>TxHash</div><code>{utils.formatHash(anchor.safeTxHash)}</code>
+          <div>Quorum</div><code>{anchor.confirmations.length} of {safe.threshold}</code>
         </div>
       {:else if state == State.Failed}
         <div>{error}</div>
@@ -216,7 +216,7 @@
 
     <span slot="actions">
       {#if state == State.Confirm}
-        <button class="primary" on:click={() => executeTransaction(project.safeTxHash)}>
+        <button class="primary" on:click={() => executeTransaction(anchor.safeTxHash)}>
           Confirm
         </button>
         <button class="text" on:click={close}>

--- a/src/base/profiles/AnchorBadge.svelte
+++ b/src/base/profiles/AnchorBadge.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+
+  const dispatch = createEventDispatcher();
+
+  export let anchors: Array<string> = [];
+  export let head: string;
+  export let commit: string;
+  export let noText = false;
+  export let noBg = false;
+
+  const text = !noText;
+</script>
+
+<style>
+  .anchor-widget {
+    display: flex;
+    padding: 0.5rem 0.75rem;
+    border-radius: inherit;
+    color: var(--color-tertiary);
+    background-color: var(--color-tertiary-background);
+    cursor: pointer;
+  }
+  .anchor-widget.not-allowed {
+    cursor: not-allowed;
+  }
+  .anchor-widget.not-anchored {
+    color: var(--color-foreground-faded);
+    background-color: var(--color-foreground-background);
+  }
+  .anchor-widget.no-bg {
+    background: none !important;
+    padding: 0 !important;
+  }
+  .anchor-label {
+    font-family: var(--font-family-monospace);
+    margin-right: 0.5rem;
+  }
+  .anchor-label:last-child {
+    margin-right: 0;
+  }
+  .anchor-latest {
+    cursor: default;
+  }
+</style>
+
+{#if anchors}
+  <!-- commit is head and latest anchor  -->
+  {#if commit == anchors[0] && commit === head}
+    <span class="anchor-widget anchor-latest" class:no-bg={noBg}>
+      <span class="anchor-label" title="{anchors[0]}">{#if text}latest&nbsp;{/if}🔐</span>
+    </span>
+  <!-- commit is not head but latest anchor  -->
+  {:else if commit == anchors[0] && commit !== head}
+    <span class="anchor-widget" class:no-bg={noBg} on:click={() => dispatch("click", head)}>
+      <span class="anchor-label" title="{anchors[0]}">{#if text}latest&nbsp;{/if}🔐</span>
+    </span>
+  <!-- commit is not head a stale anchor  -->
+  {:else if anchors.includes(commit)}
+    <span class="anchor-widget" class:no-bg={noBg} on:click={() => dispatch("click", anchors[0])}>
+      <span class="anchor-label" title="{commit}">{#if text}stale&nbsp;{/if}🔒</span>
+    </span>
+  <!-- commit is not anchored, could be head or any other commit  -->
+  {:else}
+    <span class="anchor-widget not-anchored" class:no-bg={noBg} on:click={() => dispatch("click", anchors[0])}>
+      <span class="anchor-label">{#if text}not anchored&nbsp;{/if}🔓</span>
+    </span>
+  {/if}
+{:else}
+  <!-- commit is not head and neither an anchor, and there are no anchors available  -->
+  <span class="anchor-widget not-anchored not-allowed" class:no-bg={noBg}>
+    <span class="anchor-label">{#if text}not anchored&nbsp;{/if}🔓</span>
+  </span>
+{/if}

--- a/src/base/projects/BranchSelector.spec.ts
+++ b/src/base/projects/BranchSelector.spec.ts
@@ -5,17 +5,15 @@ import { styles } from "@test/support/index";
 const defaultProps = {
   project: {
     head: "e678629cd37c770c640a2cd997fc76303c815772",
-    meta: {
-      name: "nakamoto",
-      description: "Privacy-preserving Bitcoin light-client implementation in Rust",
-      defaultBranch: "master",
-      maintainers: [
-        "rad:git:hnrkqdpm9ub19oc8dccx44echy76hzfsezyio"
-      ],
-      delegates: [
-        "hyn9diwfnytahjq8u3iw63h9jte1ydcatxax3saymwdxqu1zo645pe"
-      ]
-    }
+    name: "nakamoto",
+    description: "Privacy-preserving Bitcoin light-client implementation in Rust",
+    defaultBranch: "master",
+    maintainers: [
+      "rad:git:hnrkqdpm9ub19oc8dccx44echy76hzfsezyio"
+    ],
+    delegates: [
+      "hyn9diwfnytahjq8u3iw63h9jte1ydcatxax3saymwdxqu1zo645pe"
+    ]
   },
   branches: [
     ["master", "e678629cd37c770c640a2cd997fc76303c815772"]

--- a/src/base/projects/BranchSelector.svelte
+++ b/src/base/projects/BranchSelector.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
-  import { Info, getOid } from "@app/project";
+  import { ProjectInfo, getOid } from "@app/project";
   import { formatCommit, isOid } from "@app/utils";
   import Dropdown from "@app/Dropdown.svelte";
 
   export let branches: [string, string][];
-  export let project: Info;
+  export let project: ProjectInfo;
   export let revision: string;
   export let toggleDropdown: (input: string) => void;
   export let branchesDropdown = false;
@@ -29,7 +29,7 @@
   $: commit = getOid(project.head, revision, branches);
   $: isLabel = commit == project.head || !isOid(revision);
   $: if (commit == project.head) {
-    branchLabel = project.meta.defaultBranch;
+    branchLabel = project.defaultBranch;
   } else if (!isOid(revision)) {
     branchLabel = revision;
   }
@@ -102,7 +102,7 @@
   <!-- If there is no branch listing available, show default branch name if commit is head and else show entire commit -->
   {:else if commit === project.head}
     <div class="stat branch not-allowed">
-      {project.meta.defaultBranch}
+      {project.defaultBranch}
     </div>
     <div class="hash">
       {formatCommit(commit)}

--- a/src/base/projects/Header.svelte
+++ b/src/base/projects/Header.svelte
@@ -2,6 +2,7 @@
   import { navigate } from 'svelte-routing';
   import * as utils from '@app/utils';
   import { ProjectContent, getOid, Source } from '@app/project';
+  import AnchorBadge from '@app/base/profiles/AnchorBadge.svelte';
   import type { Tree } from "@app/project";
   import BranchSelector from './BranchSelector.svelte';
   import PeerSelector from './PeerSelector.svelte';
@@ -63,32 +64,6 @@
   .anchor {
     display: inline-flex;
   }
-  .anchor-widget {
-    display: flex;
-    padding: 0.5rem 0.75rem;
-    border-radius: inherit;
-    color: var(--color-tertiary);
-    background-color: var(--color-tertiary-background);
-    cursor: pointer;
-  }
-  .anchor-widget.not-allowed {
-    cursor: not-allowed;
-  }
-  .anchor-widget.not-anchored {
-    color: var(--color-foreground-faded);
-    background-color: var(--color-foreground-background);
-  }
-  .anchor-label {
-    font-family: var(--font-family-monospace);
-    margin-right: 0.5rem;
-  }
-  .anchor-label:last-child {
-    margin-right: 0;
-  }
-  .anchor-latest {
-    cursor: default;
-  }
-
   .seed {
     cursor: pointer;
     border-radius: inherit;
@@ -185,34 +160,8 @@
     bind:branchesDropdown={dropdownState.branch}
     on:revisionChanged={(event) => updateRevision(event.detail)} />
   <div class="anchor">
-    {#if anchors}
-      <!-- commit is head and latest anchor  -->
-      {#if commit == anchors[0] && commit === project.head}
-        <span class="anchor-widget anchor-latest">
-          <span class="anchor-label" title="{anchors[0]}">latest 🔐</span>
-        </span>
-      <!-- commit is not head but latest anchor  -->
-      {:else if commit == anchors[0] && commit !== project.head}
-        <span class="anchor-widget" on:click={() => updateRevision(project.head)}>
-          <span class="anchor-label" title="{anchors[0]}">latest 🔐</span>
-        </span>
-      <!-- commit is not head a stale anchor  -->
-      {:else if anchors.includes(commit)}
-        <span class="anchor-widget" on:click={() => updateRevision(anchors[0])}>
-          <span class="anchor-label" title="{commit}">stale 🔒</span>
-        </span>
-      <!-- commit is not anchored, could be head or any other commit  -->
-      {:else}
-        <span class="anchor-widget not-anchored" on:click={() => updateRevision(anchors[0])}>
-          <span class="anchor-label">not anchored 🔓</span>
-        </span>
-      {/if}
-    {:else}
-      <!-- commit is not head and neither an anchor, and there are no anchors available  -->
-      <span class="anchor-widget not-anchored not-allowed">
-        <span class="anchor-label">not anchored 🔓</span>
-      </span>
-    {/if}
+    <AnchorBadge {commit} {anchors}
+      head={project.head} on:click={(event) => updateRevision(event.detail)} />
   </div>
   {#if config.seed.git.host}
     <span>

--- a/src/base/projects/View.svelte
+++ b/src/base/projects/View.svelte
@@ -9,7 +9,6 @@
   import { formatOrg, formatSeedId, isRadicleId } from '@app/utils';
   import { getOid } from '@app/project';
   import { Seed } from '@app/base/seeds/Seed';
-  import { getAllAnchors } from '@app/anchors';
 
   import Header from '@app/base/projects/Header.svelte';
   import ProjectContentRoutes from '@app/base/projects/ProjectContentRoutes.svelte';
@@ -41,7 +40,8 @@
     const cfg = seedInstance && seedInstance.valid ? config.withSeed(seedInstance) : config;
     const info = await proj.getInfo(id, cfg);
     const urn = isRadicleId(id) ? id : info.urn;
-    const anchors = await getAllAnchors(config, urn, profile?.anchorsAccount ?? addressOrName);
+    const anchors = profile ? await profile.confirmedProjectAnchors(urn, config) : [];
+
     let branches = Array([info.defaultBranch, info.head]) as [string, string][];
     let peers: proj.Peer[] = [];
 

--- a/src/base/seeds/Seed.ts
+++ b/src/base/seeds/Seed.ts
@@ -1,7 +1,6 @@
 import * as api from '@app/api';
 import type { Config } from '@app/config';
 import * as proj from '@app/project';
-import type { Project } from "@app/project";
 import { isDomain } from '@app/utils';
 import { assert } from '@app/error';
 
@@ -46,11 +45,11 @@ export class Seed {
     return api.get("/peer", {}, config);
   }
 
-  static async getProject(urn: string, config: Config): Promise<proj.Info> {
+  static async getProject(urn: string, config: Config): Promise<proj.ProjectInfo> {
     return proj.getInfo(urn, config);
   }
 
-  static async getProjects(config: Config): Promise<Project[]> {
+  static async getProjects(config: Config): Promise<proj.ProjectInfo[]> {
     const result = await proj.getProjects(config);
     return result.map((project: any) => ({ ...project, id: project.urn }));
   }

--- a/src/base/seeds/View.svelte
+++ b/src/base/seeds/View.svelte
@@ -1,15 +1,24 @@
 <script lang="ts">
+  import { navigate } from "svelte-routing";
   import type { Config } from "@app/config";
   import { Seed } from "@app/base/seeds/Seed";
   import Widget from "@app/base/projects/Widget.svelte";
   import Loading from "@app/Loading.svelte";
   import SeedAddress from "@app/SeedAddress.svelte";
   import NotFound from "@app/NotFound.svelte";
+  import * as proj from "@app/project";
 
   export let config: Config;
   export let seedAddress: string;
 
   config = config.withSeed({ host: seedAddress });
+
+  const onProjectClick = (project: proj.ProjectInfo) => {
+    navigate(proj.path({
+      urn: project.urn,
+      seed: seedAddress,
+    }));
+  };
 </script>
 
 <style>
@@ -113,19 +122,15 @@
       <div class="desktop" />
     </div>
     <!-- Seed Projects -->
-    {#if info.version === "0.2.0"}
-      {#await Seed.getProjects(config) then projects}
-        <div class="projects">
-          {#each projects as project}
-            <div class="project">
-              <Widget {project} {config} seed={seedAddress} />
-            </div>
-          {/each}
-        </div>
-      {/await}
-    {:else}
-      <div class="projects subtle">For seed project listing, update http-api to v0.2.0</div>
-    {/if}
+    {#await Seed.getProjects(config) then projects}
+      <div class="projects">
+        {#each projects as project}
+          <div class="project">
+            <Widget {project} on:click={() => onProjectClick(project)} />
+          </div>
+        {/each}
+      </div>
+    {/await}
   </main>
 {:catch}
   <NotFound title={seedAddress} subtitle="Not able to query information from this seed." />

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -8,6 +8,7 @@ import type { Config } from "@app/config";
 import type { Seed, InvalidSeed } from "@app/base/seeds/Seed";
 import { Org } from "@app/base/orgs/Org";
 import { NotFoundError } from "@app/error";
+import { getProjectAnchors } from "@app/anchors";
 import type { Anchor, PendingAnchor } from "@app/project";
 
 export interface IProfile {
@@ -162,6 +163,15 @@ export class Profile {
     } else {
       return {};
     }
+  }
+
+  async confirmedProjectAnchors(urn: string, config: Config): Promise<string[]> {
+    const storage = this.anchorsAccount || this.org?.address;
+
+    if (storage) {
+      return await getProjectAnchors(urn, storage, config);
+    }
+    return [];
   }
 
   // Get the anchors account as an org, or the org, if available.


### PR DESCRIPTION
* Anchors are loaded alongside projects, but project listings always come from seeds now
* Removing project info loading from `Widget`
* Start unifying anchor handling
* Rename "Project*" to "Anchor*" when appropriate
* Move to new project api with embedded metadata