### PR TITLE
Improve display of lastCommit in Blob component

### DIFF
--- a/src/base/projects/Blob.svelte
+++ b/src/base/projects/Blob.svelte
@@ -56,10 +56,15 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    justify-content: flex-end;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
   }
 
   header .file-name {
     font-weight: var(--font-weight-normal);
+    flex-shrink: 0;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -157,6 +162,12 @@
     }
     .highlight {
       display: none;
+    }
+  }
+
+  @media (max-width: 720px) {
+    .right {
+      justify-content: center;
     }
   }
 </style>


### PR DESCRIPTION
With the addition of the new `Raw` button there came some responsiveness issues this PR should take care of.

## New way
<img width="1052" alt="Bildschirm­foto 2022-11-07 um 23 27 06" src="https://user-images.githubusercontent.com/7912302/200428793-e8648580-ec7f-42c4-a59d-a17c2513cb48.png">
<img width="485" alt="Bildschirm­foto 2022-11-07 um 23 27 22" src="https://user-images.githubusercontent.com/7912302/200428823-a097fe6e-fe7e-4c59-8ee1-a81c29a70de7.png">
<img width="492" alt="Bildschirm­foto 2022-11-07 um 23 27 36" src="https://user-images.githubusercontent.com/7912302/200428857-dcacb720-7f6e-4860-b477-69fd88c83931.png">

## Current way
<img width="1049" alt="Bildschirm­foto 2022-11-07 um 23 28 08" src="https://user-images.githubusercontent.com/7912302/200428938-877cabae-40e8-4a05-bd97-a096081f58b1.png">
<img width="604" alt="Bildschirm­foto 2022-11-07 um 23 28 22" src="https://user-images.githubusercontent.com/7912302/200428982-d96fe52b-5fd0-4d25-b374-e67a680b4f1f.png">
<img width="581" alt="Bildschirm­foto 2022-11-07 um 23 28 47" src="https://user-images.githubusercontent.com/7912302/200429049-a924b650-e6fd-4193-a7ae-61641b6356e9.png">
