### PR TITLE
Handle empty string in `Markdown` component

### DIFF
--- a/src/Markdown.svelte
+++ b/src/Markdown.svelte
@@ -248,21 +248,19 @@
   }
 </style>
 
-{#if content}
-  {#if frontMatter.length > 0}
-    <div class="front-matter">
-      <table>
-        {#each frontMatter as [key, val]}
-          <tr>
-            <td><span class="txt-bold">{key}</span></td>
-            <td>{val}</td>
-          </tr>
-        {/each}
-      </table>
-    </div>
-  {/if}
-
-  <div class="markdown" bind:this={container}>
-    {@html render(doc.content)}
+{#if frontMatter.length > 0}
+  <div class="front-matter">
+    <table>
+      {#each frontMatter as [key, val]}
+        <tr>
+          <td><span class="txt-bold">{key}</span></td>
+          <td>{val}</td>
+        </tr>
+      {/each}
+    </table>
   </div>
 {/if}
+
+<div class="markdown" bind:this={container}>
+  {@html render(doc.content)}
+</div>


### PR DESCRIPTION
We expect the `Markdown` component to receive a `content: string`, but we also check if `content` is truthy before rendering anything, and this can get messy when `content` is an empty string.

Fixed by removing the truthy check for `content`.

Closes #465 

Signed-off-by: Sebastian Martinez <me@sebastinez.dev>