### PR TITLE
Remove WalletConnect compatible link

### DIFF
--- a/src/components/Modal/ConnectWallet.svelte
+++ b/src/components/Modal/ConnectWallet.svelte
@@ -52,10 +52,8 @@
 
     <div slot="subtitle">
       <div class="text-small">
-        WalletConnect<br/>
-        <a href="https://walletconnect.com/registry?type=wallet" class="link">
-          View compatible wallets
-        </a>
+        Scan the QR code with <strong>WalletConnect</strong> or use
+        <strong>Metamask</strong>.
       </div>
     </div>
 


### PR DESCRIPTION
- Removes WalletConnect-compatible wallet link, which is not reliable.
- Adds a generic text to let people know, they should use a WalletConnect-compatible wallet.

Closes #299