### PR TITLE
Use new clients.radicle.xyz domain for some pinned projects

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -97,17 +97,17 @@
       {
         "name": "radicle-cli",
         "urn": "rad:git:hnrkmg77m8tfzj4gi4pa4mbhgysfgzwntjpao",
-        "seed": "seed.alt-clients.radicle.xyz"
+        "seed": "clients.radicle.xyz"
       },
       {
         "name": "radicle-interface",
         "urn": "rad:git:hnrkjajuucc6zp5eknt3s9xykqsrus44cjimy",
-        "seed": "seed.alt-clients.radicle.xyz"
+        "seed": "clients.radicle.xyz"
       },
       {
         "name": "radicle-client-services",
         "urn": "rad:git:hnrkk9c4zt9thuxhwi1ukxqcrs5tmhbtcsony",
-        "seed": "seed.alt-clients.radicle.xyz"
+        "seed": "clients.radicle.xyz"
       },
       {
         "name": "solmate",


### PR DESCRIPTION
Fixes:
```
Access to fetch at 'https://seed.alt-clients.radicle.xyz:8777/v1/projects/rad:git:hnrkmg77m8tfzj4gi4pa4mbhgysfgzwntjpao' from origin 'https://app.radicle.xyz' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
seed.alt-clients.radicle.xyz:8777/v1/projects/rad:git:hnrkmg77m8tfzj4gi4pa4mbhgysfgzwntjpao:1          Failed to load resource: net::ERR_FAILED
app.radicle.xyz/:1 Access to fetch at 'https://seed.alt-clients.radicle.xyz:8777/v1/projects/rad:git:hnrkjajuucc6zp5eknt3s9xykqsrus44cjimy' from origin 'https://app.radicle.xyz' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
seed.alt-clients.radicle.xyz:8777/v1/projects/rad:git:hnrkjajuucc6zp5eknt3s9xykqsrus44cjimy:1          Failed to load resource: net::ERR_FAILED
app.radicle.xyz/:1 Access to fetch at 'https://seed.alt-clients.radicle.xyz:8777/v1/projects/rad:git:hnrkk9c4zt9thuxhwi1ukxqcrs5tmhbtcsony' from origin 'https://app.radicle.xyz' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
seed.alt-clients.radicle.xyz:8777/v1/projects/rad:git:hnrkk9c4zt9thuxhwi1ukxqcrs5tmhbtcsony:1          Failed to load resource: net::ERR_FAILED
```

<img width="1840" alt="Screenshot 2022-09-29 at 15 42 12" src="https://user-images.githubusercontent.com/158411/193047789-35fab394-334a-43ca-a98c-164a29248e1e.png">
