### PR TITLE
Add missing `max` attribute to cache call

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -555,7 +555,7 @@ export const getRpcMethod = cache.cached(
     return await config.provider.send(method, props);
   },
   (method, props) => JSON.stringify([method, props]),
-  { ttl: 2 * 60 * 1000 }
+  { ttl: 2 * 60 * 1000, max: 1000 }
 );
 
 // Check whether the given path has a markdown file extension.


### PR DESCRIPTION
This gets rid of the warning we are seeing in the console.

```
TTL caching without ttlAutopurge, max, or maxSize can result in unbounded memory consumption. UnboundedCacheWarning LRU_CACHE_UNBOUNDED
```