### PR TITLE
Exit editable form state when pressing "Cancel"

### DIFF
--- a/src/Form.svelte
+++ b/src/Form.svelte
@@ -109,6 +109,7 @@
   const validate = (event: Event) => dispatch("validate", check(event));
   const cancel = () => {
     formFields = cloneDeep(fields);
+    dispatch("cancel");
   };
 </script>
 


### PR DESCRIPTION
The form didn't close when pressing the "Cancel" button. This regression was introduced in b8e7239ba4b2919dd6aee4f0e7e6874c1416cbd7.

https://user-images.githubusercontent.com/158411/192533574-77480aac-c60d-4720-b1c4-17476050fe7f.mov

