### PR TITLE
Push new routes to the history stack instead of replacing it

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -84,7 +84,7 @@ export const push = (newRoute: Route): void => {
     ? "#" + routeToPath(newRoute)
     : routeToPath(newRoute);
 
-  window.history.replaceState(newRoute, documentTitle, path);
+  window.history.pushState(newRoute, documentTitle, path);
 };
 
 export const pop = (): void => {


### PR DESCRIPTION
Ok no idea how this one passed the review..

We were using `window.history.replaceState` in the `router.push` fn instead of `window.history.pushState`