### PR TITLE
Reduce flakiness of E2E test suite

### DIFF
--- a/cypress/fixtures/ceramicStream.json
+++ b/cypress/fixtures/ceramicStream.json
@@ -1,0 +1,37 @@
+{
+  "streamId": "k2t6wyse1ukyaidd42gy4h1guy10xcycfe424h13gjxkoupzhssv9j2svmb8rr",
+  "state": {
+    "type": 1,
+    "content": "did:3:kjzl6cwe1jw1481xu9oyww9bhmueqr8f5uryk4xha9jzhj6vi063e0blpnil383",
+    "metadata": {
+      "family": "caip10-eip155:1",
+      "controllers": [
+        "0x5e813e48a81977c6fdd565ed5097eb600c73c4f0@eip155:1"
+      ]
+    },
+    "signature": 2,
+    "anchorStatus": "ANCHORED",
+    "log": [
+      {
+        "cid": "bafyreiayiqzx3vth6pu5yniakbu7nm4otiab2j4izu2knyvp2hyzbhxte4",
+        "type": 0
+      },
+      {
+        "cid": "bafyreic6lcoeq5gr3i532focvbiwe7xtajm66nsnoj5i66rmvqexgrjb6y",
+        "type": 1
+      },
+      {
+        "cid": "bafyreihochpuwo4fg36neapdljruhuzsjkakyvrcmvtxfbzcz3vn2sduye",
+        "type": 2
+      }
+    ],
+    "anchorProof": {
+      "root": "bafyreigcirwd56d5reel2gn2ndqyshyvbtvtffgqyldefwk4gucnc52lau",
+      "txHash": "bagjqcgzacitwxfpo6uh5uyoa2cwt2lknpqovc75njw53hgkscxae6jlfytwa",
+      "chainId": "eip155:1",
+      "blockNumber": 13015348,
+      "blockTimestamp": 1628838351
+    },
+    "doctype": "caip10-link"
+  }
+}

--- a/cypress/integration/connect.spec.ts
+++ b/cypress/integration/connect.spec.ts
@@ -9,7 +9,7 @@ describe("MetaMask", () => {
       }
     });
     cy.intercept("POST", "https://api.thegraph.com/subgraphs/name/radicle-dev/radicle-orgs-rinkeby", { data: { safe: null } } );
-    cy.intercept("https://gateway.ceramic.network/api/v0/streams", new Blob([]));
+    cy.intercept("https://gateway.ceramic.network/api/v0/streams", { fixture: "ceramicStream.json" });
     cy.get("button.connect").click();
     cy.get("button.secondary").click();
     cy.get("button.address").should("contain", "3256 – 5721");

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@types/sanitize-html": "^2.6.2",
         "@typescript-eslint/eslint-plugin": "^5.25.0",
         "@typescript-eslint/parser": "^5.25.0",
-        "cypress": "^9.5.1",
+        "cypress": "^9.7.0",
         "eslint": "^7.28.0",
         "eslint-plugin-radicle": "^0.2.0",
         "eslint-plugin-svelte3": "^3.2.0",
@@ -5659,9 +5659,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.2.tgz",
-      "integrity": "sha512-gYiQYvJozMzDOriUV1rCt6CeRM/pRK4nhwGJj3nJQyX2BoUdTCVwp30xDMKc771HiNVhBtgj5o5/iBdVDVXQUg==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.7.0.tgz",
+      "integrity": "sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -5697,7 +5697,7 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
@@ -17006,9 +17006,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.2.tgz",
-      "integrity": "sha512-gYiQYvJozMzDOriUV1rCt6CeRM/pRK4nhwGJj3nJQyX2BoUdTCVwp30xDMKc771HiNVhBtgj5o5/iBdVDVXQUg==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.7.0.tgz",
+      "integrity": "sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -17043,7 +17043,7 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/sanitize-html": "^2.6.2",
     "@typescript-eslint/eslint-plugin": "^5.25.0",
     "@typescript-eslint/parser": "^5.25.0",
-    "cypress": "^9.5.1",
+    "cypress": "^9.7.0",
     "eslint": "^7.28.0",
     "eslint-plugin-radicle": "^0.2.0",
     "eslint-plugin-svelte3": "^3.2.0",


### PR DESCRIPTION
The request to the Ceramic API endpoint was returning a non zero exit code in some cases, due to a uncaught `SyntaxError`

This PR adds a better fixture to the route, to reduce the flakyness.