### PR TITLE
Don't use outdated node on CI

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -6,8 +6,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '14'
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -6,9 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '14'
       - run: npm ci
       - run: ./scripts/check-format
         shell: bash

--- a/.github/workflows/check-integration-test.yml
+++ b/.github/workflows/check-integration-test.yml
@@ -7,8 +7,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      # Install NPM dependencies, cache them correctly
-      # and run all Cypress tests
       - name: Cypress run
         uses: cypress-io/github-action@v4
         with:

--- a/.github/workflows/check-unit-test.yml
+++ b/.github/workflows/check-unit-test.yml
@@ -6,9 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '14'
       - run: npm ci
       - run: ./scripts/unit-test
         shell: bash

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,8 +6,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '14'
       - run: npm ci
       - run: npm run check


### PR DESCRIPTION
ubuntu-latest [already includes](https://github.com/actions/runner-images/blob/ubuntu20/20220807.1/images/linux/Ubuntu2004-Readme.md#language-and-runtime
) a recent node version (16.16.0).

And node 14 is at its EOL.
```
WARNING: node-v14.20.0 is in LTS Maintenance mode and nearing its end of life.
It only receives *critical* security updates, *critical* bug fixes and documentation updates.
```

This should also shave off some time from our builds.