### PR TITLE
Fix `isSafe` util function

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -592,7 +592,7 @@ export async function isSafe(
     addr: address.toLowerCase(),
   });
 
-  return query?.safe !== null ? true : false;
+  return Boolean(query?.safe);
 }
 
 // Get a Gnosis Safe at an address.


### PR DESCRIPTION
We were calling `return query?.safe !== null ? true : false` but since `query` can become `undefined` through the optional chaining operator, we were returning `true` if the query wasn't able to retrieve anything.

Signed-off-by: Sebastian Martinez <me@sebastinez.dev>