### PR TITLE
Fix small alignment issues

### DIFF
--- a/src/Markdown.svelte
+++ b/src/Markdown.svelte
@@ -70,7 +70,7 @@
     color: var(--color-foreground);
     border: 1px dashed var(--color-foreground-4);
     padding: 0.5rem;
-    margin-bottom: 1.5rem;
+    margin-bottom: 2rem;
   }
   .front-matter table {
     border-collapse: collapse;
@@ -240,6 +240,11 @@
   .markdown :global(th) {
     text-align: center;
     padding: 0.5rem 1rem;
+  }
+
+  .markdown > :global(*:first-child) {
+    padding-top: 0 !important;
+    margin-top: 0 !important;
   }
 </style>
 

--- a/src/base/projects/Blob.svelte
+++ b/src/base/projects/Blob.svelte
@@ -138,6 +138,7 @@
       <div class="file-header">
         <span class="file-name">
           <span class="faded">{parentDir}</span>
+          &#8203;
           <span>{blob.info.name}</span>
         </span>
         <div class="last-commit" title={lastCommit.author.name}>

--- a/src/base/seeds/View.svelte
+++ b/src/base/seeds/View.svelte
@@ -78,6 +78,10 @@
   .inline {
     display: inline !important;
   }
+  .seed-label {
+    display: flex;
+    align-items: center;
+  }
 
   @media (max-width: 720px) {
     main {
@@ -145,7 +149,10 @@
       <SeedAddress {seed} port={seed.link.port} />
       <!-- Seed ID -->
       <div class="label">Seed ID</div>
-      <div>{formatSeedId(seed.id)} <Clipboard small text={seed.id} /></div>
+      <div class="seed-label">
+        {formatSeedId(seed.id)}
+        <Clipboard small text={seed.id} />
+      </div>
       <div class="desktop" />
       <!-- API Port -->
       <div class="label">API Port</div>


### PR DESCRIPTION
- remove space between `path` and `filename` in Blob.svelte
- remove top margin from the first element in markdown docs
- fix Seed ID alignment on seed page

Closes: https://github.com/radicle-dev/radicle-interface/issues/389

<img width="1840" alt="Screenshot 2022-09-15 at 15 08 03" src="https://user-images.githubusercontent.com/158411/190411634-950569e7-bd55-477e-ad18-bbb84e1498ae.png">

<img width="1840" alt="Screenshot 2022-09-15 at 15 07 35" src="https://user-images.githubusercontent.com/158411/190411554-a0653555-9948-4b03-ab9b-1e801a2bc584.png">
<img width="1840" alt="Screenshot 2022-09-15 at 15 06 41" src="https://user-images.githubusercontent.com/158411/190411379-28fb6e10-5f17-4a8c-937c-0849a05bd393.png">
