### PR TITLE
Gracefully handle API quota exhaustion

### DIFF
--- a/src/base/orgs/Org.ts
+++ b/src/base/orgs/Org.ts
@@ -203,16 +203,24 @@ export class Org {
       GetSafesByOwners,
       { owners: [owner] },
     );
-    const safes = safesByOwner.safes.reduce(
-      (prev: any, curr: Safe) => prev.concat(curr.id),
-      [],
-    );
+
+    let safes = [];
+    if (safesByOwner && safesByOwner.safes.length > 0) {
+      safes = safesByOwner.safes.reduce(
+        (prev: any, curr: Safe) => prev.concat(curr.id),
+        [],
+      );
+    }
+
     const orgsByOwner = await utils.querySubgraph(
       config.orgs.subgraph,
       GetOrgsByOwners,
       { owners: [...safes, owner] },
     );
-    const orgs: { id: string; owner: string }[] = [...orgsByOwner.orgs];
+    let orgs: { id: string; owner: string }[] = [];
+    if (orgsByOwner && orgsByOwner.orgs) {
+      orgs = [...orgsByOwner.orgs];
+    }
 
     return orgs.map(o => new Org(o.id, o.owner));
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -377,7 +377,7 @@ export async function querySubgraphWithRetry(
   query: string,
   variables: Record<string, any>,
   retries = 3,
-): Promise<null | any> {
+): Promise<Record<string, any> | null> {
   const response = await fetch(url, {
     method: "POST",
     headers: {
@@ -393,11 +393,14 @@ export async function querySubgraphWithRetry(
   if (json.errors) {
     console.error("querySubgraph:", json.errors);
 
-    if (retries > 0) querySubgraphWithRetry(url, query, variables, retries - 1);
-    else return null;
+    if (retries > 0) {
+      return querySubgraphWithRetry(url, query, variables, retries - 1);
+    } else {
+      return null;
+    }
+  } else {
+    return json.data;
   }
-
-  return json.data;
 }
 
 export const querySubgraph = cache.cached(
@@ -589,7 +592,7 @@ export async function isSafe(
     addr: address.toLowerCase(),
   });
 
-  return query.safe !== null ? true : false;
+  return query?.safe !== null ? true : false;
 }
 
 // Get a Gnosis Safe at an address.


### PR DESCRIPTION
We had to rewrite `querySubgraphWithRetry` due to flaws in the return value logic and how the recursion took place.