### PR TITLE
Always use the same timezone when running unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "scripts/build",
     "check": "scripts/check",
     "coverage": "npx nyc report",
-    "test:unit": "vitest run",
+    "test:unit": "TZ='UTC' vitest run",
     "test:components": "cypress run --component",
     "test:e2e": "cypress run",
     "test:open": "cypress open"


### PR DESCRIPTION
When running unit tests locally, some of them fail with:

```
 ❯ src/utils.test.ts:5:14199
  - Expected   "Sat, 01 Jan 2022 12:00:00 GMT"
  + Received   "Sat, 01 Jan 2022 11:00:00 GMT"

 ❯ src/utils.test.ts:5:14199
  - Expected   "Sat, 05 Mar 2022 12:00:00 GMT"
  + Received   "Sat, 05 Mar 2022 11:00:00 GMT"
```

We set the timezone explicitly before running the tests, to prevent timezone sensitive tests from failing.