### PR TITLE
Add project detail loader and `View file` tooltip

### DIFF
--- a/src/base/projects/Commit/CommitTeaser.svelte
+++ b/src/base/projects/Commit/CommitTeaser.svelte
@@ -96,7 +96,7 @@
   <div class="column-right">
     <CommitVerifiedBadge {commit} />
     <span class="secondary hash">{formatCommit(commit.header.sha1)}</span>
-    <div class="browse" on:click|stopPropagation={() => browseCommit(commit.header.sha1)}>
+    <div class="browse" title="View file" on:click|stopPropagation={() => browseCommit(commit.header.sha1)}>
       <Icon name="browse" width={17} inline fill />
     </div>
   </div>

--- a/src/base/projects/Project.svelte
+++ b/src/base/projects/Project.svelte
@@ -2,6 +2,7 @@
   import type { Config } from '@app/config';
   import * as proj from '@app/project';
   import Placeholder from '@app/Placeholder.svelte';
+  import Loading from '@app/Loading.svelte';
   import { formatProfile, formatSeedId, setOpenGraphMetaTag } from '@app/utils';
   import { browserStore } from '@app/project';
   import { fetchCommits } from '@app/commit';
@@ -64,7 +65,9 @@
 <ProjectMeta noDescription={content !== proj.ProjectContent.Tree} {project} {peer} />
 
 {#if revision}
-  {#await project.getRoot(revision) then { tree, commit }}
+  {#await project.getRoot(revision)}
+    <Loading center />
+  {:then { tree, commit }}
     <Header {tree} {commit} {browserStore} {project} noAnchor />
 
     {#if content == proj.ProjectContent.Tree}

--- a/src/base/projects/SourceBrowser/FileDiff.svelte
+++ b/src/base/projects/SourceBrowser/FileDiff.svelte
@@ -146,7 +146,7 @@
       {/if}
     </div>
     <div class="browse clickable" on:click|stopPropagation={() => dispatch("browse", file.path)}>
-      <Icon name="browse" width={20} inline fill />
+      <Icon name="browse" title="View file" width={20} inline fill />
     </div>
   </header>
   {#if !collapsed}


### PR DESCRIPTION
This PR adds a `<Loading>` indicator to the project view to show the user that something is happening.
Adds `View file` next to the browse icon in the `CommitTeaser`, `Changeset` and `FileDiff` components

Closes #268 
Closes #267 