### PR TITLE
Fix badge alignment in dropdown

### DIFF
--- a/src/Dropdown.svelte
+++ b/src/Dropdown.svelte
@@ -16,11 +16,13 @@
     white-space: nowrap;
     cursor: pointer;
     padding: 0.5rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
   }
   .dropdown-item:hover, .selected {
     background-color: var(--color-foreground-background-lighter);
   }
-
   @media (max-width: 720px) {
     .dropdown {
       left: 32px;


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/radicle-dev/radicle-interface/pull/345.

<img width="583" alt="Screenshot 2022-08-30 at 15 12 08" src="https://user-images.githubusercontent.com/158411/187445753-08d06729-c1d2-405b-92d7-1f0eba72342f.png">

vs 

<img width="663" alt="Screenshot 2022-08-30 at 15 12 11" src="https://user-images.githubusercontent.com/158411/187445757-760f2d57-de74-4e2e-a27b-a283ca3ab052.png">
