### PR TITLE
Add empty seeds.pinned property to Rinkeby config

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -71,6 +71,9 @@
     "users": {
       "pinned": []
     },
+    "seeds": {
+      "pinned": []
+    },
     "safe": {
       "api": "https://safe-transaction.rinkeby.gnosis.io",
       "viewer": "https://rinkeby.gnosis-safe.io/app/#/safes"


### PR DESCRIPTION
When browsing the interface on RInkeby the landing page was not loading, due to `config.seeds.pinned` being `undefined`.
I added an empty array similar to `users` and `orgs` to allow the landing page to be loaded.