### PR TITLE
Undo markdown hard-wrapping

### DIFF
--- a/src/Markdown.svelte
+++ b/src/Markdown.svelte
@@ -20,7 +20,7 @@
   let container: HTMLElement;
 
   const render = (content: string): string => {
-    return xss(marked.parse(content, { breaks: true }), {
+    return xss(marked.parse(content), {
       whiteList: {
         ...getDefaultWhiteList(),
         img: ["src"],


### PR DESCRIPTION
It breaks long hard-wrapped paragraphs in our RIPs.

<img width="1840" alt="Screenshot 2022-09-13 at 13 06 39" src="https://user-images.githubusercontent.com/158411/189885886-932164ec-f7e9-4d72-9e5c-4071ac4b4cb4.png">

vs 

<img width="1840" alt="Screenshot 2022-09-13 at 13 06 56" src="https://user-images.githubusercontent.com/158411/189885905-60b1fb49-e5c6-4884-b8a6-0670f80fae08.png">

This will break the default GitHub cheat-sheet TOC though:

<img width="1060" alt="Screenshot 2022-09-13 at 13 07 51" src="https://user-images.githubusercontent.com/158411/189886034-193f4bdf-de26-4414-afc7-963442583abb.png">
