### PR TITLE
Show commit SHA below patch title

### DIFF
--- a/src/base/projects/Patch.svelte
+++ b/src/base/projects/Patch.svelte
@@ -57,7 +57,7 @@
   }
   .summary-left {
     display: flex;
-    align-items: center;
+    flex-direction: column;
   }
   .summary-title {
     display: flex;


### PR DESCRIPTION
This fixes a visual regression.

Left is proposed:

<img width="1728" alt="Screenshot 2022-09-20 at 09 50 21" src="https://user-images.githubusercontent.com/158411/191199433-d629c9e9-fd80-45da-8012-4089c5c23a82.png">
<img width="1728" alt="Screenshot 2022-09-20 at 09 50 51" src="https://user-images.githubusercontent.com/158411/191199447-3c5a877e-4b09-4954-a147-9e49a8ae30e4.png">
