### PR TITLE
Add a first exploration of the component documentation

### DIFF
--- a/src/Address.svelte
+++ b/src/Address.svelte
@@ -1,8 +1,31 @@
+<!--
+ @component
+ ## Usage
+ An inline element to show a ETH address or profile information (name and avatar).  
+ Displays a blockie avatar if no profile or avatar is found  
+ Allows the navigate to profiles or external sites, e.g. multisig safes
+ 
+ ## Best Practices
+ - Where possible we should pass in a resolved `profile`.
+ 
+ ## Props
+ @param address - ETH address in hex format
+ @param wallet - Wallet configuration
+ @param profile - A resolved profile, to reduce unnecessary profile resolving
+ @param resolve - Defines if address should be resolved
+ @param noBadge - Surpresses the display of address type as badge
+ @param noAvatar - Surpresses the display of any type of avatar
+ @param compact - Shrinks information like hex string address
+ @param small - Reduces size of text content to `txt-small`
+ @param tiny - Reduces size even further to `txt-tiny`
+ @param highlight - Highlights text content
+-->
 <script lang="ts">
   import type { Wallet } from "@app/wallet";
 
-  import { onMount } from "svelte";
-  import { ethers } from "ethers";
+  import Avatar from "@app/Avatar.svelte";
+  import Badge from "@app/Badge.svelte";
+  import Link from "@app/router/Link.svelte";
   import {
     AddressType,
     explorerLink,
@@ -11,12 +34,12 @@
     parseEnsLabel,
   } from "@app/utils";
   import { Profile, ProfileType } from "@app/profile";
-  import Avatar from "@app/Avatar.svelte";
-  import Badge from "@app/Badge.svelte";
-  import Link from "@app/router/Link.svelte";
+  import { ethers } from "ethers";
+  import { onMount } from "svelte";
 
   export let address: string;
   export let wallet: Wallet;
+  export let profile: Profile | null = null;
   export let resolve = false;
   export let noBadge = false;
   export let noAvatar = false;
@@ -24,8 +47,6 @@
   export let small = false;
   export let tiny = false;
   export let highlight = false;
-  // This property allows components eg. Header.svelte to pass a resolved profile object.
-  export let profile: Profile | null = null;
 
   let addressType: AddressType | null = null;
 
@@ -43,7 +64,7 @@
         );
       }
     } else {
-      // If there is a profile we can use the profile.type to avoid identifying it again.
+      // If there is a profile we can use `profile.type` to avoid identifying it again.
       addressType = profile.type;
     }
   });

--- a/src/Avatar.svelte
+++ b/src/Avatar.svelte
@@ -1,3 +1,22 @@
+<!--
+ @component
+ ## Usage
+ A `img` wrapper to provide additional functionality to display avatars  
+ If the passed source isn't Address, URN or Peer ID it falls back to blockies
+ 
+ ## Best Practices
+ - The `grayscale` prop should be used for disabled things
+ - THe `title` prop shouldn't be "avatar", since `alt` is already equal to `avatar`
+ 
+ ## Error Handling
+ - If the image source isn't found, we fallback to a blockie
+ 
+ ## Props
+ @param title - The `image` `title` attribute
+ @param source - The `image` `src` attribute
+ @param inline - Changes the `image` element from `display: block` to `inline-block`
+ @param grayscale - Converts the avatar image to grayscale, used for a disabled look
+-->
 <script lang="ts">
   import { createIcon } from "@app/blockies";
   import { isAddress, isPeerId, isRadicleId } from "@app/utils";

--- a/src/Badge.svelte
+++ b/src/Badge.svelte
@@ -1,3 +1,11 @@
+<!--
+ @component
+ ## Usage
+ A generic badge, with rounded edges, used besides text as identifier
+ 
+ ## Props
+ @param variant - Intent the text needs to convey
+-->
 <script lang="ts">
   export let variant:
     | "caution"


### PR DESCRIPTION
So this is a first work on documenting components.

I think it doesn't make much sense to do so for every component, but the ones that are more often used could benefit from it.

So far I think a good structure would be:
```
## Usage
`one or multiple lines on how this component should be used`

## Best practices
`a list of things that should be taken into account, for code style, perf, etc.`

## Props
`the props that the component expects, eventually also the defaults.
```

Feel free to add your opinion on it