### PR TITLE
Lowercase ENS name search query

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -53,9 +53,14 @@ export async function resolve(
         results.projects.push(...projects);
 
         // ========= ENS Names =========
+        const normalizedQuery = q.toLowerCase();
         let profile: Profile | null;
         try {
-          profile = await Profile.get(q, ProfileType.Minimal, config);
+          profile = await Profile.get(
+            normalizedQuery,
+            ProfileType.Minimal,
+            config,
+          );
         } catch (e) {
           profile = null;
         }
@@ -71,7 +76,10 @@ export async function resolve(
           let profiles: Profile[];
           try {
             profiles = await Profile.getMulti(
-              [`${q}.${config.registrar.domain}`, `${q}.eth`],
+              [
+                `${normalizedQuery}.${config.registrar.domain}`,
+                `${normalizedQuery}.eth`,
+              ],
               config,
             );
           } catch (e) {


### PR DESCRIPTION
Since ENS names go through a UTS46 normalisation process case-folds labels before hashing them.
So we shouldn't be ENS querying uppercase names.

Signed-off-by: Sebastian Martinez <me@sebastinez.dev>