### PR TITLE
Improve error message when missing web3 provider

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -222,7 +222,7 @@ function getProvider(
   } else if (metamask) {
     return metamask;
   } else {
-    throw new Error("No Web3 provider available.");
+    throw new Error("A wallet such as Metamask must be enabled on your browser.");
   }
 }
 


### PR DESCRIPTION
Changes the `No Web3 provider available` error message to `A wallet such as Metamask must be enabled on your browser.`