### PR TITLE
Show delegate badge in commits

### DIFF
--- a/cypress/e2e/projectCommits.spec.ts
+++ b/cypress/e2e/projectCommits.spec.ts
@@ -129,7 +129,7 @@ describe("project commits", () => {
         });
       });
 
-    cy.get(".commit-teaser .badge").trigger("mouseenter");
+    cy.get(".commit-teaser .badge").last().trigger("mouseenter");
     // Checking that the initial commit has the Verified badge
     cy.get(".popup .header").should(
       "have.text",

--- a/src/base/projects/Commit/CommitAuthorship.svelte
+++ b/src/base/projects/Commit/CommitAuthorship.svelte
@@ -1,16 +1,20 @@
 <script lang="ts">
   import type { CommitMetadata } from "@app/commit";
+
+  import Badge from "@app/Badge.svelte";
   import { formatTimestamp, gravatarURL } from "@app/utils";
 
   export let commit: CommitMetadata;
-  export let showTime = true;
-  export let showAuthor = true;
+  export let noTime = false;
+  export let noAuthor = false;
+  export let noDelegate = false;
 </script>
 
 <style>
   .authorship {
     display: flex;
     align-items: center;
+    gap: 0.25rem;
     color: var(--color-foreground-5);
     padding: 0.125rem 0;
   }
@@ -23,10 +27,6 @@
     width: 1rem;
     height: 1rem;
     border-radius: var(--border-radius);
-    margin-right: 0.25rem;
-  }
-  .authorship .avatar:not(:first-child) {
-    margin-left: 0.125rem;
   }
 
   @media (max-width: 720px) {
@@ -43,44 +43,49 @@
       alt="avatar"
       src={gravatarURL(commit.header.committer.email)} />
     {#if commit.context?.committer}
-      <span class="txt-bold committer verified-committer">
+      <span class="txt-bold committer">
         {commit.context?.committer.peer.person.name}
       </span>
-      <span>&nbsp;committed</span>
+      {#if !noDelegate && commit.context?.committer.peer.delegate}
+        <Badge variant="tertiary">delegate</Badge>
+      {/if}
+      <span>committed</span>
     {:else}
       <span class="desktop-inline committer">
         {commit.header.committer.name}
       </span>
-      <span>&nbsp;committed</span>
+      <span>committed</span>
     {/if}
   {:else}
-    {#if showAuthor}
+    {#if !noAuthor}
       <img
         class="avatar"
         alt="avatar"
         src={gravatarURL(commit.header.author.email)} />
       <span class="desktop-inline author">{commit.header.author.name}</span>
-      <span>&nbsp;authored&nbsp;</span>
+      <span>authored</span>
     {/if}
     <img
       class="avatar"
       alt="avatar"
       src={gravatarURL(commit.header.committer.email)} />
     {#if commit.context?.committer}
-      <span class="txt-bold committer verified-committer">
+      <span class="txt-bold committer">
         {commit.context?.committer.peer.person.name}
       </span>
-      <span>&nbsp;committed</span>
+      {#if !noDelegate && commit.context?.committer.peer.delegate}
+        <Badge variant="tertiary">delegate</Badge>
+      {/if}
+      <span>committed</span>
     {:else}
       <span class="desktop-inline committer">
         {commit.header.committer.name}
       </span>
-      <span>&nbsp;committed</span>
+      <span>committed</span>
     {/if}
   {/if}
-  {#if showTime}
-    <span>&nbsp;</span>
-    <span class="desktop-inline txt-tiny time">
+  {#if !noTime}
+    <span class="desktop-inline">
       {formatTimestamp(commit.header.committerTime)}
     </span>
   {/if}

--- a/src/base/projects/Commit/CommitTeaser.svelte
+++ b/src/base/projects/Commit/CommitTeaser.svelte
@@ -91,7 +91,7 @@
         {commit.header.summary}
       </div>
     </div>
-    <CommitAuthorship {commit} />
+    <CommitAuthorship {commit} noDelegate />
   </div>
   <div class="column-right">
     {#if commit.context.committer}

--- a/src/base/projects/Commit/CommitVerifiedBadge.svelte
+++ b/src/base/projects/Commit/CommitVerifiedBadge.svelte
@@ -33,7 +33,7 @@
     margin-top: 0.5rem;
     padding: 0.5rem 0;
     position: absolute;
-    width: 14rem;
+    min-width: 14rem;
     z-index: 99;
   }
   .header {
@@ -73,7 +73,7 @@
           </div>
         </div>
         <div class="committer">
-          <CommitAuthorship {commit} showAuthor={false} showTime={false} />
+          <CommitAuthorship {commit} noAuthor noTime />
           {#if commit.context.committer}
             <div class="peer">
               {commit.context.committer.peer.id}


### PR DESCRIPTION
- Shows a delegate `Badge` in `CommitAuthorship` if available.
- Changes `width: 14rem` to `min-width: 14rem` to allow space for horizontal text without the need of wrapping it.
  e.g. <Avatar> cloudhead [delegate] committed already was in need of being wrapped which doesn't look nice.

Closes #404 