### PR TITLE
Add support for custom seed node ports

### DIFF
--- a/cypress/e2e/projectCommits.spec.ts
+++ b/cypress/e2e/projectCommits.spec.ts
@@ -86,7 +86,7 @@ describe("project commits", () => {
 
   it("display commit groups and commit trailers", () => {
     cy.visit(
-      "/seeds/willow.radicle.garden/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/history",
+      "/seeds/willow.radicle.garden:8777/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/history",
       {
         onBeforeLoad(win) {
           const address = "0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D";
@@ -147,7 +147,7 @@ describe("project commits", () => {
   it("display commit details", () => {
     cy.location().should(location => {
       expect(location.pathname).to.eq(
-        "/seeds/willow.radicle.garden/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/commits/cbf5df499ab4f4a908f1756fbe2c236a4530516a",
+        "/seeds/willow.radicle.garden:8777/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/commits/cbf5df499ab4f4a908f1756fbe2c236a4530516a",
       );
     });
     cy.get("header .summary .txt-medium").should("have.text", "initial commit");

--- a/cypress/e2e/projectHeader.spec.ts
+++ b/cypress/e2e/projectHeader.spec.ts
@@ -58,7 +58,7 @@ describe("project header", () => {
     ).as("projectCommit");
   });
   it("renders header correctly", () => {
-    cy.visit("/seeds/willow.radicle.garden/bright-forest-protocol", {
+    cy.visit("/seeds/willow.radicle.garden:8777/bright-forest-protocol", {
       onBeforeLoad(win) {
         const address = "0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D";
         const privateKey =
@@ -109,7 +109,7 @@ describe("project header", () => {
     ]);
     cy.location().should(location => {
       expect(location.pathname).to.eq(
-        "/seeds/willow.radicle.garden/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/remotes/hyndc7nx9keq76p1bkw9831arcndeeu3trwsc7kxt3osmpi6j9oeke/tree",
+        "/seeds/willow.radicle.garden:8777/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/remotes/hyndc7nx9keq76p1bkw9831arcndeeu3trwsc7kxt3osmpi6j9oeke/tree",
       );
     });
     cy.get(
@@ -130,7 +130,7 @@ describe("project header", () => {
     cy.wait(["@projectTreecbf5df4", "@projectReadme"]);
     cy.location().should(location => {
       expect(location.pathname).to.eq(
-        "/seeds/willow.radicle.garden/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/remotes/hyndc7nx9keq76p1bkw9831arcndeeu3trwsc7kxt3osmpi6j9oeke/tree/master",
+        "/seeds/willow.radicle.garden:8777/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/remotes/hyndc7nx9keq76p1bkw9831arcndeeu3trwsc7kxt3osmpi6j9oeke/tree/master",
       );
     });
     cy.get("div.stat.branch").should("have.text", "master");
@@ -142,7 +142,7 @@ describe("project header", () => {
     cy.wait(["@projectTreecbf5df4", "@projectCommits"]);
     cy.location().should(location => {
       expect(location.pathname).to.eq(
-        "/seeds/willow.radicle.garden/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/remotes/hyndc7nx9keq76p1bkw9831arcndeeu3trwsc7kxt3osmpi6j9oeke/history/master",
+        "/seeds/willow.radicle.garden:8777/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/remotes/hyndc7nx9keq76p1bkw9831arcndeeu3trwsc7kxt3osmpi6j9oeke/history/master",
       );
     });
     cy.get("div.stat.commit-count").should("have.class", "active");
@@ -153,7 +153,7 @@ describe("project header", () => {
     cy.wait(["@projectTreecbf5df4", "@projectIssues"]);
     cy.location().should(location => {
       expect(location.pathname).to.eq(
-        "/seeds/willow.radicle.garden/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/remotes/hyndc7nx9keq76p1bkw9831arcndeeu3trwsc7kxt3osmpi6j9oeke/issues",
+        "/seeds/willow.radicle.garden:8777/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/remotes/hyndc7nx9keq76p1bkw9831arcndeeu3trwsc7kxt3osmpi6j9oeke/issues",
       );
     });
     cy.get("div.stat.issue-count").should("have.class", "active");
@@ -164,7 +164,7 @@ describe("project header", () => {
     cy.wait(["@projectTree56e4e02", "@projectPatches"]);
     cy.location().should(location => {
       expect(location.pathname).to.eq(
-        "/seeds/willow.radicle.garden/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/remotes/hyndc7nx9keq76p1bkw9831arcndeeu3trwsc7kxt3osmpi6j9oeke/patches",
+        "/seeds/willow.radicle.garden:8777/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/remotes/hyndc7nx9keq76p1bkw9831arcndeeu3trwsc7kxt3osmpi6j9oeke/patches",
       );
     });
     cy.get("div.stat.patch-count").should("have.class", "active");

--- a/cypress/e2e/projectRoot.spec.ts
+++ b/cypress/e2e/projectRoot.spec.ts
@@ -26,7 +26,7 @@ describe("project meta", () => {
       "https://willow.radicle.garden:8777/v1/projects/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/readme/56e4e029c294b08546386e1fb706b772c7433c49",
       { fixture: "projectReadme.json" },
     ).as("projectReadme");
-    cy.visit("/seeds/willow.radicle.garden/bright-forest-protocol", {
+    cy.visit("/seeds/willow.radicle.garden:8777/bright-forest-protocol", {
       onBeforeLoad(win) {
         const address = "0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D";
         const privateKey =

--- a/src/Address.svelte
+++ b/src/Address.svelte
@@ -100,9 +100,7 @@
         <Badge variant="foreground">org</Badge>
       {/if}
     {:else if addressType === AddressType.Contract}
-      <a href={explorerLink(address, config)} target="_blank" rel="noreferrer">
-        {addressLabel}
-      </a>
+      <a href={`/${address}`}>{addressLabel}</a>
       {#if !noBadge}
         <Badge variant="foreground">contract</Badge>
       {/if}

--- a/src/Dropdown.svelte
+++ b/src/Dropdown.svelte
@@ -1,17 +1,19 @@
-<script lang="ts">
+<script lang="ts" strictEvents>
+  type T = $$Generic;
+
   import { createEventDispatcher } from "svelte";
   import Badge from "@app/Badge.svelte";
 
   export let items: {
     key: string;
     title: string;
-    value: string;
+    value: T;
     badge: string | null;
   }[];
-  export let selected: string | null = null;
+  export let selected: T | null = null;
 
-  const dispatch = createEventDispatcher();
-  const onSelect = (item: string) => {
+  const dispatch = createEventDispatcher<{ select: T }>();
+  const onSelect = (item: T) => {
     dispatch("select", item);
   };
 </script>

--- a/src/Profile.svelte
+++ b/src/Profile.svelte
@@ -185,7 +185,7 @@
         <RadicleUrn urn={profile.id} />
       {/if}
       <!-- Seed Address -->
-      {#if profile.seed && profile.seed.valid}
+      {#if profile.seed}
         <div class="label">Seed</div>
         <SeedAddress seed={profile.seed} port={config.seed.link.port} />
       {/if}
@@ -244,7 +244,7 @@
       {/if}
     </div>
 
-    {#if profile.seed?.valid}
+    {#if profile.seed}
       <Async fetch={getProjectsAndStats(profile.seed, profile.id)} let:result>
         <Projects
           {profile}

--- a/src/Profile.svelte
+++ b/src/Profile.svelte
@@ -187,7 +187,7 @@
       <!-- Seed Address -->
       {#if profile.seed}
         <div class="label">Seed</div>
-        <SeedAddress seed={profile.seed} port={config.seed.link.port} />
+        <SeedAddress seed={profile.seed} />
       {/if}
       <!-- Address -->
       <div class="label">Address</div>

--- a/src/Search.svelte
+++ b/src/Search.svelte
@@ -32,7 +32,7 @@
 
       const projectOnSeeds = config.seeds.pinned.map(seed => ({
         nameOrUrn: query,
-        seed: seed.api,
+        seedHttpApi: seed.httpApi,
       }));
 
       // The query is a radicle project URN.

--- a/src/Search.svelte
+++ b/src/Search.svelte
@@ -17,7 +17,7 @@
     | { type: "nothing" }
     | { type: "error"; message: string }
     | { type: "singleProfile"; id: string }
-    | { type: "singleProject"; seedHost: string; id: string }
+    | { type: "singleProject"; seedHost: Host; id: string }
     | { type: "projectsAndProfiles"; projectsAndProfiles: ProjectsAndProfiles };
 
   async function searchProjectsAndProfiles(
@@ -30,9 +30,9 @@
         return { type: "singleProfile", id: query };
       }
 
-      const projectOnSeeds = Object.keys(config.seeds.pinned).map(seed => ({
+      const projectOnSeeds = config.seeds.pinned.map(seed => ({
         nameOrUrn: query,
-        seed,
+        seed: seed.api,
       }));
 
       // The query is a radicle project URN.
@@ -42,7 +42,7 @@
         if (projects.length === 1) {
           return {
             type: "singleProject",
-            seedHost: projects[0].seed.host,
+            seedHost: projects[0].seed,
             id: query,
           };
         } else {
@@ -96,7 +96,7 @@
       if (profileCount === 0 && projectCount === 1) {
         return {
           type: "singleProject",
-          seedHost: projectsAndProfiles.projects[0].seed.host,
+          seedHost: projectsAndProfiles.projects[0].seed,
           id: query,
         };
       }
@@ -168,9 +168,12 @@
       dispatch("finished");
     } else if (searchResult.type === "singleProject") {
       input = "";
-      navigate(`/seeds/${searchResult.seedHost}/${searchResult.id}`, {
-        replace: true,
-      });
+      navigate(
+        `/seeds/${searchResult.seedHost.host}:${searchResult.seedHost.port}/${searchResult.id}`,
+        {
+          replace: true,
+        },
+      );
       dispatch("finished");
     } else if (searchResult.type === "projectsAndProfiles") {
       // TODO: show some kind of notification about any errors to the user.

--- a/src/SeedAddress.spec.ts
+++ b/src/SeedAddress.spec.ts
@@ -17,37 +17,12 @@ describe("SeedAddress", () => {
       cy.mount(SeedAddress, {
         props: {
           seed,
-          port: 8776,
         },
       });
       cy.get("span.seed-icon").should("have.text", "🐱");
       cy.contains("seed.cloudhead.io")
         .should("have.attr", "href", "/seeds/seed.cloudhead.io")
         .should("be.visible");
-    });
-  });
-
-  it("shows the full seed id", () => {
-    getConfig().then(cfg => {
-      const seed = new Seed(
-        {
-          host: "seed.cloudhead.io",
-          id: "hydkkkf5ksbe5fuszdhpqhytu3q36gwagj874wxwpo5a8ti8coygh1",
-        },
-        cfg,
-      );
-      cy.mount(SeedAddress, {
-        props: {
-          seed,
-          port: 8776,
-          full: true,
-        },
-      });
-      cy.get("span.seed-icon").should("have.text", "🐱");
-      cy.get("body")
-        .contains("hydkkk…coygh1@seed.cloudhead.io")
-        .should("be.visible");
-      cy.get("body").contains(":8776").should("be.visible");
     });
   });
 });

--- a/src/SeedAddress.svelte
+++ b/src/SeedAddress.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-  import { formatSeedAddress, formatSeedId, formatSeedHost } from "@app/utils";
   import type { Seed } from "@app/base/seeds/Seed";
+
+  import { formatSeedHost } from "@app/utils";
   import Clipboard from "@app/Clipboard.svelte";
 
   export let seed: Seed;
-  export let port: number;
-  export let full = false;
 </script>
 
 <style>
@@ -33,23 +32,14 @@
 <div class="wrapper">
   <div class="seed-address">
     <span class="seed-icon">{seed.emoji}</span>
-    {#if full}
-      <span>
-        <a href="/seeds/{formatSeedHost(seed.host)}" class="link">
-          {formatSeedId(seed.id)}@{seed.host}
-        </a>
-      </span>
-      <span class="faded">:{port}</span>
-    {:else}
-      <span>
-        <a href="/seeds/{formatSeedHost(seed.host)}" class="link">
-          {formatSeedHost(seed.host)}
-        </a>
-      </span>
-    {/if}
+    <span>
+      <a
+        href="/seeds/{formatSeedHost(seed.httpApi.host)}:{seed.httpApi.port}"
+        class="link">
+        {formatSeedHost(seed.host)}
+      </a>
+    </span>
   </div>
-  <Clipboard
-    small
-    text={full ? formatSeedAddress(seed.id, seed.host, port) : seed.host} />
+  <Clipboard small text={seed.host} />
 </div>
 <div class="desktop" />

--- a/src/SeedDropdown.svelte
+++ b/src/SeedDropdown.svelte
@@ -13,7 +13,10 @@
   $: formatSeeds = async () => {
     return await Promise.all(
       Object.values(seeds).map(async session => {
-        const seed = await Seed.lookup(session.domain, config);
+        const seed = await Seed.lookup(
+          { host: session.domain, port: null },
+          config,
+        );
         const key = `${seed.emoji} ${seed.host}`;
 
         return {

--- a/src/SeedDropdown.svelte
+++ b/src/SeedDropdown.svelte
@@ -21,7 +21,7 @@
 
         return {
           key,
-          value: seed.host,
+          value: `${seed.httpApi.host}:${seed.httpApi.port}`,
           title: `Go to ${seed.host}`,
           badge: null,
         };

--- a/src/base/home/Index.svelte
+++ b/src/base/home/Index.svelte
@@ -23,7 +23,7 @@
       ? Project.getMulti(
           config.projects.pinned.map(project => ({
             nameOrUrn: project.urn,
-            seed: project.seed,
+            seedHttpApi: project.seed.httpApi,
           })),
         )
       : Promise.resolve([]);
@@ -114,7 +114,7 @@
             <Widget
               compact
               project={result.info}
-              seed={{ api: result.seed }}
+              seed={{ httpApi: result.seed }}
               on:click={() => onClick(result.info, result.seed)} />
           </div>
         {/each}

--- a/src/base/home/Index.svelte
+++ b/src/base/home/Index.svelte
@@ -32,7 +32,7 @@
     navigate(
       proj.path({
         urn: project.urn,
-        seed: seed.host,
+        seed: seed,
         profile: null,
         revision: project.head,
       }),

--- a/src/base/projects/Header.svelte
+++ b/src/base/projects/Header.svelte
@@ -105,13 +105,13 @@
     <CloneButton seedHost={seed.git.host} {urn} />
   {/if}
   <span>
-    {#if seed.api.host}
+    {#if seed.httpApi.host}
       <!-- svelte-ignore a11y-click-events-have-key-events -->
       <div
         class="stat seed clickable widget"
         title="Project data is fetched from this seed"
-        on:click={() => navigate(`/seeds/${seed.api.host}`)}>
-        <span>{seed.api.host}</span>
+        on:click={() => navigate(`/seeds/${seed.httpApi.host}`)}>
+        <span>{seed.httpApi.host}</span>
       </div>
     {/if}
   </span>

--- a/src/base/projects/Header.svelte
+++ b/src/base/projects/Header.svelte
@@ -110,7 +110,8 @@
       <div
         class="stat seed clickable widget"
         title="Project data is fetched from this seed"
-        on:click={() => navigate(`/seeds/${seed.httpApi.host}`)}>
+        on:click={() =>
+          navigate(`/seeds/${seed.httpApi.host}:${seed.httpApi.port}`)}>
         <span>{seed.httpApi.host}</span>
       </div>
     {/if}

--- a/src/base/projects/History.svelte
+++ b/src/base/projects/History.svelte
@@ -19,12 +19,16 @@
   };
 
   const fetchMoreCommits = async (): Promise<CommitMetadata[]> => {
-    const response = await Project.getCommits(project.urn, project.seed.api, {
-      // Fetching 31 elements since we remove the first one
-      parent: history.headers[history.headers.length - 1].header.sha1,
-      perPage: 31,
-      verified: true,
-    });
+    const response = await Project.getCommits(
+      project.urn,
+      project.seed.httpApi,
+      {
+        // Fetching 31 elements since we remove the first one
+        parent: history.headers[history.headers.length - 1].header.sha1,
+        perPage: 31,
+        verified: true,
+      },
+    );
     // Removing the first element of the array, since it's the same as the last of the current list
     return response.headers.slice(1);
   };

--- a/src/base/projects/Project.svelte
+++ b/src/base/projects/Project.svelte
@@ -80,7 +80,7 @@
       <Browser {project} {commit} {tree} {browserStore} />
     {:else if content === proj.ProjectContent.History}
       <Async
-        fetch={proj.Project.getCommits(project.urn, project.seed.api, {
+        fetch={proj.Project.getCommits(project.urn, project.seed.httpApi, {
           parent: commit,
           verified: true,
         })}
@@ -106,7 +106,7 @@
 
   {#if content === proj.ProjectContent.Issues}
     <Async
-      fetch={issue.Issue.getIssues(project.urn, project.seed.api)}
+      fetch={issue.Issue.getIssues(project.urn, project.seed.httpApi)}
       let:result>
       <Issues {project} state={issueFilter} {config} issues={result} />
     </Async>
@@ -115,14 +115,14 @@
       fetch={issue.Issue.getIssue(
         project.urn,
         $browserStore.issue,
-        project.seed.api,
+        project.seed.httpApi,
       )}
       let:result>
       <Issue {project} {config} issue={result} />
     </Async>
   {:else if content === proj.ProjectContent.Patches}
     <Async
-      fetch={patch.Patch.getPatches(project.urn, project.seed.api)}
+      fetch={patch.Patch.getPatches(project.urn, project.seed.httpApi)}
       let:result>
       <Patches {project} {config} patches={result} />
     </Async>
@@ -131,7 +131,7 @@
       fetch={patch.Patch.getPatch(
         project.urn,
         $browserStore.patch,
-        project.seed.api,
+        project.seed.httpApi,
       )}
       let:result>
       <Patch {project} {config} patch={result} />

--- a/src/base/projects/Routes.svelte
+++ b/src/base/projects/Routes.svelte
@@ -10,11 +10,11 @@
 <!-- With a seed context -->
 
 <Route path="/seeds/:seed/:id/*" let:params>
-  <View {config} seedHost={params.seed} id={params.id} />
+  <View {config} host={params.seed} id={params.id} />
 </Route>
 
 <Route path="/seeds/:seed/:id/remotes/:peer/*" let:params>
-  <View {config} seedHost={params.seed} peer={params.peer} id={params.id} />
+  <View {config} host={params.seed} peer={params.peer} id={params.id} />
 </Route>
 
 <!-- Explicit user and org context, will at some point be replaced by the generic route -->

--- a/src/base/projects/View.svelte
+++ b/src/base/projects/View.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Config } from "@app/config";
+  import type { Host } from "@app/api";
   import { Route, Router } from "svelte-routing";
   import { Project, ProjectContent } from "@app/project";
   import Loading from "@app/Loading.svelte";
@@ -8,10 +9,21 @@
   import ProjectRoute from "./ProjectRoute.svelte";
 
   export let id: string; // Project name or URN.
-  export let seedHost: string | null = null;
+  export let host: string | null = null;
   export let profileName: string | null = null; // Address or name of parent profile.
   export let peer: string | null = null;
   export let config: Config;
+
+  let seedHost: Host | null = null;
+
+  if (host) {
+    if (host.split(":").length === 2) {
+      const [h, p] = host.split(":");
+      seedHost = { host: h, port: Number(p) };
+    } else {
+      seedHost = { host, port: null };
+    }
+  }
 </script>
 
 <style>

--- a/src/base/projects/Widget.svelte
+++ b/src/base/projects/Widget.svelte
@@ -7,12 +7,12 @@
   import { formatCommit } from "@app/utils";
 
   export let project: proj.ProjectInfo;
-  export let seed: { api: Host };
+  export let seed: { httpApi: Host };
   export let faded = false;
   export let compact = false;
 
   const loadCommits = async () => {
-    const commits = await Project.getActivity(project.urn, seed.api);
+    const commits = await Project.getActivity(project.urn, seed.httpApi);
 
     return groupCommitsByWeek(commits.activity);
   };

--- a/src/base/registrations/View.svelte
+++ b/src/base/registrations/View.svelte
@@ -131,7 +131,9 @@
           label: "Seed Host",
           validate: "domain",
           placeholder: "seed.acme.org",
-          url: r.profile.seed && `/seeds/${r.profile.seed.host}`,
+          url:
+            r.profile.seed &&
+            `/seeds/${r.profile.seed.host}:${config.seed.httpApi.port}`,
           description:
             "The seed host address. " +
             "Only domain names with TLS are supported. " +

--- a/src/base/registrations/View.svelte
+++ b/src/base/registrations/View.svelte
@@ -135,7 +135,7 @@
           description:
             "The seed host address. " +
             "Only domain names with TLS are supported. " +
-            `HTTP(S) API requests use port ${config.seed.api.port}.`,
+            `HTTP(S) API requests use port ${config.seed.httpApi.port}.`,
           value: r.profile.seed?.host ?? "",
           editable: true,
         },

--- a/src/base/registrations/registrar.ts
+++ b/src/base/registrations/registrar.ts
@@ -8,7 +8,7 @@ import { Failure } from "@app/error";
 import type { Config } from "@app/config";
 import { isFulfilled, unixTime } from "@app/utils";
 import { assert } from "@app/error";
-import { Seed, InvalidSeed } from "@app/base/seeds/Seed";
+import { Seed } from "@app/base/seeds/Seed";
 import * as cache from "@app/cache";
 
 export interface Registration {
@@ -21,7 +21,7 @@ export interface EnsProfile {
   id?: string;
   owner?: string;
   address?: string;
-  seed?: Seed | InvalidSeed;
+  seed?: Seed;
   url?: string;
   avatar?: string;
   twitter?: string;
@@ -126,9 +126,8 @@ export async function getRegistration(
         },
         config,
       );
-    } catch (e: any) {
-      console.debug(e, seedHost, seedId);
-      profile.seed = new InvalidSeed(seedHost, seedId);
+    } catch (error) {
+      console.debug({ error, seedHost, seedId });
     }
   }
 
@@ -153,7 +152,7 @@ export async function getSeed(
   name: string,
   config: Config,
   resolver?: EnsResolver | null,
-): Promise<Seed | InvalidSeed | null> {
+): Promise<Seed | null> {
   name = name.toLowerCase();
 
   resolver = resolver ?? (await getResolver(name, config));
@@ -175,9 +174,9 @@ export async function getSeed(
 
   try {
     return new Seed({ host, id, git, api }, config);
-  } catch (e: any) {
-    console.debug(e, host, id);
-    return new InvalidSeed(id, host);
+  } catch (error: unknown) {
+    console.debug({ error, host, id, api });
+    return null;
   }
 }
 

--- a/src/base/seeds/Seed.ts
+++ b/src/base/seeds/Seed.ts
@@ -10,21 +10,7 @@ export interface Stats {
   users: { count: number };
 }
 
-export class InvalidSeed {
-  valid = false as const;
-
-  host?: string;
-  id?: string;
-
-  constructor(host?: string, id?: string) {
-    this.host = host;
-    this.id = id;
-  }
-}
-
 export class Seed {
-  public valid = true as const;
-
   public httpApi: Host;
   public git: Host;
   public link: { host: string; id: string; port: number };

--- a/src/base/seeds/View.svelte
+++ b/src/base/seeds/View.svelte
@@ -179,7 +179,7 @@
       <div class="desktop" />
       <!-- API Port -->
       <div class="label">API Port</div>
-      <div>{seed.api.port}</div>
+      <div>{seed.httpApi.port}</div>
       <div class="desktop" />
       <!-- API Version -->
       <div class="label">Version</div>

--- a/src/base/seeds/View.svelte
+++ b/src/base/seeds/View.svelte
@@ -21,8 +21,16 @@
   export let session: Session | null;
   export let host: string;
 
-  const hostName = formatSeedHost(host);
-  const seedHost: Host = { host, port: null };
+  let seedHost: Host;
+
+  if (host.split(":").length === 2) {
+    const [h, p] = host.split(":");
+    seedHost = { host: h, port: Number(p) };
+  } else {
+    seedHost = { host, port: null };
+  }
+
+  const hostName = formatSeedHost(seedHost.host);
   let siweSession: SeedSession | null = null;
 
   const getProjectsAndStats = async (
@@ -38,7 +46,9 @@
 
   $: if (session?.siwe) {
     const entries = Object.entries(session.siwe);
-    const result = entries.find(([, session]) => session.domain === host);
+    const result = entries.find(
+      ([, session]) => session.domain === seedHost.host,
+    );
     if (result) {
       siweSession = result[1];
     }
@@ -117,7 +127,7 @@
   <title>{hostName}</title>
 </svelte:head>
 
-{#await Seed.lookup(host, config)}
+{#await Seed.lookup(seedHost, config)}
   <main class="off-centered">
     <Loading center />
   </main>
@@ -183,6 +193,6 @@
   </main>
 {:catch}
   <NotFound
-    title={host}
+    title={seedHost.host}
     subtitle="Not able to query information from this seed." />
 {/await}

--- a/src/base/seeds/View.svelte
+++ b/src/base/seeds/View.svelte
@@ -169,7 +169,7 @@
     <div class="fields">
       <!-- Seed Address -->
       <div class="label">Address</div>
-      <SeedAddress {seed} port={seed.link.port} />
+      <SeedAddress {seed} />
       <!-- Seed ID -->
       <div class="label">Seed ID</div>
       <div class="seed-label">

--- a/src/base/seeds/View/Projects.svelte
+++ b/src/base/seeds/View/Projects.svelte
@@ -38,7 +38,7 @@
     navigate(
       proj.path({
         urn: project.urn,
-        seed: seed?.host,
+        seed: seed.api,
         profile: profile?.name ?? profile?.address,
         revision: project.head,
       }),

--- a/src/base/seeds/View/Projects.svelte
+++ b/src/base/seeds/View/Projects.svelte
@@ -18,7 +18,7 @@
   const fetchMoreProjects = async (): Promise<proj.ProjectInfo[]> => {
     try {
       stats = await seed.getStats();
-      const projects = await proj.Project.getProjects(seed.api, {
+      const projects = await proj.Project.getProjects(seed.httpApi, {
         perPage: 10,
         page: (page += 1),
       });
@@ -38,7 +38,7 @@
     navigate(
       proj.path({
         urn: project.urn,
-        seed: seed.api,
+        seed: seed.httpApi,
         profile: profile?.name ?? profile?.address,
         revision: project.head,
       }),

--- a/src/components/Modal/SearchResults.svelte
+++ b/src/components/Modal/SearchResults.svelte
@@ -48,7 +48,10 @@
       <ul>
         {#each results.projects as project}
           <li>
-            <a use:link href="/seeds/{project.seed.host}/{project.info.urn}">
+            <a
+              use:link
+              href="/seeds/{project.seed.host}:{project.seed.port}/{project.info
+                .urn}">
               <span title={project.seed.host}>
                 <span>
                   {getSeedEmoji(project.seed.host, config)}&nbsp;{project.info

--- a/src/config.json
+++ b/src/config.json
@@ -44,79 +44,85 @@
     }
   },
   "seeds": {
-    "pinned": {
-      "willow.radicle.garden": {
-        "emoji": "🪵"
+    "pinned": [
+      {
+        "name": "willow.radicle.garden",
+        "emoji": "🪵",
+        "api": { "host": "willow.radicle.garden", "port": 8777 }
       },
-      "pine.radicle.garden": {
-        "emoji": "🌲"
+      {
+        "name": "pine.radicle.garden",
+        "emoji": "🌲",
+        "api": { "host": "pine.radicle.garden", "port": 8777 }
       },
-      "maple.radicle.garden": {
-        "emoji": "🍁"
+      {
+        "name": "maple.radicle.garden",
+        "emoji": "🍁",
+        "api": { "host": "maple.radicle.garden", "port": 8777 }
       }
-    }
+    ]
   },
   "projects": {
     "pinned": [
       {
         "name": "radicle-cli",
         "urn": "rad:git:hnrkmg77m8tfzj4gi4pa4mbhgysfgzwntjpao",
-        "seed": "clients.radicle.xyz"
+        "seed": { "host": "clients.radicle.xyz", "port": 8777 }
       },
       {
         "name": "radicle-interface",
         "urn": "rad:git:hnrkjajuucc6zp5eknt3s9xykqsrus44cjimy",
-        "seed": "clients.radicle.xyz"
+        "seed": { "host": "clients.radicle.xyz", "port": 8777 }
       },
       {
         "name": "radicle-client-services",
         "urn": "rad:git:hnrkk9c4zt9thuxhwi1ukxqcrs5tmhbtcsony",
-        "seed": "clients.radicle.xyz"
+        "seed": { "host": "clients.radicle.xyz", "port": 8777 }
       },
       {
         "name": "solmate",
         "urn": "rad:git:hnrkbgczcfh9ycjtdfynmqyg478bqrso1hnty",
-        "seed": "willow.radicle.garden"
+        "seed": { "host": "willow.radicle.garden", "port": 8777 }
       },
       {
         "name": "openzeppelin-contracts",
         "urn": "rad:git:hnrkbx9xzjg8tf9hj9uh5qdxwuyjddsxyaw6o",
-        "seed": "willow.radicle.garden"
+        "seed": { "host": "willow.radicle.garden", "port": 8777 }
       },
       {
         "name": "haskell-language-server",
         "urn": "rad:git:hnrkf1jaje1e93rua64zgphg7zb14qo9zexgy",
-        "seed": "pine.radicle.garden"
+        "seed": { "host": "pine.radicle.garden", "port": 8777 }
       },
       {
         "name": "rx",
         "urn": "rad:git:hnrk8aoks6w3tdbcwt9dqnor9aqy8tjha3k5o",
-        "seed": "maple.radicle.garden"
+        "seed": { "host": "maple.radicle.garden", "port": 8777 }
       },
       {
         "name": "astrolabe",
         "urn": "rad:git:hnrkrwewct7pb1biwmf59qa3rzod8mauundzy",
-        "seed": "willow.radicle.garden"
+        "seed": { "host": "willow.radicle.garden", "port": 8777 }
       },
       {
         "name": "svelte-dappkit",
         "urn": "rad:git:hnrkgcm1e588ewy7iiq4abrrgtf5ioq577eno",
-        "seed": "maple.radicle.garden"
+        "seed": { "host": "maple.radicle.garden", "port": 8777 }
       },
       {
         "name": "tmyxer",
         "urn": "rad:git:hnrkp5jgfxwxrffjsp148fyzdc457pa9ja38y",
-        "seed": "pine.radicle.garden"
+        "seed": { "host": "pine.radicle.garden", "port": 8777 }
       },
       {
         "name": "pax",
         "urn": "rad:git:hnrkffdfm4et8c4g1ebpbkjj46nagyiepmu5o",
-        "seed": "pine.radicle.garden"
+        "seed": { "host": "pine.radicle.garden", "port": 8777 }
       },
       {
         "name": "hexade",
         "urn": "rad:git:hnrkxj511yr48oo3usrt4jzfoucj88zphpryo",
-        "seed": "pine.radicle.garden"
+        "seed": { "host": "pine.radicle.garden", "port": 8777 }
       }
     ]
   },

--- a/src/config.json
+++ b/src/config.json
@@ -38,7 +38,7 @@
   "reactions": ["👍", "👎", "😄", "🎉", "🙁", "🚀", "👀"],
   "radicle": {
     "seed": {
-      "api": { "port": 8777 },
+      "httpApi": { "port": 8777 },
       "link": { "port": 8776 },
       "git": { "port": 443 }
     }
@@ -48,17 +48,17 @@
       {
         "name": "willow.radicle.garden",
         "emoji": "🪵",
-        "api": { "host": "willow.radicle.garden", "port": 8777 }
+        "httpApi": { "host": "willow.radicle.garden", "port": 8777 }
       },
       {
         "name": "pine.radicle.garden",
         "emoji": "🌲",
-        "api": { "host": "pine.radicle.garden", "port": 8777 }
+        "httpApi": { "host": "pine.radicle.garden", "port": 8777 }
       },
       {
         "name": "maple.radicle.garden",
         "emoji": "🍁",
-        "api": { "host": "maple.radicle.garden", "port": 8777 }
+        "httpApi": { "host": "maple.radicle.garden", "port": 8777 }
       }
     ]
   },
@@ -67,62 +67,62 @@
       {
         "name": "radicle-cli",
         "urn": "rad:git:hnrkmg77m8tfzj4gi4pa4mbhgysfgzwntjpao",
-        "seed": { "host": "clients.radicle.xyz", "port": 8777 }
+        "seed": { "httpApi": { "host": "clients.radicle.xyz", "port": 8777 } }
       },
       {
         "name": "radicle-interface",
         "urn": "rad:git:hnrkjajuucc6zp5eknt3s9xykqsrus44cjimy",
-        "seed": { "host": "clients.radicle.xyz", "port": 8777 }
+        "seed": { "httpApi": { "host": "clients.radicle.xyz", "port": 8777 } }
       },
       {
         "name": "radicle-client-services",
         "urn": "rad:git:hnrkk9c4zt9thuxhwi1ukxqcrs5tmhbtcsony",
-        "seed": { "host": "clients.radicle.xyz", "port": 8777 }
+        "seed": { "httpApi": { "host": "clients.radicle.xyz", "port": 8777 } }
       },
       {
         "name": "solmate",
         "urn": "rad:git:hnrkbgczcfh9ycjtdfynmqyg478bqrso1hnty",
-        "seed": { "host": "willow.radicle.garden", "port": 8777 }
+        "seed": { "httpApi": { "host": "willow.radicle.garden", "port": 8777 } }
       },
       {
         "name": "openzeppelin-contracts",
         "urn": "rad:git:hnrkbx9xzjg8tf9hj9uh5qdxwuyjddsxyaw6o",
-        "seed": { "host": "willow.radicle.garden", "port": 8777 }
+        "seed": { "httpApi": { "host": "willow.radicle.garden", "port": 8777 } }
       },
       {
         "name": "haskell-language-server",
         "urn": "rad:git:hnrkf1jaje1e93rua64zgphg7zb14qo9zexgy",
-        "seed": { "host": "pine.radicle.garden", "port": 8777 }
+        "seed": { "httpApi": { "host": "pine.radicle.garden", "port": 8777 } }
       },
       {
         "name": "rx",
         "urn": "rad:git:hnrk8aoks6w3tdbcwt9dqnor9aqy8tjha3k5o",
-        "seed": { "host": "maple.radicle.garden", "port": 8777 }
+        "seed": { "httpApi": { "host": "maple.radicle.garden", "port": 8777 } }
       },
       {
         "name": "astrolabe",
         "urn": "rad:git:hnrkrwewct7pb1biwmf59qa3rzod8mauundzy",
-        "seed": { "host": "willow.radicle.garden", "port": 8777 }
+        "seed": { "httpApi": { "host": "willow.radicle.garden", "port": 8777 } }
       },
       {
         "name": "svelte-dappkit",
         "urn": "rad:git:hnrkgcm1e588ewy7iiq4abrrgtf5ioq577eno",
-        "seed": { "host": "maple.radicle.garden", "port": 8777 }
+        "seed": { "httpApi": { "host": "maple.radicle.garden", "port": 8777 } }
       },
       {
         "name": "tmyxer",
         "urn": "rad:git:hnrkp5jgfxwxrffjsp148fyzdc457pa9ja38y",
-        "seed": { "host": "pine.radicle.garden", "port": 8777 }
+        "seed": { "httpApi": { "host": "pine.radicle.garden", "port": 8777 } }
       },
       {
         "name": "pax",
         "urn": "rad:git:hnrkffdfm4et8c4g1ebpbkjj46nagyiepmu5o",
-        "seed": { "host": "pine.radicle.garden", "port": 8777 }
+        "seed": { "httpApi": { "host": "pine.radicle.garden", "port": 8777 } }
       },
       {
         "name": "hexade",
         "urn": "rad:git:hnrkxj511yr48oo3usrt4jzfoucj88zphpryo",
-        "seed": { "host": "pine.radicle.garden", "port": 8777 }
+        "seed": { "httpApi": { "host": "pine.radicle.garden", "port": 8777 } }
       }
     ]
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import type { Host } from "@app/api";
 import { get, writable } from "svelte/store";
 import type { Writable } from "svelte/store";
 import { ethers } from "ethers";
@@ -26,8 +27,8 @@ export class Config {
   radToken: { address: string; faucet: string };
   reverseRegistrar: { address: string };
   users: { pinned: string[] };
-  projects: { pinned: { urn: string; name: string; seed: string }[] };
-  seeds: { pinned: Record<string, { emoji: string }> };
+  projects: { pinned: { urn: string; name: string; seed: Host }[] };
+  seeds: { pinned: { name: string; emoji: string; api: Host }[] };
   provider: ethers.providers.JsonRpcProvider;
   signer: (ethers.Signer & TypedDataSigner) | WalletConnectSigner | null;
   walletConnect: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,8 +27,10 @@ export class Config {
   radToken: { address: string; faucet: string };
   reverseRegistrar: { address: string };
   users: { pinned: string[] };
-  projects: { pinned: { urn: string; name: string; seed: Host }[] };
-  seeds: { pinned: { name: string; emoji: string; api: Host }[] };
+  projects: {
+    pinned: { urn: string; name: string; seed: { httpApi: Host } }[];
+  };
+  seeds: { pinned: { name: string; emoji: string; httpApi: Host }[] };
   provider: ethers.providers.JsonRpcProvider;
   signer: (ethers.Signer & TypedDataSigner) | WalletConnectSigner | null;
   walletConnect: {
@@ -49,7 +51,7 @@ export class Config {
       };
   abi: { [contract: string]: string[] };
   seed: {
-    api: { port: number };
+    httpApi: { port: number };
     git: { port: number };
     link: { port: number };
   };

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -9,7 +9,7 @@ import {
 } from "@app/utils";
 import type { Config } from "@app/config";
 import { cached } from "@app/cache";
-import type { Seed, InvalidSeed } from "@app/base/seeds/Seed";
+import type { Seed } from "@app/base/seeds/Seed";
 import { Org } from "@app/base/orgs/Org";
 import { NotFoundError, MissingReverseRecord } from "@app/error";
 
@@ -92,8 +92,7 @@ export class Profile {
     }
   }
 
-  // We add null here to differentiate between a `undefined` and a invalid / null seed
-  get seed(): Seed | InvalidSeed | null {
+  get seed(): Seed | null {
     return this.profile?.ens?.seed ?? null;
   }
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -453,11 +453,8 @@ export class Project implements ProjectInfo {
       ? await Seed.lookup(seedHost, config)
       : null;
 
-    if (!profile && !seed) {
+    if (!seed) {
       throw new Error("Couldn't load project");
-    }
-    if (!seed?.valid) {
-      throw new Error("Couldn't load project: invalid seed");
     }
 
     const info = await Project.getInfo(id, seed.httpApi);

--- a/src/project.ts
+++ b/src/project.ts
@@ -383,7 +383,7 @@ export class Project implements ProjectInfo {
   async getCommit(commit: string): Promise<Commit> {
     return new Request(
       `projects/${this.urn}/commits/${commit}`,
-      this.seed.api,
+      this.seed.httpApi,
     ).get();
   }
 
@@ -391,7 +391,7 @@ export class Project implements ProjectInfo {
     if (path === "/") path = "";
     return new Request(
       `projects/${this.urn}/tree/${commit}/${path}`,
-      this.seed.api,
+      this.seed.httpApi,
     ).get();
   }
 
@@ -404,14 +404,14 @@ export class Project implements ProjectInfo {
   ): Promise<Blob> {
     return new Request(
       `projects/${this.urn}/blob/${commit}/${path}`,
-      this.seed.api,
+      this.seed.httpApi,
     ).get(options);
   }
 
   async getReadme(commit: string): Promise<Blob> {
     return new Request(
       `projects/${this.urn}/readme/${commit}`,
-      this.seed.api,
+      this.seed.httpApi,
     ).get();
   }
 
@@ -430,7 +430,7 @@ export class Project implements ProjectInfo {
     if (this.profile) {
       options.profile = this.profile?.nameOrAddress;
     } else {
-      options.seed = this.seed.api;
+      options.seed = this.seed.httpApi;
     }
 
     return path(options);
@@ -460,14 +460,14 @@ export class Project implements ProjectInfo {
       throw new Error("Couldn't load project: invalid seed");
     }
 
-    const info = await Project.getInfo(id, seed.api);
+    const info = await Project.getInfo(id, seed.httpApi);
     const urn = isRadicleId(id) ? id : info.urn;
 
     // Older versions of http-api don't include the URN.
     if (!info.urn) info.urn = urn;
 
     const peers: Peer[] = info.delegates
-      ? await Project.getRemotes(urn, seed.api)
+      ? await Project.getRemotes(urn, seed.httpApi)
       : [];
 
     let remote: Remote = {
@@ -476,7 +476,7 @@ export class Project implements ProjectInfo {
 
     if (peer) {
       try {
-        remote = await Project.getRemote(urn, peer, seed.api);
+        remote = await Project.getRemote(urn, peer, seed.httpApi);
       } catch {
         remote.heads = {};
       }
@@ -486,14 +486,14 @@ export class Project implements ProjectInfo {
   }
 
   static async getMulti(
-    projs: { nameOrUrn: Urn; seed: Host }[],
+    projs: { nameOrUrn: Urn; seedHttpApi: Host }[],
   ): Promise<{ info: ProjectInfo; seed: Host }[]> {
     const promises = [];
 
     for (const proj of projs) {
       promises.push(
-        Project.getInfo(proj.nameOrUrn, proj.seed).then(info => {
-          return { info, seed: proj.seed };
+        Project.getInfo(proj.nameOrUrn, proj.seedHttpApi).then(info => {
+          return { info, seed: proj.seedHttpApi };
         }),
       );
     }

--- a/src/siwe.ts
+++ b/src/siwe.ts
@@ -28,7 +28,7 @@ export function createSiweMessage(
   nextWeek.setDate(nextWeek.getDate() + 7);
 
   const message = new SiweMessage({
-    domain: seed.api.host,
+    domain: seed.httpApi.host,
     address,
     statement: "It's a Radicle world!",
     uri: window.location.origin,
@@ -57,14 +57,14 @@ export async function signInWithEthereum(
   }
 
   const address = await config.signer.getAddress();
-  const result = await createUnauthorizedSession(seed.api);
+  const result = await createUnauthorizedSession(seed.httpApi);
   const message = createSiweMessage(seed, address, result.nonce, config);
   const signature = await config.signer.signMessage(message);
 
   const auth: {
     id: string;
     session: SeedSession;
-  } = await new Request(`sessions/${result.id}`, seed.api).put({
+  } = await new Request(`sessions/${result.id}`, seed.httpApi).put({
     message,
     signature,
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -325,8 +325,9 @@ export function parseEmoji(input: string): string {
 // @dev: This helper fn lets us get a seed emoji quick without multiLookups or complex type usage.
 // TODO: Should be revisited, when we have a stable implementation for seed avatars.
 export function getSeedEmoji(input: string, config: Config): string {
-  if (config.seeds.pinned[input]) {
-    return config.seeds.pinned[input].emoji;
+  const seed = config.seeds.pinned.find(s => s.name === input);
+  if (seed) {
+    return seed.emoji;
   }
   return "🌱";
 }


### PR DESCRIPTION
Closes: https://github.com/radicle-dev/radicle-interface/issues/440.

Note: this change makes the port explicit for all seed nodes.

http://127.0.0.1:3000/0x5d6623eab298ba3064ab19813bf9326988397c87
http://127.0.0.1:3000/seeds/api.radicle.thegraph.com:443
http://127.0.0.1:3000/seeds/api.radicle.thegraph.com:443/rad:git:hnrkxgekdi5gikjcqru4swpm1kfrhqqry7qto/tree/8c62a29ddc6c4d3c9322209bcd59ce5a55f2a0e3

<img width="1840" alt="Screenshot 2022-10-17 at 18 28 27" src="https://user-images.githubusercontent.com/158411/196232065-8e837e74-f25f-45fe-80e0-92bbc22ad05e.png">
<img width="1840" alt="Screenshot 2022-10-17 at 18 28 20" src="https://user-images.githubusercontent.com/158411/196232101-e45b5d03-6ae7-4faa-90c6-a7150f62a83f.png">
<img width="1840" alt="Screenshot 2022-10-14 at 17 40 16" src="https://user-images.githubusercontent.com/158411/195886625-0bc950a3-90a3-49ea-bb15-63ce2f7efc7f.png">
<img width="1840" alt="Screenshot 2022-10-14 at 17 40 12" src="https://user-images.githubusercontent.com/158411/195886604-88b97adf-01ef-4f67-b10d-846534046604.png">

