### PR TITLE
Removes `compilerOptions.dev` and chunk size warnings on build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,6 @@ const config: UserConfig = {
   },
   plugins: [
     svelte({
-      hot: !process.env.VITEST,
       compilerOptions: {
         dev: process.env.NODE_ENV !== "production",
       },
@@ -47,7 +46,17 @@ const config: UserConfig = {
   },
   build: {
     outDir: "build",
-    sourcemap: true,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          ethers: ["ethers", "@ethersproject/abstract-provider"],
+          auth: ["siwe", "@walletconnect/client"],
+          cache: ["lru-cache", "@stardazed/streams"],
+          markdown: ["katex", "dompurify", "marked", "@radicle/gray-matter"],
+          dom: ["svelte", "pure-svg-code", "twemoji"],
+        },
+      },
+    },
   },
 };
 


### PR DESCRIPTION
We split some third party packages into their own bundles to reduce the size of the index.js bundle.
We also don't need hmr ever in production.

Also removes the sourcemap output in build to reduce the size of the total bundle.
In dev environment we still get an inlined sourcemap, to help debugging.

Improves the speed also a bit, "about 200ms locally hosted" since we don't have to wait for e.g. markdown, siwe, walletconnect packages for a first contentful paint, since they have a considerable size