### PR TITLE
Show fetch more button only when more projects are available

### DIFF
--- a/src/Async.svelte
+++ b/src/Async.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import Loading from "@app/Loading.svelte";
 
-  export let fetch: any;
+  type T = $$Generic;
+
+  export let fetch: Promise<T>;
 </script>
 
 {#await fetch}

--- a/src/List.svelte
+++ b/src/List.svelte
@@ -5,13 +5,12 @@
 
   type Item = $$Generic;
 
+  export let complete = false;
   export let items: Item[];
   export let query: () => Promise<Item[]>;
 
   // Used to handle the display of the trigger to load more items, according to the current loading state.
   let loading = false;
-  // Should be changed to true, once no more items are being returned.
-  let complete = false;
 
   const transitionParams = { duration: 200 };
 

--- a/src/Profile.svelte
+++ b/src/Profile.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import type { SvelteComponent } from "svelte";
   import type { Config } from "@app/config";
+  import type { Seed, Stats } from "@app/base/seeds/Seed";
+  import type { ProjectInfo } from "@app/project";
   import Address from "@app/Address.svelte";
   import Avatar from "@app/Avatar.svelte";
   import Icon from "@app/Icon.svelte";
@@ -37,6 +39,18 @@
   let transferOwnerForm: typeof SvelteComponent | null = null;
   const transferOwnership = () => {
     transferOwnerForm = TransferOwnership;
+  };
+
+  const getProjectsAndStats = async (
+    seed: Seed,
+    id?: string,
+  ): Promise<{
+    stats: Stats;
+    projects: ProjectInfo[];
+  }> => {
+    const stats = await seed.getStats();
+    const projects = await seed.getProjects(10, id);
+    return { stats, projects };
   };
 
   $: account = $session && $session.address;
@@ -447,8 +461,12 @@
       {/await}
     {/if}
     {#if profile.seed?.valid}
-      <Async fetch={profile.seed.getProjects(10, profile.id)} let:result>
-        <Projects {profile} seed={profile.seed} projects={result} />
+      <Async fetch={getProjectsAndStats(profile.seed, profile.id)} let:result>
+        <Projects
+          {profile}
+          seed={profile.seed}
+          stats={result.stats}
+          projects={result.projects} />
       </Async>
     {/if}
   </main>

--- a/src/base/seeds/Seed.ts
+++ b/src/base/seeds/Seed.ts
@@ -4,6 +4,11 @@ import * as proj from "@app/project";
 import { isDomain, isLocal } from "@app/utils";
 import { assert } from "@app/error";
 
+export interface Stats {
+  projects: { count: number };
+  users: { count: number };
+}
+
 export class InvalidSeed {
   valid = false as const;
 
@@ -114,6 +119,13 @@ export class Seed {
       ...project,
       id: project.urn,
     }));
+  }
+
+  async getStats(): Promise<{
+    projects: { count: number };
+    users: { count: number };
+  }> {
+    return new Request("/stats", this.api).get();
   }
 
   static async getPeer(host: Host): Promise<{ id: string }> {

--- a/src/base/seeds/View.svelte
+++ b/src/base/seeds/View.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import type { Config } from "@app/config";
+  import type { Stats } from "@app/base/seeds/Seed";
+  import type { ProjectInfo } from "@app/project";
   import { formatSeedId, formatSeedHost } from "@app/utils";
   import { Seed } from "@app/base/seeds/Seed";
   import Loading from "@app/Loading.svelte";
@@ -22,6 +24,17 @@
   const hostName = formatSeedHost(host);
   const seedHost: Host = { host, port: null };
   let siweSession: SeedSession | null = null;
+
+  const getProjectsAndStats = async (
+    seed: Seed,
+  ): Promise<{
+    stats: Stats;
+    projects: ProjectInfo[];
+  }> => {
+    const stats = await seed.getStats();
+    const projects = await Project.getProjects(seedHost, { perPage: 10 });
+    return { stats, projects };
+  };
 
   $: if (session?.siwe) {
     const entries = Object.entries(session.siwe);
@@ -164,8 +177,8 @@
       <div class="desktop" />
     </div>
     <!-- Seed Projects -->
-    <Async fetch={Project.getProjects(seedHost, { perPage: 10 })} let:result>
-      <Projects {seed} projects={result} />
+    <Async fetch={getProjectsAndStats(seed)} let:result>
+      <Projects {seed} projects={result.projects} stats={result.stats} />
     </Async>
   </main>
 {:catch}


### PR DESCRIPTION
- Fetches project count information from `/stats` http-api endpoint
- If less projects are shown than the project count, show a `More` button
- If the amount of projects shown is equal to the total amount stop showing it.
- If the seed does not support the `/stats` endpoint the button will shown until we're not able to fetch more projects.