### PR TITLE
Add `line-height: 1.625` to `li` and `ol` elements

### DIFF
--- a/src/Markdown.svelte
+++ b/src/Markdown.svelte
@@ -205,12 +205,14 @@
   }
 
   .markdown :global(ol) {
+    line-height: 1.625;
     list-style-type: decimal;
     margin-bottom: 1rem;
     padding-left: 1.5rem;
   }
 
   .markdown :global(ul) {
+    line-height: 1.625;
     list-style-type: inherit;
     padding-left: 1.25rem;
     margin-bottom: 1rem;


### PR DESCRIPTION
Current design with `line-height: 1.5`
<img width="996" alt="Bildschirm­foto 2022-11-07 um 11 58 29" src="https://user-images.githubusercontent.com/7912302/200294000-224c9cb2-9096-402f-a1bd-4002b62002ad.png">

New `line-height: 1.625`
<img width="1002" alt="Bildschirm­foto 2022-11-07 um 11 57 56" src="https://user-images.githubusercontent.com/7912302/200293905-bb924f59-361e-4374-9318-a981b76f8fdc.png">

Closes #459 