### PR TITLE
Use Metamask as provider before trying to use Alchemy

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -225,13 +225,13 @@ function getProvider(
   config: Record<string, any>,
   metamask: ethers.providers.JsonRpcProvider | null,
 ): ethers.providers.JsonRpcProvider {
-  if (import.meta.env.PROD) {
+  if (metamask) {
+    return metamask;
+  } else if (import.meta.env.PROD) {
     return new ethers.providers.AlchemyWebSocketProvider(
       network.name,
       config.alchemy.key,
     );
-  } else if (metamask) {
-    return metamask;
   } else if (import.meta.env.DEV) {
     // The ethers defaultProvider doesn't include a `send` method, which breaks the `utils.getTokens` fn.
     // Since Metamask nor WalletConnect provide an `alchemy_getTokenBalances` nor `alchemy_getTokenMetadata` endpoint,


### PR DESCRIPTION
Instead of going first for Alchemy in production, try to use Metamask if available, to reduce load on Alchemy and also give users the chance to use their own jsonrpc endpoint.