### PR TITLE
Allow switch between rendered markdown and raw content

### DIFF
--- a/cypress/e2e/projectHeader.spec.ts
+++ b/cypress/e2e/projectHeader.spec.ts
@@ -78,9 +78,15 @@ describe("project header", () => {
       "@projectTree56e4e02",
       "@projectReadme",
     ]);
-    cy.get("div.stat.seed span").should("have.text", "willow.radicle.garden");
-    cy.get("div.stat.commit-count").should("have.text", "3\n    commit(s)");
-    cy.get("div.stat.contributor-count").should(
+    cy.get('[aria-label="Seed"] span').should(
+      "have.text",
+      "willow.radicle.garden",
+    );
+    cy.get('[aria-label="Commit count"]').should(
+      "have.text",
+      "3\n    commit(s)",
+    );
+    cy.get('[aria-label="Contributor count"]').should(
       "have.text",
       "1\n    contributor(s)",
     );
@@ -138,35 +144,37 @@ describe("project header", () => {
   });
 
   it("navigate to commit history", () => {
-    cy.get("div.stat.commit-count").should("not.have.class", "active").click();
+    cy.get('[aria-label="Commit count"]')
+      .should("not.have.class", "active")
+      .click();
     cy.wait(["@projectCommits"]);
     cy.location().should(location => {
       expect(location.pathname).to.eq(
         "/seeds/willow.radicle.garden/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/remotes/hyndc7nx9keq76p1bkw9831arcndeeu3trwsc7kxt3osmpi6j9oeke/history/master",
       );
     });
-    cy.get("div.stat.commit-count").should("have.class", "active");
+    cy.get('[aria-label="Commit count"]').should("have.class", "active");
   });
 
   it("navigate to issues listing", () => {
-    cy.get("div.stat.issue-count").click();
+    cy.get('[aria-label="Issue count"]').click();
     cy.wait(["@projectIssues"]);
     cy.location().should(location => {
       expect(location.pathname).to.eq(
         "/seeds/willow.radicle.garden/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/remotes/hyndc7nx9keq76p1bkw9831arcndeeu3trwsc7kxt3osmpi6j9oeke/issues",
       );
     });
-    cy.get("div.stat.issue-count").should("have.class", "active");
+    cy.get('[aria-label="Issue count"]').should("have.class", "active");
   });
 
   it("navigate to patches listing", () => {
-    cy.get("div.stat.patch-count").click();
+    cy.get('[aria-label="Patch count"]').click();
     cy.wait(["@projectPatches"]);
     cy.location().should(location => {
       expect(location.pathname).to.eq(
         "/seeds/willow.radicle.garden/rad:git:hnrk8mbpirp7ua7sy66o4t9soasbq4y8uwgoy/remotes/hyndc7nx9keq76p1bkw9831arcndeeu3trwsc7kxt3osmpi6j9oeke/patches",
       );
     });
-    cy.get("div.stat.patch-count").should("have.class", "active");
+    cy.get('[aria-label="Patch count"]').should("have.class", "active");
   });
 });

--- a/src/base/projects/Browser.svelte
+++ b/src/base/projects/Browser.svelte
@@ -12,7 +12,6 @@
 
   import Tree from "./Tree.svelte";
   import Blob from "./Blob.svelte";
