### PR TITLE
Show loading indicators after a delay

### DIFF
--- a/src/Loading.svelte
+++ b/src/Loading.svelte
@@ -1,10 +1,22 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
+
   export let small = false;
   export let color = "secondary";
   export let center = false;
   export let fadeIn = false;
   export let margins = false;
   export let condensed = false;
+
+  let show: boolean = false;
+
+  const timeout = window.setTimeout(() => {
+    show = true;
+  }, 200);
+
+  onDestroy(() => {
+    window.clearTimeout(timeout);
+  });
 </script>
 
 <style>
@@ -136,18 +148,20 @@
   }
 </style>
 
-<div class="container">
-  <div
-    class="spinner"
-    class:fade-in={fadeIn}
-    class:small
-    class:center
-    class:margins
-    class:condensed>
-    <div class="bounce1" style="background-color: var(--color-{color})" />
-    {#if !condensed}
-      <div class="bounce2" style="background-color: var(--color-{color})" />
-      <div class="bounce3" style="background-color: var(--color-{color})" />
-    {/if}
+{#if show}
+  <div class="container">
+    <div
+      class="spinner"
+      class:fade-in={fadeIn}
+      class:small
+      class:center
+      class:margins
+      class:condensed>
+      <div class="bounce1" style="background-color: var(--color-{color})" />
+      {#if !condensed}
+        <div class="bounce2" style="background-color: var(--color-{color})" />
+        <div class="bounce3" style="background-color: var(--color-{color})" />
+      {/if}
+    </div>
   </div>
-</div>
+{/if}


### PR DESCRIPTION
This prevents from loading indicators flickering for a split second during a page draw. For requests that take longer than 200ms we show the loading animation.

Before:

https://user-images.githubusercontent.com/158411/188100584-482797a9-ceb2-4a5e-95aa-05a4ac057959.mov


After:


https://user-images.githubusercontent.com/158411/188100630-7d2a2e40-0799-482d-81b1-c976951778e5.mov

