### PR TITLE
Change monospace font to JetBrains Mono

### DIFF
--- a/public/typography.css
+++ b/public/typography.css
@@ -22,7 +22,7 @@
 
 :root {
   --font-family-sans-serif: Inter, sans-serif;
-  --font-family-monospace: monospace;
+  --font-family-monospace: "JetBrains Mono", monospace;
   --font-weight-normal: 400;
   --font-weight-medium: 600;
   --font-weight-bold: 700;


### PR DESCRIPTION
This PR changes the default monospace font used in the web client to [JetBrains Mono](https://www.jetbrains.com/lp/mono/)
If JetBrainsMono isn't installed locally it falls back to the default monospace font, in MacOS it's Courier

Closes #282 