### PR TITLE
Get rid of crossorigin warnings in console

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
     <link rel="stylesheet" type="text/css" href="/index.css" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico">
-    <link rel="preload" href="/fonts/Inter-Regular.woff" as="font" type="font/woff">
-    <link rel="preload" href="/fonts/Inter-SemiBold.otf" as="font" type="font/otf">
+    <link rel="preload" href="/fonts/Inter-Regular.woff" as="font" type="font/woff" crossorigin="anonymous">
+    <link rel="preload" href="/fonts/Inter-SemiBold.otf" as="font" type="font/otf" crossorigin="anonymous">
     <script type="text/javascript">
       // Workaround to get `global` to work in old-school transitive
       // dependencies.


### PR DESCRIPTION
This gets rid of these:

⚠️ A preload for 'https://app.radicle.network/fonts/Inter-Regular.woff' is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.