### PR TITLE
Enable loading more items in commit history and project listing

### DIFF
--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import { Link } from "svelte-routing";
   import Avatar from "@app/Avatar.svelte";
   import type { Profile } from "@app/profile";
   import type { Config } from "@app/config";
   import { formatName, formatAddress } from "@app/utils";
   import type { Seed } from "@app/base/seeds/Seed";
-  import Loading from "@app/Loading.svelte";
 
   export let profile:
     | Profile
@@ -20,15 +18,6 @@
   export let config: Config;
   export let path: string;
   export let members: string[] = [];
-
-  let numberOfProjects: number | null = null;
-
-  onMount(async () => {
-    if (seed) {
-      const projects = await seed.getProjects();
-      numberOfProjects = projects.length;
-    }
-  });
 </script>
 
 <style>
@@ -118,14 +107,6 @@
         {:else}
           {formatAddress(profile.address)}
         {/if}
-      {:else if numberOfProjects !== null}
-        {#if numberOfProjects > 0}
-          {numberOfProjects} project(s)
-        {:else}
-          No projects
-        {/if}
-      {:else if numberOfProjects === null}
-        <Loading center fadeIn small />
       {/if}
     </div>
   </div>

--- a/src/List.svelte
+++ b/src/List.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import Button from "@app/Button.svelte";
+  import Loading from "@app/Loading.svelte";
+  import { fade } from "svelte/transition";
+
+  type Item = $$Generic;
+
+  export let items: Item[];
+  export let query: () => Promise<Item[]>;
+
+  // Used to handle the display of the trigger to load more items, according to the current loading state.
+  let loading = false;
+  // Should be changed to true, once no more items are being returned.
+  let complete = false;
+
+  const transitionParams = { duration: 200 };
+
+  const fetchMore = async () => {
+    loading = true;
+    const response = await query();
+
+    if (response.length > 0) {
+      items = [...items, ...response];
+    } else {
+      complete = true;
+    }
+
+    loading = false;
+  };
+</script>
+
+<style>
+  .more {
+    margin-top: 1rem;
+    height: 40px;
+    text-align: center;
+  }
+</style>
+
+<slot name="list" {items} />
+{#if !complete}
+  <slot name="more" {fetchMore} {loading}>
+    {#if loading}
+      <div class="more" transition:fade={transitionParams}>
+        <Loading small />
+      </div>
+    {:else}
+      <div class="more" transition:fade={transitionParams}>
+        <Button
+          variant="secondary"
+          waiting={loading}
+          disabled={loading}
+          on:click={fetchMore}>
+          More
+        </Button>
+      </div>
+    {/if}
+  </slot>
+{/if}

--- a/src/Profile.svelte
+++ b/src/Profile.svelte
@@ -20,6 +20,7 @@
   import { MissingReverseRecord, NotFoundError } from "@app/error";
   import NotFound from "@app/NotFound.svelte";
   import RadicleUrn from "@app/RadicleUrn.svelte";
+  import Async from "@app/Async.svelte";
   import Badge from "@app/Badge.svelte";
   import Button from "@app/Button.svelte";
 
@@ -446,7 +447,14 @@
       {/await}
     {/if}
     {#if profile.seed?.valid}
-      <Projects {profile} seed={profile.seed} {account} {config} />
+      <Async fetch={profile.seed.getProjects(10, profile.id)} let:result>
+        <Projects
+          {profile}
+          seed={profile.seed}
+          {account}
+          projects={result}
+          {config} />
+      </Async>
     {/if}
   </main>
 

--- a/src/base/projects/Project.svelte
+++ b/src/base/projects/Project.svelte
@@ -7,7 +7,6 @@
   import Loading from "@app/Loading.svelte";
   import { formatProfile, formatSeedId, setOpenGraphMetaTag } from "@app/utils";
   import { browserStore } from "@app/project";
-  import { fetchCommits } from "@app/commit";
   import * as patch from "@app/patch";
   import * as issue from "@app/issue";
 
@@ -80,7 +79,12 @@
     {#if content === proj.ProjectContent.Tree}
       <Browser {project} {commit} {tree} {browserStore} />
     {:else if content === proj.ProjectContent.History}
-      <Async fetch={fetchCommits(project, commit)} let:result>
+      <Async
+        fetch={proj.Project.getCommits(project.urn, project.seed.api, {
+          parent: commit,
+          verified: true,
+        })}
+        let:result>
         <History {project} history={result} />
       </Async>
     {:else if content === proj.ProjectContent.Commit}

--- a/src/base/seeds/Seed.ts
+++ b/src/base/seeds/Seed.ts
@@ -105,10 +105,10 @@ export class Seed {
     return proj.Project.getInfo(urn, this.api);
   }
 
-  async getProjects(id?: string): Promise<proj.ProjectInfo[]> {
+  async getProjects(perPage: number, id?: string): Promise<proj.ProjectInfo[]> {
     const result = id
-      ? await proj.Project.getDelegateProjects(id, this.api)
-      : await proj.Project.getProjects(this.api);
+      ? await proj.Project.getDelegateProjects(id, this.api, { perPage })
+      : await proj.Project.getProjects(this.api, { perPage });
 
     return result.map((project: proj.ProjectInfo) => ({
       ...project,

--- a/src/base/seeds/View.svelte
+++ b/src/base/seeds/View.svelte
@@ -11,12 +11,16 @@
   import Address from "@app/Address.svelte";
   import SiweConnect from "@app/SiweConnect.svelte";
   import type { SeedSession } from "@app/siwe";
+  import Async from "@app/Async.svelte";
+  import { Project } from "@app/project";
+  import type { Host } from "@app/api";
 
   export let config: Config;
   export let session: Session | null;
   export let host: string;
 
   const hostName = formatSeedHost(host);
+  const seedHost: Host = { host, port: null };
   let siweSession: SeedSession | null = null;
 
   $: if (session?.siwe) {
@@ -153,7 +157,9 @@
       <div class="desktop" />
     </div>
     <!-- Seed Projects -->
-    <Projects {seed} {config} />
+    <Async fetch={Project.getProjects(seedHost, { perPage: 10 })} let:result>
+      <Projects {seed} {config} projects={result} />
+    </Async>
   </main>
 {:catch}
   <NotFound

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -1,4 +1,4 @@
-import { Stats, Person, Project } from "@app/project";
+import type { Stats, Person } from "@app/project";
 import type { Diff } from "@app/diff";
 import { ApiError } from "@app/api";
 import { getDaysPassed } from "@app/utils";
@@ -11,10 +11,6 @@ export interface CommitsHistory {
 export interface CommitMetadata {
   header: CommitHeader;
   context: CommitContext;
-}
-export interface GroupedCommitsHistory {
-  headers: CommitGroup[];
-  stats: Stats;
 }
 
 export interface Author {
@@ -89,12 +85,6 @@ export function formatGroupTime(timestamp: number): string {
   });
 }
 
-export const groupCommitHistory = (
-  history: CommitsHistory,
-): GroupedCommitsHistory => {
-  return { ...history, headers: groupCommits(history.headers) };
-};
-
 export function groupCommits(
   commits: { header: CommitHeader; context: CommitContext }[],
 ): CommitGroup[] {
@@ -139,17 +129,6 @@ export function groupCommits(
       "Not able to create commit history, please consider updating seed HTTP API.",
     );
   }
-}
-
-export async function fetchCommits(
-  project: Project,
-  parentCommit: string,
-): Promise<GroupedCommitsHistory> {
-  const commitsQuery = await Project.getCommits(project.urn, project.seed.api, {
-    parent: parentCommit,
-    verified: true,
-  });
-  return groupCommitHistory(commitsQuery);
 }
 
 export function groupCommitsByWeek(commits: number[]): WeeklyActivity[] {

--- a/src/project.ts
+++ b/src/project.ts
@@ -330,15 +330,33 @@ export class Project implements ProjectInfo {
     };
   }
 
-  static async getProjects(host: Host): Promise<ProjectInfo[]> {
-    return new Request("projects", host).get();
+  static async getProjects(
+    host: Host,
+    opts?: {
+      perPage?: number;
+      page?: number;
+    },
+  ): Promise<ProjectInfo[]> {
+    const params: Record<string, any> = {
+      "per-page": opts?.perPage,
+      page: opts?.page,
+    };
+    return new Request("projects", host).get(params);
   }
 
   static async getDelegateProjects(
     delegate: string,
     host: Host,
+    opts?: {
+      perPage?: number;
+      page?: number;
+    },
   ): Promise<ProjectInfo[]> {
-    return new Request(`delegates/${delegate}/projects`, host).get();
+    const params: Record<string, any> = {
+      "per-page": opts?.perPage,
+      page: opts?.page,
+    };
+    return new Request(`delegates/${delegate}/projects`, host).get(params);
   }
 
   static async getRemote(


### PR DESCRIPTION
Adds a `More` button on the end of the commits history, and when clicked loads more commits

<img width="1184" alt="Bildschirmfoto 2022-08-25 um 15 37 18" src="https://user-images.githubusercontent.com/7912302/186679541-70377539-028a-401c-ab92-a8702dd206cf.png">

This PR depends on the merge and implementation of https://github.com/radicle-dev/radicle-client-services/pull/181
Since this would allow us to check if there are more commits to be loaded or if we are already at the end