### PR TITLE
Move `seeds.pinned` out of network scope

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -26,19 +26,6 @@
     "users": {
       "pinned": ["cloudhead.radicle.eth"]
     },
-    "seeds": {
-      "pinned": {
-        "willow.radicle.garden": {
-          "emoji": "🪵"
-        },
-        "pine.radicle.garden": {
-          "emoji": "🌲"
-        },
-        "maple.radicle.garden": {
-          "emoji": "🍁"
-        }
-      }
-    },
     "safe": {
       "api": "https://safe-transaction.gnosis.io",
       "viewer": "https://gnosis-safe.io/app/#/safes"
@@ -69,9 +56,6 @@
     "users": {
       "pinned": []
     },
-    "seeds": {
-      "pinned": []
-    },
     "safe": {
       "api": "https://safe-transaction.rinkeby.gnosis.io",
       "viewer": "https://rinkeby.gnosis-safe.io/app/#/safes"
@@ -93,6 +77,19 @@
       "api": { "port": 8777 },
       "link": { "port": 8776 },
       "git": { "port": 443 }
+    }
+  },
+  "seeds": {
+    "pinned": {
+      "willow.radicle.garden": {
+        "emoji": "🪵"
+      },
+      "pine.radicle.garden": {
+        "emoji": "🌲"
+      },
+      "maple.radicle.garden": {
+        "emoji": "🍁"
+      }
     }
   },
   "projects": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -115,7 +115,6 @@ export class Config {
     this.reverseRegistrar = cfg.reverseRegistrar;
     this.orgs = cfg.orgs;
     this.users = cfg.users;
-    this.seeds = cfg.seeds;
     this.safe = cfg.safe;
     this.safe.client = this.safe.api
       ? new SafeServiceClient(this.safe.api)
@@ -124,6 +123,7 @@ export class Config {
     this.signer = null;
     this.gasLimits = gasLimits;
     this.projects = config.projects;
+    this.seeds = config.seeds;
     this.abi = config.abi;
     this.ceramic = {
       client: ceramic,


### PR DESCRIPTION
Instead of defining the seeds in relation to the current network we should be able to query them agnostic to the current connected network

This fixes issues with different search results depending on the connected network

Signed-off-by: Sebastian Martinez <me@sebastinez.dev>