### PR TITLE
Add delegate info to peer selector

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -31,6 +31,7 @@
 	--color-light: #add0e4;
 	--color-yellow: #ffff99;
 	--color-yellow-background: #ffff9911;
+	--color-yellow-background-lighter: #ffff9922;
 	--color-positive: #53db53;
 	--color-positive-background: #53db5311;
 	--color-positive-1: #11332b;
@@ -51,6 +52,7 @@
 	--color-foreground-faded: #777788;
 	--color-foreground-subtle: #444455;
 	--color-foreground-subtler: #333344;
+	--color-foreground-even-subtler: #292936;
 	--color-foreground-background: #121a21;
 	--color-foreground-background-subtle: #10171e;
 	--color-foreground-background-lighter: #151f24;
@@ -336,6 +338,10 @@ label.input {
 	margin: 0 0.5rem;
 	font-size: 0.75rem;
 	line-height: 1.6;
+}
+.badge.primary {
+	color: var(--color-primary);
+	background: var(--color-primary-background);
 }
 .badge.tertiary {
 	color: var(--color-tertiary);

--- a/src/Dropdown.svelte
+++ b/src/Dropdown.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
 
-  export let items: string[];
+  export let items: { key: string; value: string; badge: string | null }[];
+  export let selected: string | null;
   export let visible = false;
 
   const dispatch = createEventDispatcher();
@@ -17,14 +18,17 @@
     margin-top: 0.5rem;
     border-radius: 0.25rem;
     position: absolute;
-    box-shadow: 8px 8px 24px var(--color-shadow);
+    box-shadow: 16px 16px 32px 32px var(--color-shadow);
   }
   .dropdown-item {
     cursor: pointer;
     padding: 0.5rem 1rem;
   }
