### PR TITLE
Make sure commonly used markdown renders nicely

### DIFF
--- a/src/Markdown.svelte
+++ b/src/Markdown.svelte
@@ -121,7 +121,8 @@
     margin: 1rem 0 0.125rem;
   }
 
-  .markdown :global(h5) {
+  .markdown :global(h5),
+  .markdown :global(h6) {
     font-weight: var(--font-weight-medium);
     font-size: var(--font-size-small);
     padding: 0.35rem 0;
@@ -129,10 +130,7 @@
   }
 
   .markdown :global(h6) {
-    font-weight: var(--font-weight-medium);
-    font-size: var(--font-size-tiny);
-    padding: 0.25rem 0;
-    margin: 1rem 0 0.125rem;
+    color: var(--color-foreground-6);
   }
 
   .markdown :global(p) {

--- a/src/Markdown.svelte
+++ b/src/Markdown.svelte
@@ -162,6 +162,9 @@
     font-family: var(--font-family-monospace);
     font-size: var(--font-size-regular);
     color: var(--color-secondary-6);
+    background-color: var(--color-foreground-2);
+    border-radius: 0.5rem;
+    padding: 0.125rem 0.25rem;
   }
 
   .markdown :global(pre code) {

--- a/src/Markdown.svelte
+++ b/src/Markdown.svelte
@@ -23,7 +23,7 @@
     return xss(marked.parse(content), {
       whiteList: {
         ...getDefaultWhiteList(),
-        img: ["src"],
+        img: ["src", "alt", "title"],
         audio: ["src"],
         video: ["src"],
         a: ["href", "name"],

--- a/src/Markdown.svelte
+++ b/src/Markdown.svelte
@@ -144,9 +144,9 @@
   }
 
   .markdown :global(blockquote) {
-    font-style: italic;
-    padding: 0.625rem 0;
-    margin: 0;
+    border-left: 0.3rem solid var(--color-foreground-4);
+    padding: 0 0 0 1rem;
+    margin: 0 0 0.625rem 0;
   }
 
   .markdown :global(strong) {

--- a/src/Markdown.svelte
+++ b/src/Markdown.svelte
@@ -203,7 +203,7 @@
 
   .markdown :global(hr) {
     height: 0;
-    margin: 0rem 0;
+    margin: 1rem 0;
     overflow: hidden;
     background: transparent;
     border: 0;

--- a/src/Markdown.svelte
+++ b/src/Markdown.svelte
@@ -247,6 +247,13 @@
     padding-top: 0 !important;
     margin-top: 0 !important;
   }
+  .markdown :global(dl dt) {
+    font-style: italic;
+    margin-top: 1rem;
+  }
+  .markdown :global(dl dd) {
+    margin: 0 0 0 2rem;
+  }
 </style>
 
 {#if content}


### PR DESCRIPTION
Refs https://github.com/radicle-dev/radicle-interface/issues/373.

Fixes:
  - image titles
  
<img width="348" alt="Screenshot 2022-09-20 at 16 23 56" src="https://user-images.githubusercontent.com/158411/191284066-22b5938b-57cb-4623-8bc1-f941be6b7401.png">
<img width="320" alt="Screenshot 2022-09-20 at 16 23 58" src="https://user-images.githubusercontent.com/158411/191284071-982167d1-b2b3-4573-ad83-0b252445ec22.png">

 - inline code block background
<img width="395" alt="Screenshot 2022-09-20 at 16 27 20" src="https://user-images.githubusercontent.com/158411/191285030-d48c8934-20cc-40c2-83d5-fcbc68187974.png">

- H6 size and color
<img width="119" alt="Screenshot 2022-09-20 at 16 26 22" src="https://user-images.githubusercontent.com/158411/191285065-d17f5aa4-802a-4f5d-89c9-d39c48d9a3ef.png">

- format blockquotes
<img width="1007" alt="Screenshot 2022-09-20 at 17 08 20" src="https://user-images.githubusercontent.com/158411/191296285-a1d5b407-054e-41ad-ba58-a4dd5fa8c90b.png">
<img width="1000" alt="Screenshot 2022-09-20 at 17 08 27" src="https://user-images.githubusercontent.com/158411/191296296-72659e7f-7bff-48f0-8f11-abac7726101b.png">

- `<hr />` tag spacing
<img width="1135" alt="Screenshot 2022-09-20 at 17 17 36" src="https://user-images.githubusercontent.com/158411/191297685-a07f82bb-0788-4d48-bd02-157baa2697af.png">

- style definition lists

<img width="898" alt="Screenshot 2022-09-20 at 17 21 53" src="https://user-images.githubusercontent.com/158411/191298772-23857e63-b805-42c2-8526-f484c7308ef9.png">
