### PR TITLE
Fix twemoji base

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -540,7 +540,7 @@ export const markdownExtensions = [emojisMarkedExtension, katexMarkedExtension];
 
 export function twemoji(node: HTMLElement) {
   twemojiModule.parse(node, {
-    base: "/",
+    base: process.env.hashRouting ? "./" : "/",
     folder: "twemoji",
     ext: ".svg",
     className: `txt-emoji`,


### PR DESCRIPTION
Twemojis were imported with an absolute base, we need to listen to `window.hashRouting` and switch to a relative base if we use hash routing