### PR TITLE
Avoid the re-rendering of the ProjectMeta component

### DIFF
--- a/src/base/projects/View.svelte
+++ b/src/base/projects/View.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Wallet } from "@app/wallet";
-  import type { ProjectRoute, ProjectsParams } from "@app/router/definitions";
+  import type { ProjectRoute } from "@app/router/definitions";
   import type { State as IssueState } from "./Issues.svelte";
   import type { State as PatchState } from "./Patches.svelte";
 
@@ -29,35 +29,36 @@
 
   $: urn = activeRoute.params.urn;
   $: peer = activeRoute.params.peer ?? null;
+  $: seed = activeRoute.params.seed ?? null;
+  $: profile = activeRoute.params.profile ?? null;
 
   $: searchParams = new URLSearchParams(activeRoute.params.search || "");
   $: issueFilter = (searchParams.get("state") as IssueState) || "open";
   $: patchFilter = (searchParams.get("state") as PatchState) || "proposed";
 
-  const getProject = async (params: ProjectsParams) => {
-    const project = await proj.Project.get(
-      params.urn,
-      params.peer ?? null,
-      params.profile ?? null,
-      params.seed ?? null,
-      wallet,
-    );
-    if (params.route) {
+  const getProject = async (
+    urn: string,
+    peer: string | null,
+    profile: string | null,
+    seed: string | null,
+  ) => {
+    const project = await proj.Project.get(urn, peer, profile, seed, wallet);
+    if (activeRoute.params.route) {
       const { revision, path } = proj.parseRoute(
-        params.route,
+        activeRoute.params.route,
         project.branches,
       );
       router.updateProjectRoute({
         revision,
         path,
-        hash: params.hash,
+        hash: activeRoute.params.hash,
         route: undefined,
       });
     }
-    if (!params.revision) {
+    if (!activeRoute.params.revision) {
       // We need a revision to fetch `getRoot`.
       // Don't use router.updateProjectRoute, to avoid changing the URL.
-      params.revision = project.defaultBranch;
+      activeRoute.params.revision = project.defaultBranch;
     }
 
     return project;
@@ -96,7 +97,7 @@
 </style>
 
 <main>
-  {#await getProject(activeRoute.params)}
+  {#await getProject(urn, peer, profile, seed)}
     <header>
       <Loading center />
     </header>


### PR DESCRIPTION
By passing a too broad scope into the `getProject` function in the  project view we are re-rendering everything always

This PR reduces the scope to the required `urn`, `seed`, `profile` and `peer` information

https://user-images.githubusercontent.com/7912302/200275163-c3684aa4-0b9a-4307-856c-d268e08a2ee1.mov

