### PR TITLE
Improve pinned projects

### DIFF
--- a/src/base/projects/Widget.svelte
+++ b/src/base/projects/Widget.svelte
@@ -114,7 +114,11 @@
     <div class="id">
       <span class="name">{project.name}</span>
     </div>
-    <div class="description">{project.description || ""}</div>
+    {#if project.description}
+      <div class="description">{project.description}</div>
+    {:else}
+      <div class="description txt-missing">No description</div>
+    {/if}
     <div class="stateHash">
       {#if project.head}
         {#if compact}

--- a/src/config.json
+++ b/src/config.json
@@ -135,7 +135,7 @@
       {
         "name": "astrolabe",
         "urn": "rad:git:hnrkrwewct7pb1biwmf59qa3rzod8mauundzy",
-        "seed": "maple.radicle.garden"
+        "seed": "willow.radicle.garden"
       },
       {
         "name": "svelte-dappkit",


### PR DESCRIPTION
Show "No description" when the project description is missing.

> @joelhans: Also I saw that you added astrolabe to the homepage, which is very exciting because that's my project(!), but I really messed that repo up and ended up moving to the willow seed node instead, so maybe we switch the link to point there instead? https://app.radicle.network/seeds/willow.radicle.garden/rad:git:hnrkrwewct7pb1biwmf59qa3rzod8mauundzy


<img width="1840" alt="Screenshot 2022-09-22 at 11 28 13" src="https://user-images.githubusercontent.com/158411/191711267-f17dee6d-6864-412b-a37b-b2ae6771d1bb.png">
