### PR TITLE
Replace Rinkeby testnet with Goerli

### DIFF
--- a/src/Header.svelte
+++ b/src/Header.svelte
@@ -189,9 +189,9 @@
   </div>
 
   <div class="right">
-    {#if config && config.network.name === "rinkeby"}
+    {#if config && config.network.name === "goerli"}
       <a use:link href="/faucet">
-        <span class="network">Rinkeby</span>
+        <span class="network">Goerli</span>
       </a>
     {:else if config && config.network.name === "homestead"}
       <!-- Don't show anything -->

--- a/src/base/faucet/Index.svelte
+++ b/src/base/faucet/Index.svelte
@@ -2,7 +2,7 @@
   import type { Config } from "@app/config";
 
   import { session } from "@app/session";
-  import { setOpenGraphMetaTag, toWei } from "@app/utils";
+  import { setOpenGraphMetaTag, toWei, capitalize } from "@app/utils";
   import { formatEther } from "@ethersproject/units";
   import { navigate } from "svelte-routing";
   import {
@@ -22,7 +22,7 @@
 
   setOpenGraphMetaTag([
     { prop: "og:title", content: "Radicle Faucet" },
-    { prop: "og:description", content: "Rinkeby Testnet Faucet" },
+    { prop: "og:description", content: "Goerli Testnet Faucet" },
     { prop: "og:url", content: window.location.href },
   ]);
 
@@ -120,14 +120,14 @@
 <main>
   <div class="title">
     Obtain RAD tokens on <span class="txt-bold">
-      {config.network.name}
+      {capitalize(config.network.name)}
     </span>
   </div>
 
   {#if config.network.name === "homestead"}
     <div class="subtitle">
       To get RAD tokens on <span class="txt-bold">
-        {config.network.name},
+        {capitalize(config.network.name)},
       </span>
       please
       <br />
@@ -140,7 +140,7 @@
   {:else if !$session}
     <div class="subtitle">
       To get RAD tokens on <span class="txt-bold">
-        {config.network.name}
+        {capitalize(config.network.name)}
       </span>
       &#8203;,
       <br />

--- a/src/base/registrations/Index.svelte
+++ b/src/base/registrations/Index.svelte
@@ -86,8 +86,8 @@
   <div class="subtitle">
     Register a unique name with our ENS registrar, under <br />
     the
-    <span class="txt-bold">radicle.eth</span>
-    domain (e.g. cloudhead.radicle.eth).
+    <span class="txt-bold">{config.registrar.domain}</span>
+    domain (e.g. cloudhead.{config.registrar.domain}).
     <br />
     Radicle names never expire and free to register.
   </div>

--- a/src/base/registrations/Submit.svelte
+++ b/src/base/registrations/Submit.svelte
@@ -21,7 +21,9 @@
   const registrationOwner = owner || session.address;
 
   const view = () =>
-    navigate(`/registrations/${name}.radicle.eth`, { state: { retry: true } });
+    navigate(`/registrations/${name}.${config.registrar.domain}`, {
+      state: { retry: true },
+    });
 
   onMount(async () => {
     try {

--- a/src/config.json
+++ b/src/config.json
@@ -16,20 +16,20 @@
     "tokens": [],
     "alchemy": { "key": "cQFlLK8EokIGlJhd_soImwEyUoC7Ec8r" }
   },
-  "rinkeby": {
+  "goerli": {
     "registrar": {
-      "domain": "radicle.eth",
-      "address": "0x80b68878442b6510D768Be1bd88712710B86eAcD"
+      "domain": "radicle-goerli.eth",
+      "address": "0xD88303A92577bFDF5A82FddeF342F3A27A972405"
     },
     "radToken": {
-      "address": "0x7b6CbebC5646D996d258dcD4ca1d334B282e9948",
-      "faucet": "0x9Aa75397eD632A3060aCb5dE7f96e2457bceED8d"
+      "address": "0x3EE94D192397aAFAe438C9803825eb1Aa4402e09",
+      "faucet": "0xc627191d2BB8839eAcbb7191f9500B84d201A066"
     },
     "users": {
       "pinned": []
     },
     "reverseRegistrar": {
-      "address": "0x6F628b68b30Dc3c17f345c9dbBb1E483c2b7aE5c"
+      "address": "0xD5610A08E370051a01fdfe4bB3ddf5270af1aA48"
     },
     "tokens": [],
     "alchemy": { "key": "1T6h-0rxu7SRzKEtmukIoxaJOXazLDNs" }

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import type { TypedDataSigner } from "@ethersproject/abstract-signer";
 import WalletConnect from "@walletconnect/client";
 import config from "@app/config.json";
 import { WalletConnectSigner } from "./WalletConnectSigner";
+import { capitalize } from "@app/utils";
 
 declare global {
   interface Window {
@@ -241,7 +242,11 @@ export async function getConfig(): Promise<Config> {
 
   const networkConfig = (<Record<string, any>>config)[network.name];
   if (!networkConfig) {
-    throw new Error(`Network ${network.name} is not supported`);
+    throw new Error(
+      `${capitalize(
+        network.name,
+      )} is not supported. Connect to Homestead or Goerli instead.`,
+    );
   }
 
   const provider = getProvider(network, networkConfig, metamask);

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -159,9 +159,9 @@ describe("String Assertions", () => {
 describe("Others", () => {
   test.each([
     {
-      name: "rinkeby",
+      name: "goerli",
       expected:
-        "https://rinkeby.etherscan.io/address/0x5E813e48a81977c6Fdd565ed5097eb600C73C4f0",
+        "https://goerli.etherscan.io/address/0x5E813e48a81977c6Fdd565ed5097eb600C73C4f0",
     },
     {
       name: "",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -292,8 +292,8 @@ export function getSearchParam(
 
 // Get the explorer link of an address, eg. Etherscan.
 export function explorerLink(addr: string, config: Config): string {
-  if (config.network.name === "rinkeby") {
-    return `https://rinkeby.etherscan.io/address/${addr}`;
+  if (config.network.name === "goerli") {
+    return `https://goerli.etherscan.io/address/${addr}`;
   }
   return `https://etherscan.io/address/${addr}`;
 }


### PR DESCRIPTION
Closes https://github.com/radicle-dev/radicle-interface/issues/438.

TBD:
- [x] deploy faucet -> thanks @sebastinez!
- [x] figure out how to get `reverseRegistrar` address -> https://app.ens.domains/name/addr.reverse/details
- [x] give the 'radicle.eth' domain to the registrar -> the "controller" had to be transferred to the registrar contract
- [x] fill faucet with `1'000'000` RAD

<img width="1840" alt="Screenshot 2022-10-12 at 18 00 37" src="https://user-images.githubusercontent.com/158411/195400257-87aad691-80d3-4391-bbc4-bba5dbaa75f3.png">
<img width="1840" alt="Screenshot 2022-10-12 at 18 39 00" src="https://user-images.githubusercontent.com/158411/195400263-2ef0cd2e-503c-498b-bdde-61a0ce67de84.png">
<img width="1840" alt="Screenshot 2022-10-12 at 18 39 10" src="https://user-images.githubusercontent.com/158411/195400264-51b4a506-b4b5-42da-8d76-ae2cf694675c.png">
<img width="1840" alt="Screenshot 2022-10-12 at 18 39 17" src="https://user-images.githubusercontent.com/158411/195400266-75e58e4e-10ec-4551-a112-df78b32dd38d.png">
<img width="1840" alt="Screenshot 2022-10-12 at 18 40 05" src="https://user-images.githubusercontent.com/158411/195400269-77caa43f-9382-49d8-affb-94d832a412d0.png">
<img width="1840" alt="Screenshot 2022-10-13 at 10 17 14" src="https://user-images.githubusercontent.com/158411/195541899-19ba3855-8b38-4f6e-8cbc-810fdc06e978.png">
