### PR TITLE
Fix emoji parser

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -810,7 +810,7 @@ const markdownEmojiTokenizer: marked.TokenizerExtension = {
     return src.indexOf(":");
   },
   tokenizer(src: string) {
-    const rule = /^:[\w+-]+:/;
+    const rule = /^:([\w+-]+):/;
     const match = rule.exec(src);
     if (match) {
       return {


### PR DESCRIPTION
Fixes a regex error, since I only used a character set and not a group the return value of `.exec(src)` is not the one we needed..