### PR TITLE
Improve Profile Edit and Transfer buttons

### DIFF
--- a/src/base/registrations/View.svelte
+++ b/src/base/registrations/View.svelte
@@ -184,11 +184,9 @@
       <button
         style="min-width: 60px;"
         class="small primary" class:active={editable} disabled={!isOwner(state.owner)}
+        title={!isOwner(state.owner) ? "Only owner can edit this profile" : ""}
         on:click={() => editable = !editable}>
           Edit
-      </button>
-      <button class="small secondary" disabled>
-        Transfer
       </button>
     </header>
     <Form {config} {editable} {fields} on:save={onSave} on:cancel={() => editable = false} />


### PR DESCRIPTION
This PR closes #262 

It removes the `Transfer` button, since the functionality hasn't been implemented.
Adds a `title` property to the `Edit` button to explain that one must be the owner of the profile to make edits.