### PR TITLE
Remove global table styling

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -272,16 +272,3 @@ button.error:hover {
   color: var(--color-background);
   background-color: var(--color-negative);
 }
-
-table {
-  table-layout: fixed;
-  border-collapse: separate;
-  border-spacing: 2rem 0;
-}
-td {
-  text-align: left;
-  text-overflow: ellipsis;
-}
-td strong {
-  font-weight: var(--font-weight-medium);
-}

--- a/src/Markdown.svelte
+++ b/src/Markdown.svelte
@@ -91,11 +91,6 @@
     color: var(--color-foreground);
   }
 
-  .markdown :global(*:first-child) {
-    padding-top: 0;
-    margin-top: 0;
-  }
-
   .markdown :global(h1) {
     font-size: calc(var(--font-size-huge) * 0.75);
     font-weight: var(--font-weight-medium);
@@ -224,6 +219,27 @@
     list-style-type: inherit;
     padding-left: 1.25rem;
     margin-bottom: 1rem;
+  }
+  .markdown :global(table) {
+    margin: 1.5rem 0;
+    border-collapse: collapse;
+    border-radius: 0.5rem;
+    border-style: hidden;
+    box-shadow: 0 0 0 1px var(--color-foreground-subtle);
+    overflow: hidden;
+  }
+  .markdown :global(td) {
+    text-align: left;
+    text-overflow: ellipsis;
+    border: 1px solid var(--color-foreground-subtle);
+    padding: 0.5rem 1rem;
+  }
+  .markdown :global(tr:nth-child(even)) {
+    background-color: var(--color-foreground-even-subtler);
+  }
+  .markdown :global(th) {
+    text-align: center;
+    padding: 0.5rem 1rem;
   }
 </style>
 

--- a/src/base/vesting/Index.svelte
+++ b/src/base/vesting/Index.svelte
@@ -53,6 +53,15 @@
     margin-left: 1.5rem;
     color: var(--color-secondary);
   }
+  table {
+    table-layout: fixed;
+    border-collapse: separate;
+    border-spacing: 2rem 0;
+  }
+  td {
+    text-align: left;
+    text-overflow: ellipsis;
+  }
 </style>
 
 <svelte:head>


### PR DESCRIPTION
- inline the styles where appropriate
- style markdown tables properly
- this also fixes a heading spacing issue

Refs: https://github.com/radicle-dev/radicle-interface/issues/373.

<img width="1728" alt="Screenshot 2022-09-12 at 12 37 25" src="https://user-images.githubusercontent.com/158411/189634678-2d9a92bd-d042-432f-99ef-56d011b9b372.png">
<img width="1728" alt="Screenshot 2022-09-12 at 12 38 38" src="https://user-images.githubusercontent.com/158411/189634698-b1238971-9eaf-424e-862a-9534355e14c7.png">
<img width="1728" alt="Screenshot 2022-09-12 at 12 40 10" src="https://user-images.githubusercontent.com/158411/189634703-bc94c207-7ff1-4b15-9ff2-f8ae37c0630c.png">
<img width="1728" alt="Screenshot 2022-09-12 at 12 43 10" src="https://user-images.githubusercontent.com/158411/189634710-1602101d-cb7b-42e6-af88-1048ad65cf52.png">