### PR TITLE
Add seed peer id to `rad clone` in `CloneButton`

### DIFF
--- a/src/base/projects/CloneButton.svelte
+++ b/src/base/projects/CloneButton.svelte
@@ -5,9 +5,12 @@
   import { closeFocused } from "@app/Floating.svelte";
 
   export let seedHost: string;
+  export let seedId: string;
   export let urn: string;
 
-  $: radCloneUrl = `rad clone rad://${seedHost}/${utils.parseRadicleId(urn)}`;
+  $: radCloneUrl = `rad clone rad://${seedId}@${seedHost}/${utils.parseRadicleId(
+    urn,
+  )}`;
   $: gitCloneUrl = `https://${seedHost}/${utils.parseRadicleId(urn)}.git`;
 </script>
 

--- a/src/base/projects/Header.svelte
+++ b/src/base/projects/Header.svelte
@@ -101,7 +101,7 @@
     on:branchChanged={event => updateRevision(event.detail)} />
 
   {#if seed.git.host}
-    <CloneButton seedHost={seed.git.host} {urn} />
+    <CloneButton seedHost={seed.git.host} seedId={seed.id} {urn} />
   {/if}
   <span>
     {#if seed.api.host}


### PR DESCRIPTION
**Important**: Requires `radicle-cli v.0.7.0` to be stable before merging.
Replaces `rad clone` command provided by the `CloneButton` from

```
rad clone rad://clients.radicle.xyz/hnrkbtw9t1of4ykjy6er4qqwxtc54k9943eto
```
to
```
rad clone rad://yyncx743heiqf13ocz4dk373uuf4quiiscwfn75qb7d8rupjnkn7c@clients.radicle.xyz/hnrkbtw9t1of4ykjy6er4qqwxtc54k9943eto
```