### PR TITLE
Close Floating Modal when clicking Clipboard and style improvements

### DIFF
--- a/src/Clipboard.svelte
+++ b/src/Clipboard.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
   import Icon from '@app/Icon.svelte';
   import { toClipboard } from '@app/utils';
+  import { createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher();
+
+  const copy = () => {
+    toClipboard(text);
+    dispatch("copied");
+  };
 
   export let text: string;
   export let small = false;
@@ -30,7 +38,7 @@
   }
 </style>
 
-<span class="clipboard" class:small on:click|stopPropagation={() => toClipboard(text)}>
+<span class="clipboard" class:small on:click|stopPropagation={copy}>
   {#if small}
     <Icon name="clipboard-small" width={12} height={12} />
   {:else}

--- a/src/Input.svelte
+++ b/src/Input.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Clipboard from '@app/Clipboard.svelte';
+  import { closeFocused } from '@app/Floating.svelte';
 
   export let name: string;
   export let value: string;
@@ -10,6 +11,7 @@
 <style>
   main {
     display: flex;
+    align-items: center;
   }
   .clipboard {
     visibility: hidden;
@@ -39,7 +41,7 @@
   <input class={$$props.class} readonly={clipboard} {name} {value} />
   {#if clipboard}
     <span class="clipboard {$$props.class}">
-      <Clipboard text={value} {small} />
+      <Clipboard text={value} {small} on:copied={closeFocused} />
     </span>
   {/if}
 </main>


### PR DESCRIPTION
### Changeset
- Adds `git clone ...` to the second input field in the Clone popover.
- Closes clone popover when Clipboard icon gets clicked.
-  Fix the copy icon gradient overlay (it overlaps its container)