### PR TITLE
Add smoke check for production builds

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -12,3 +12,10 @@ jobs:
       - uses: actions/checkout@v2
       - run: npm ci
       - run: npm run build
+      - name: Cypress run
+        uses: cypress-io/github-action@v4
+        with:
+          browser: chrome
+          start: npm run serve
+          wait-on: "http://localhost:4173"
+          command: npx cypress run --config baseUrl="http://localhost:4173" --spec 'cypress/e2e/home.spec.ts'


### PR DESCRIPTION
This PR extends the build CI pipeline, to assert that the production build created by `npm run build`  and served by `npm run serve`, passes through the `home.spec.test` e2e test.

Closes #456 