-  import Readme from "./Readme.svelte";
 
   enum Status {
     Loading,
@@ -207,11 +206,7 @@
         {#await getBlob}
           <Loading small center />
         {:then blob}
-          {#if utils.isMarkdownPath(blob.path)}
-            <Readme {activeRoute} content={blob.content} {getImage} />
-          {:else}
-            <Blob {line} {blob} />
-          {/if}
+          <Blob {line} {blob} {getImage} {activeRoute} />
         {:catch}
           <Placeholder icon="🍂">
             <span slot="title">

--- a/src/base/projects/Header.svelte
+++ b/src/base/projects/Header.svelte
@@ -8,6 +8,7 @@
   import CloneButton from "@app/base/projects/CloneButton.svelte";
   import PeerSelector from "@app/base/projects/PeerSelector.svelte";
   import { closeFocused } from "@app/Floating.svelte";
+  import Stat from "@app/base/projects/Stat.svelte";
 
   export let activeRoute: ProjectRoute;
   export let project: Project;
@@ -75,12 +76,6 @@
     border-radius: var(--border-radius-small);
     min-width: max-content;
   }
-  .clickable {
-    cursor: pointer;
-  }
-  .clickable:hover {
-    background-color: var(--color-foreground-2);
-  }
   .not-allowed {
     cursor: not-allowed;
   }
@@ -128,49 +123,43 @@
   {/if}
   <span>
     {#if seed.api.host}
-      <!-- svelte-ignore a11y-click-events-have-key-events -->
-      <div
-        class="stat seed clickable widget"
+      <Stat
+        clickable
         title="Project data is fetched from this seed"
         on:click={goToSeed}>
         <span>{seed.api.host}</span>
-      </div>
+      </Stat>
     {/if}
   </span>
-  <!-- svelte-ignore a11y-click-events-have-key-events -->
-  <div
-    class="stat commit-count clickable widget"
-    class:active={activeRoute.params.view.resource === "history"}
+  <Stat
+    clickable
+    active={activeRoute.params.view.resource === "history"}
     on:click={() => toggleContent("history", true)}>
     <span class="txt-bold">{tree.stats.commits}</span>
     commit(s)
-  </div>
+  </Stat>
   {#if project.issues}
-    <!-- svelte-ignore a11y-click-events-have-key-events -->
-    <div
-      class="stat issue-count clickable widget"
-      class:active={activeRoute.params.view.resource === "issues"}
-      class:not-allowed={project.issues === 0}
-      class:clickable={project.issues > 0}
+    <Stat
+      active={activeRoute.params.view.resource === "issues"}
+      notAllowed={project.issues === 0}
+      clickable={project.issues > 0}
       on:click={() => toggleContent("issues", false)}>
       <span class="txt-bold">{project.issues}</span>
       issue(s)
-    </div>
+    </Stat>
   {/if}
   {#if project.patches}
-    <!-- svelte-ignore a11y-click-events-have-key-events -->
-    <div
-      class="stat patch-count clickable widget"
-      class:active={activeRoute.params.view.resource === "patches"}
-      class:not-allowed={project.patches === 0}
-      class:clickable={project.patches > 0}
+    <Stat
+      clickable={project.patches > 0}
+      active={activeRoute.params.view.resource === "patches"}
+      disabled={project.patches === 0}
       on:click={() => toggleContent("patches", false)}>
       <span class="txt-bold">{project.patches}</span>
       patch(es)
-    </div>
+    </Stat>
   {/if}
-  <div class="stat contributor-count widget">
+  <Stat>
     <span class="txt-bold">{tree.stats.contributors}</span>
     contributor(s)
-  </div>
+  </Stat>
 </header>

--- a/src/base/projects/Header.svelte
+++ b/src/base/projects/Header.svelte
@@ -8,7 +8,7 @@
   import CloneButton from "@app/base/projects/CloneButton.svelte";
   import PeerSelector from "@app/base/projects/PeerSelector.svelte";
   import { closeFocused } from "@app/Floating.svelte";
-  import Stat from "@app/base/projects/Stat.svelte";
+  import HeaderToggleLabel from "@app/base/projects/HeaderToggleLabel.svelte";
 
   export let activeRoute: ProjectRoute;
   export let project: Project;
@@ -72,27 +72,6 @@
     flex-wrap: wrap;
     gap: 0.5rem;
   }
-  .widget {
-    border-radius: var(--border-radius-small);
-    min-width: max-content;
-  }
-  .not-allowed {
-    cursor: not-allowed;
-  }
-  .not-allowed.widget {
-    color: var(--color-foreground-5);
-  }
-  .stat {
-    font-family: var(--font-family-monospace);
-    padding: 0.5rem 0.75rem;
-    height: 2rem;
-    line-height: initial;
-    background: var(--color-foreground-1);
-  }
-  .stat.active {
-    color: var(--color-background);
-    background: var(--color-foreground);
-  }
 
   @media (max-width: 960px) {
     header {
@@ -123,43 +102,47 @@
   {/if}
   <span>
     {#if seed.api.host}
-      <Stat
+      <HeaderToggleLabel
         clickable
+        ariaLabel="Seed"
         title="Project data is fetched from this seed"
         on:click={goToSeed}>
         <span>{seed.api.host}</span>
-      </Stat>
+      </HeaderToggleLabel>
     {/if}
   </span>
-  <Stat
+  <HeaderToggleLabel
+    ariaLabel="Commit count"
     clickable
     active={activeRoute.params.view.resource === "history"}
     on:click={() => toggleContent("history", true)}>
     <span class="txt-bold">{tree.stats.commits}</span>
     commit(s)
-  </Stat>
+  </HeaderToggleLabel>
   {#if project.issues}
-    <Stat
+    <HeaderToggleLabel
+      ariaLabel="Issue count"
       active={activeRoute.params.view.resource === "issues"}
-      notAllowed={project.issues === 0}
+      disabled={project.issues === 0}
       clickable={project.issues > 0}
       on:click={() => toggleContent("issues", false)}>
       <span class="txt-bold">{project.issues}</span>
       issue(s)
-    </Stat>
+    </HeaderToggleLabel>
   {/if}
   {#if project.patches}
-    <Stat
+    <HeaderToggleLabel
+      ariaLabel="Patch count"
       clickable={project.patches > 0}
       active={activeRoute.params.view.resource === "patches"}
       disabled={project.patches === 0}
       on:click={() => toggleContent("patches", false)}>
       <span class="txt-bold">{project.patches}</span>
       patch(es)
-    </Stat>
+    </HeaderToggleLabel>
   {/if}
-  <Stat>
+  <HeaderToggleLabel ariaLabel="Contributor count">
     <span class="txt-bold">{tree.stats.contributors}</span>
     contributor(s)
-  </Stat>
+  </HeaderToggleLabel>
 </header>

--- a/src/base/projects/HeaderToggleLabel.svelte
+++ b/src/base/projects/HeaderToggleLabel.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
-
   export let title: string | undefined = undefined;
+  export let ariaLabel: string | undefined = undefined;
   export let active = false;
   export let clickable = false;
-  export let notAllowed = false;
-
-  const dispatch = createEventDispatcher();
+  export let disabled = false;
 </script>
 
 <style>
@@ -14,7 +11,7 @@
     font-family: var(--font-family-monospace);
     font-size: var(--font-size-tiny);
     padding: 0.5rem 0.75rem;
-    padding-bottom: 1rem; /* moving the inner text a tad higher to match the previous span usage */
+    padding-bottom: 1rem; /* moving the content a tad higher to match the previous span usage */
     height: 2rem;
     background: var(--color-foreground-1);
     border: none;
@@ -41,12 +38,12 @@
 
 <button
   {title}
+  {disabled}
   class:active
-  class:not-allowed={notAllowed}
   class:clickable
-  class="stat clickable"
-  on:click={() => {
-    if (!notAllowed) dispatch("click");
-  }}>
+  class:not-allowed={disabled}
+  class="stat"
+  aria-label={ariaLabel}
+  on:click>
   <slot />
 </button>

--- a/src/base/projects/Readme.svelte
+++ b/src/base/projects/Readme.svelte
@@ -14,9 +14,8 @@
 <style>
   article {
     padding: 2rem;
-    max-width: 64rem;
+    width: 100%;
     background: var(--color-foreground-1);
-    border-radius: var(--border-radius);
   }
 </style>
 

--- a/src/base/projects/Stat.svelte
+++ b/src/base/projects/Stat.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  export let title: string | undefined = undefined;
+  export let active = false;
+  export let clickable = false;
+  export let notAllowed = false;
+
+  const dispatch = createEventDispatcher();
+</script>
+
+<style>
+  .stat {
+    font-family: var(--font-family-monospace);
+    font-size: var(--font-size-tiny);
+    padding: 0.5rem 0.75rem;
+    padding-bottom: 1rem; /* moving the inner text a tad higher to match the previous span usage */
+    height: 2rem;
+    background: var(--color-foreground-1);
+    border: none;
+    color: var(--color-foreground);
+    border-radius: var(--border-radius-small);
+    min-width: max-content;
+  }
+  .active {
+    color: var(--color-background);
+    background: var(--color-foreground) !important;
+    background-color: var(--color-foreground);
+  }
+  .clickable {
+    cursor: pointer;
+  }
+  .clickable:hover {
+    background-color: var(--color-foreground-2);
+  }
+  .not-allowed {
+    cursor: not-allowed;
+    color: var(--color-foreground-5);
+  }
+</style>
+
+<button
+  {title}
+  class:active
+  class:not-allowed={notAllowed}
+  class:clickable
+  class="stat clickable"
+  on:click={() => {
+    if (!notAllowed) dispatch("click");
+  }}>
+  <slot />
+</button>


### PR DESCRIPTION
This PR adds a toggle button on the top right of the file preview shown in the Browser.
This allows to see the markdown file in its raw format and also reference a specific line of the file by URL.

It also refactors the project header stats into their own component `Stat.svelte`

<img width="1152" alt="Bildschirm­foto 2022-11-04 um 13 09 05" src="https://user-images.githubusercontent.com/7912302/199969323-27b912a0-84c4-47b5-be2e-57e1a2e4f5d8.png">

<img width="1152" alt="Bildschirm­foto 2022-11-04 um 14 08 30" src="https://user-images.githubusercontent.com/7912302/199979878-a94a008d-edf3-44da-853e-39bcc885c644.png">

<img width="1154" alt="Bildschirm­foto 2022-11-04 um 14 10 15" src="https://user-images.githubusercontent.com/7912302/199980262-bba2bcf5-d30b-409f-973a-1017a36328f0.png">

<img width="1159" alt="Bildschirm­foto 2022-11-04 um 14 10 48" src="https://user-images.githubusercontent.com/7912302/199980339-97d3dc72-73a1-4e53-9f58-849ed67d4287.png">

Closes #423 