### PR TITLE
Hide debug logs

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -19,7 +19,7 @@ export class MockExtensionProvider extends ethers.providers.BaseProvider {
   constructor(network: ethers.providers.Networkish, address: string) {
     super(network);
     this.currentAddress = address;
-    console.log("Creating Mock provider");
+    console.debug("Creating Mock provider");
   }
 
   get ready(): Promise<ethers.providers.Network> {
@@ -98,7 +98,7 @@ export class MockExtensionProvider extends ethers.providers.BaseProvider {
           byzantium: true
         };
       default:
-        console.log("Unknown method", method);
+        console.debug("Unknown method", method);
         break;
     }
   }

--- a/src/Comment.svelte
+++ b/src/Comment.svelte
@@ -32,12 +32,12 @@
 
   const selectReaction = (event: { detail: string }) => {
     // TODO: Once we allow adding reactions through the http-api, we should call it here.
-    console.log(event.detail);
+    console.debug(event.detail);
   };
 
   const incrementReaction = (event: { detail: string }) => {
     // TODO: Once we allow increment reactions through the http-api, we should call it here.
-    console.log(event.detail);
+    console.debug(event.detail);
   };
 </script>
 

--- a/src/base/registrations/registrar.ts
+++ b/src/base/registrations/registrar.ts
@@ -56,7 +56,7 @@ export const state = writable<Connection>({ connection: State.Connecting });
 window.registrarState = state;
 
 state.subscribe((s: Connection) => {
-  console.log("register.state", s);
+  console.debug("register.state", s);
 });
 
 export async function getRegistration(name: string, config: Config, resolver?: EnsResolver | null): Promise<Registration | null> {
@@ -317,7 +317,7 @@ async function register(name: string, owner: string, salt: Uint8Array, config: C
   );
   state.set({ connection: State.Registering });
 
-  console.log("Sent", tx);
+  console.debug("Sent", tx);
 
   await tx.wait();
   window.localStorage.removeItem("commitment");

--- a/src/base/vesting/state.ts
+++ b/src/base/vesting/state.ts
@@ -14,5 +14,5 @@ export enum State {
 export const state = writable(State.Idle);
 
 state.subscribe(s => {
-  console.log("vesting.state", s);
+  console.debug("vesting.state", s);
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -242,8 +242,8 @@ export async function getConfig(): Promise<Config> {
     : null;
   const metamaskSigner = metamask?.getSigner() || null;
 
-  console.log("metamask", metamask);
-  console.log("metamaskSigner", metamaskSigner);
+  console.debug("metamask", metamask);
+  console.debug("metamaskSigner", metamaskSigner);
 
   let network = { name: "homestead", chainId: 1 };
   if (metamask) {
@@ -263,7 +263,7 @@ export async function getConfig(): Promise<Config> {
     provider,
     metamaskSigner,
   );
-  console.log("config", cfg);
+  console.debug("config", cfg);
 
   return cfg;
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -116,7 +116,7 @@ export const loadState = (initial: State): Store => {
 
       try {
         await config.walletConnect.client.connect();
-        console.log("WalletConnect: connected.");
+        console.debug("WalletConnect: connected.");
 
         const address = await signer.getAddress();
         const tokenBalance: BigNumber = await config.token.balanceOf(address);
@@ -156,7 +156,7 @@ export const loadState = (initial: State): Store => {
 
         store.set({ connection: Connection.Connected, session });
       } catch (e: any) {
-        console.log("WalletConnect: connection failed.");
+        console.debug("WalletConnect: connection failed.");
         store.set({ connection: Connection.Disconnected });
 
         // There seems to be no way to detect this "error" caused by the user
@@ -351,7 +351,7 @@ export async function connectSeed(seedSession: { id: string; session: SeedSessio
 }
 
 state.subscribe(s => {
-  console.log("session.state", s);
+  console.debug("session.state", s);
 });
 
 export async function approveSpender(spender: string, amount: BigNumber, config: Config): Promise<void> {


### PR DESCRIPTION
I think debug logs should be logged with the appropriate log level, so they don't mix in with other stuff that's going on in the console.

They're still accessible via:
<img width="235" alt="Screenshot 2022-08-15 at 17 41 55" src="https://user-images.githubusercontent.com/158411/184667855-f4f3f13c-1566-4e49-bd48-290b1651dbc7.png">