-  .dropdown-item:hover {
+  .dropdown-item:hover, .selected {
     background-color: var(--color-foreground-background-lighter);
+  }
+  .dropdown .badge {
+    margin: 0;
   }
 
   @media (max-width: 720px) {
@@ -37,8 +41,12 @@
 
 {#if visible}
   <div class="dropdown">
-    {#each items as item}
-      <div class="dropdown-item" on:click={() => onSelect(item)}>{item}</div>
+    {#each items as {key, value, badge}}
+      <div class="dropdown-item" class:selected={value === selected} on:click={() => onSelect(value)} title={value}>{@html key}
+        {#if badge}
+          <span class="badge primary">{badge}</span>
+        {/if}
+      </div>
     {/each}
   </div>
 {/if}

--- a/src/base/projects/BranchSelector.svelte
+++ b/src/base/projects/BranchSelector.svelte
@@ -17,7 +17,7 @@
 
   let branchLabel: string | null = null;
 
-  $: branchList = Object.keys(branches).sort();
+  $: branchList = Object.keys(branches).sort().map(b => ({ key: b, value: b, badge: null }));
   $: showSelector = branchList.length > 1;
   $: head = branches[project.defaultBranch];
   $: commit = getOid(revision, branches) || head;
@@ -81,6 +81,7 @@
         </div>
         <Dropdown
           items={branchList}
+          selected={branchLabel}
           visible={branchesDropdown}
           on:select={(e) => switchBranch(e.detail)} />
       </span>

--- a/src/base/projects/Header.svelte
+++ b/src/base/projects/Header.svelte
@@ -73,16 +73,16 @@
   }
 
   .clone {
-    color: var(--color-primary);
-    background-color: var(--color-primary-background);
+    color: var(--color-yellow);
+    background-color: var(--color-yellow-background);
     font-family: var(--font-family-monospace);
     padding: 0.5rem 0.75rem;
     border-radius: 0.25rem;
     cursor: pointer;
     user-select: none;
   }
-  .clone:hoverr {
-    background-color: var(--color-primary-background-lighter);
+  .clone:hover {
+    background-color: var(--color-yellow-background-lighter);
   }
   .commit-count {
     cursor: pointer;
@@ -103,8 +103,8 @@
     display: block;
   }
   .clone-dropdown input {
-    color: var(--color-primary);
-    background: var(--color-primary-background);
+    color: var(--color-yellow);
+    background: var(--color-yellow-background);
   }
   .dropdown input {
     font-size: 0.75rem;

--- a/src/base/projects/PeerSelector.spec.ts
+++ b/src/base/projects/PeerSelector.spec.ts
@@ -1,0 +1,80 @@
+import PeerSelector from "./PeerSelector.svelte";
+import { mount } from "radicle-svelte-unit-test";
+import { styles } from "@test/support/index";
+
+const defaultProps = {
+  peer: "hyyg555wwkkutaysg6yr67qnu5d5ji54iur3n5uzzszndh8dp7ofue",
+  peers: [
+    {
+      "id": "hyyg555wwkkutaysg6yr67qnu5d5ji54iur3n5uzzszndh8dp7ofue",
+      "name": "sebastinez",
+      "delegate": true
+    }
+  ],
+  toggleDropdown: () => console.log("toggle"),
+};
+
+describe('PeerSelector', function () {
+  it("Render correctly with default props", () => {
+    mount(PeerSelector, {
+      props: defaultProps
+    }, styles);
+    cy.get("span.peer-id").should("has.text", "sebastinez");
+    cy.get("span.badge").should("has.text", "delegate");
+  });
+
+  it("Test Peer selection", () => {
+    mount(PeerSelector, {
+      props: {
+        ...defaultProps, peers: [
+          {
+            "id": "hyyg555wwkkutaysg6yr67qnu5d5ji54iur3n5uzzszndh8dp7ofue",
+            "name": "sebastinez",
+            "delegate": false
+          },
+          {
+            "id": "hydkkkf5ksbe5fuszdhpqhytu3q36gwagj874wxwpo5a8ti8coygh1",
+            "name": "cloudhead",
+            "delegate": true
+          },
+        ],
+        peersDropdown: true
+      }, callbacks: {
+        peerChanged: cy.stub().as("peerChanged")
+      }
+    }, styles);
+    cy.get("div.dropdown > div").last().click();
+    cy.get("@peerChanged")
+      .should("be.calledOnce")
+      .its("firstCall.args.0.detail")
+      .should("equal", "hydkkkf5ksbe5fuszdhpqhytu3q36gwagj874wxwpo5a8ti8coygh1");
+  });
+  it("If no peers are provided, no dropdown should be showed", () => {
+    mount(PeerSelector, {
+      props: {
+        ...defaultProps,
+        peers: [],
+        peersDropdown: true
+      }
+    }, styles);
+    cy.get("div.dropdown > div.dropdown-item").should("not.exist");
+  });
+  it("If peer identity is not being resolved, fallback to peer id", () => {
+    mount(PeerSelector, {
+      props: {
+        ...defaultProps,
+        peers: [
+          {
+            "id": "hyyg555wwkkutaysg6yr67qnu5d5ji54iur3n5uzzszndh8dp7ofue",
+          }
+        ],
+        peersDropdown: true
+      }
+    }, styles);
+    cy.get("span.peer-id").should("has.text", "hyyg55…p7ofue");
+    cy.get("span.badge").should("not.exist");
+    cy.get("div.dropdown > .dropdown-item")
+      .first()
+      .should("contain", "hyyg555wwkkutaysg6yr67qnu5d5ji54iur3n5uzzszndh8dp7ofue");
+  });
+});

--- a/src/project.ts
+++ b/src/project.ts
@@ -86,6 +86,12 @@ export interface Remote {
   heads: Branches;
 }
 
+export interface Peer {
+  id: PeerId;
+  name: string;
+  delegate: boolean;
+}
+
 export interface Browser {
   content: ProjectContent;
   revision: string | null;
@@ -203,12 +209,12 @@ export class Project implements ProjectInfo {
   maintainers: Urn[];
   delegates: PeerId[];
   seed: Seed;
-  peers: (string | { id: string })[];
+  peers: Peer[];
   branches: Branches;
   profile: Profile | null;
   anchors: string[];
 
-  constructor(urn: string, info: ProjectInfo, seed: Seed, peers: (string | { id: string })[], branches: Branches, profile: Profile | null, anchors: string[]) {
+  constructor(urn: string, info: ProjectInfo, seed: Seed, peers: Peer[], branches: Branches, profile: Profile | null, anchors: string[]) {
     this.urn = urn;
     this.head = info.head;
     this.name = info.name;
@@ -258,7 +264,7 @@ export class Project implements ProjectInfo {
     return api.get(`projects/${urn}/remotes/${peer}`, {}, host);
   }
 
-  static async getRemotes(urn: string, host: api.Host): Promise<(PeerId | { id: string })[]> {
+  static async getRemotes(urn: string, host: api.Host): Promise<Peer[]> {
     return api.get(`projects/${urn}/remotes`, {}, host);
   }
 
@@ -331,7 +337,7 @@ export class Project implements ProjectInfo {
     // Older versions of http-api don't include the URN.
     if (! info.urn) info.urn = urn;
 
-    const peers: (PeerId | { id: string })[] = info.delegates
+    const peers: Peer[] = info.delegates
       ? await Project.getRemotes(urn, seed.api)
       : [];
 


### PR DESCRIPTION
This PR closes #203

It adds the delegate metadata obtained from the seed nodes at the route `<host>/v1/projects/<urn>/remotes`
Which has the following format
```json
[
  {
    "id": "hyyg555wwkkutaysg6yr67qnu5d5ji54iur3n5uzzszndh8dp7ofue",
    "name": "sebastinez",
    "delegate": true
  }
]
```
And it shows it the following way.
<img width="587" alt="Bildschirmfoto 2022-02-22 um 18 01 53" src="https://user-images.githubusercontent.com/7912302/155218706-80390eda-1c32-4eed-89e6-d38b1ce4dea4.png">

If there is no metadata provided by the seed node it maintains the current format showing the peer ids without additional metadata
<img width="439" alt="Bildschirmfoto 2022-02-22 um 18 03 43" src="https://user-images.githubusercontent.com/7912302/155218977-4e24aba1-5b2c-46a8-9770-6637f35ac349.png">

Also the current selected peer is being highlighted, the same applies to the branch selector which uses the same `Dropdown` component underneath.
<img width="354" alt="Bildschirmfoto 2022-02-22 um 18 04 49" src="https://user-images.githubusercontent.com/7912302/155219169-7c506183-489e-4957-b783-60a411c384a4.png">