### PR TITLE
Make file tree sticky

### DIFF
--- a/src/base/projects/Browser.svelte
+++ b/src/base/projects/Browser.svelte
@@ -134,6 +134,11 @@
   nav {
     padding: 0 2rem;
   }
+  .sticky {
+    position: sticky;
+    top: 2rem;
+    max-height: 100vh;
+  }
 
   @media (max-width: 960px) {
     .container {
@@ -164,6 +169,9 @@
     .column-left-visible {
       display: block;
     }
+    .sticky {
+      max-height: initial;
+    }
   }
 </style>
 
@@ -183,7 +191,7 @@
   <div class="container center-content">
     {#if tree.entries.length > 0}
       <div class="column-left" class:column-left-visible={mobileFileTree}>
-        <div class="source-tree">
+        <div class="source-tree sticky">
           <Tree
             {tree}
             {path}


### PR DESCRIPTION
When browsing the source in a repo, the file tree is now always visible.

Tested on Linux: Firefox/Chromium, Android: Firefox/Chrome, MacOS: Safari/Brave.

The behaviour on mobile has not been changed.

The video below shows how it looks like with a long file and a long tree, a long file and a short tree, a short file and a short tree, and a short file and a long tree (where "short" means all of it fits on the screen)

[RadicleStickyFileTree.webm](https://user-images.githubusercontent.com/23722804/193448725-6cca7328-3e47-4567-baef-42cf6f7877a4.webm)



Closes #125 