### PR TITLE
Dynamic imports

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -7,7 +7,7 @@
   import Header from "@app/Header.svelte";
   import Loading from "@app/Loading.svelte";
   import Modal from "@app/Modal.svelte";
-  import Preload from "@app/router/Preload.svelte";
+  import DynamicComponentImport from "@app/router/DynamicComponentImport.svelte";
 
   initialize();
 
@@ -78,41 +78,41 @@
     <Header session={$session} {wallet} />
     <div class="wrapper">
       {#if $activeRouteStore.resource === "home"}
-        <Preload path="../base/home/Index.svelte" />
+        <DynamicComponentImport path="../base/home/Index.svelte" />
       {:else if $activeRouteStore.resource === "faucet"}
-        <Preload
+        <DynamicComponentImport
           path="../base/faucet/Routes.svelte"
           {wallet}
           activeRoute={$activeRouteStore} />
       {:else if $activeRouteStore.resource === "seeds"}
-        <Preload
+        <DynamicComponentImport
           path="../base/seeds/Routes.svelte"
           {wallet}
-          host={$activeRouteStore.params.host}
-          session={$session} />
+          session={$session}
+          host={$activeRouteStore.params.host} />
       {:else if $activeRouteStore.resource === "registrations"}
-        <Preload
+        <DynamicComponentImport
           path="../base/registrations/Routes.svelte"
           {wallet}
-          activeRoute={$activeRouteStore}
-          session={$session} />
+          session={$session}
+          activeRoute={$activeRouteStore} />
       {:else if $activeRouteStore.resource === "vesting"}
-        <Preload
+        <DynamicComponentImport
           path="../base/vesting/Index.svelte"
           {wallet}
           session={$session} />
       {:else if $activeRouteStore.resource === "projects"}
-        <Preload
+        <DynamicComponentImport
           path="../base/projects/View.svelte"
           {wallet}
           activeRoute={$activeRouteStore} />
       {:else if $activeRouteStore.resource === "profile"}
-        <Preload
+        <DynamicComponentImport
           path="../Profile.svelte"
           {wallet}
           addressOrName={$activeRouteStore.params.addressOrName} />
       {:else if $activeRouteStore.resource === "404"}
-        <Preload
+        <DynamicComponentImport
           path="../NotFound.svelte"
           title="404"
           subtitle="Nothing here" />

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,18 +4,10 @@
   import { initialize, activeRouteStore } from "@app/router";
   import { twemoji, unreachable } from "@app/utils";
 
-  import ColorPalette from "@app/ColorPalette.svelte";
-  import Faucet from "@app/base/faucet/Routes.svelte";
   import Header from "@app/Header.svelte";
-  import Home from "@app/base/home/Index.svelte";
   import Loading from "@app/Loading.svelte";
   import Modal from "@app/Modal.svelte";
-  import NotFound from "@app/NotFound.svelte";
-  import Profile from "@app/Profile.svelte";
-  import Projects from "@app/base/projects/View.svelte";
-  import Registrations from "@app/base/registrations/Routes.svelte";
-  import Seeds from "@app/base/seeds/Routes.svelte";
-  import Vesting from "@app/base/vesting/Index.svelte";
+  import Preload from "@app/router/Preload.svelte";
 
   initialize();
 
@@ -83,33 +75,47 @@
       <Loading center />
     </div>
   {:then wallet}
-    <ColorPalette />
     <Header session={$session} {wallet} />
     <div class="wrapper">
       {#if $activeRouteStore.resource === "home"}
-        <Home />
+        <Preload path="/src/base/home/Index.svelte" />
       {:else if $activeRouteStore.resource === "faucet"}
-        <Faucet {wallet} activeRoute={$activeRouteStore} />
-      {:else if $activeRouteStore.resource === "seeds"}
-        <Seeds
+        <Preload
+          path="/src/base/faucet/Routes.svelte"
           {wallet}
-          session={$session}
-          host={$activeRouteStore.params.host} />
-      {:else if $activeRouteStore.resource === "registrations"}
-        <Registrations
-          {wallet}
-          session={$session}
           activeRoute={$activeRouteStore} />
+      {:else if $activeRouteStore.resource === "seeds"}
+        <Preload
+          path="/src/base/seeds/Routes.svelte"
+          {wallet}
+          host={$activeRouteStore.params.host}
+          session={$session} />
+      {:else if $activeRouteStore.resource === "registrations"}
+        <Preload
+          path="/src/base/registrations/Routes.svelte"
+          {wallet}
+          activeRoute={$activeRouteStore}
+          session={$session} />
       {:else if $activeRouteStore.resource === "vesting"}
-        <Vesting {wallet} session={$session} />
+        <Preload
+          path="/src/base/vesting/Index.svelte"
+          {wallet}
+          session={$session} />
       {:else if $activeRouteStore.resource === "projects"}
-        <Projects {wallet} activeRoute={$activeRouteStore} />
+        <Preload
+          path="/src/base/projects/View.svelte"
+          {wallet}
+          activeRoute={$activeRouteStore} />
       {:else if $activeRouteStore.resource === "profile"}
-        <Profile
-          addressOrName={$activeRouteStore.params.addressOrName}
-          {wallet} />
+        <Preload
+          path="src/Profile.svelte"
+          {wallet}
+          addressOrName={$activeRouteStore.params.addressOrName} />
       {:else if $activeRouteStore.resource === "404"}
-        <NotFound title="404" subtitle="Nothing here" />
+        <Preload
+          path="src/NotFound.svelte"
+          title="404"
+          subtitle="Nothing here" />
       {:else}
         {unreachable($activeRouteStore)}
       {/if}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -78,42 +78,42 @@
     <Header session={$session} {wallet} />
     <div class="wrapper">
       {#if $activeRouteStore.resource === "home"}
-        <Preload path="/src/base/home/Index.svelte" />
+        <Preload path="../base/home/Index.svelte" />
       {:else if $activeRouteStore.resource === "faucet"}
         <Preload
-          path="/src/base/faucet/Routes.svelte"
+          path="../base/faucet/Routes.svelte"
           {wallet}
           activeRoute={$activeRouteStore} />
       {:else if $activeRouteStore.resource === "seeds"}
         <Preload
-          path="/src/base/seeds/Routes.svelte"
+          path="../base/seeds/Routes.svelte"
           {wallet}
           host={$activeRouteStore.params.host}
           session={$session} />
       {:else if $activeRouteStore.resource === "registrations"}
         <Preload
-          path="/src/base/registrations/Routes.svelte"
+          path="../base/registrations/Routes.svelte"
           {wallet}
           activeRoute={$activeRouteStore}
           session={$session} />
       {:else if $activeRouteStore.resource === "vesting"}
         <Preload
-          path="/src/base/vesting/Index.svelte"
+          path="../base/vesting/Index.svelte"
           {wallet}
           session={$session} />
       {:else if $activeRouteStore.resource === "projects"}
         <Preload
-          path="/src/base/projects/View.svelte"
+          path="../base/projects/View.svelte"
           {wallet}
           activeRoute={$activeRouteStore} />
       {:else if $activeRouteStore.resource === "profile"}
         <Preload
-          path="src/Profile.svelte"
+          path="../Profile.svelte"
           {wallet}
           addressOrName={$activeRouteStore.params.addressOrName} />
       {:else if $activeRouteStore.resource === "404"}
         <Preload
-          path="src/NotFound.svelte"
+          path="../NotFound.svelte"
           title="404"
           subtitle="Nothing here" />
       {:else}

--- a/src/Form.svelte
+++ b/src/Form.svelte
@@ -54,13 +54,8 @@
   import cloneDeep from "lodash/cloneDeep";
   import { createEventDispatcher } from "svelte";
   import { marked } from "marked";
-  import {
-    markdownExtensions as extensions,
-    capitalize,
-    isUrl,
-    isAddress,
-    formatSeedId,
-  } from "@app/utils";
+  import { markdownExtensions as extensions } from "@app/marked";
+  import { capitalize, isUrl, isAddress, formatSeedId } from "@app/utils";
 
   import Address from "@app/Address.svelte";
   import Button from "@app/Button.svelte";

--- a/src/Markdown.svelte
+++ b/src/Markdown.svelte
@@ -3,14 +3,8 @@
   import { marked } from "marked";
   import matter from "@radicle/gray-matter";
   import type * as proj from "@app/project";
-  import {
-    markdownExtensions as extensions,
-    renderer,
-    getImageMime,
-    isUrl,
-    twemoji,
-    scrollIntoView,
-  } from "@app/utils";
+  import { markdownExtensions as extensions, renderer } from "@app/marked";
+  import { getImageMime, isUrl, twemoji, scrollIntoView } from "@app/utils";
   import dompurify from "dompurify";
 
   export let content: string;

--- a/src/marked.ts
+++ b/src/marked.ts
@@ -1,5 +1,7 @@
 import type { marked } from "marked";
+
 import katex from "katex";
+import { parseEmoji } from "@app/utils";
 
 const emojisMarkedExtension = {
   name: "emoji",

--- a/src/marked.ts
+++ b/src/marked.ts
@@ -1,0 +1,83 @@
+import type { marked } from "marked";
+import katex from "katex";
+
+const emojisMarkedExtension = {
+  name: "emoji",
+  level: "inline",
+  start: (src: string) => src.indexOf(":"),
+  tokenizer(src: string) {
+    const match = src.match(/^:([\w+-]+):/);
+    if (match) {
+      return {
+        type: "emoji",
+        raw: match[0],
+        text: match[1].trim(),
+      };
+    }
+  },
+  renderer: (token: marked.Tokens.Generic) =>
+    `<span>${parseEmoji(token.text)}</span>`,
+};
+
+const katexMarkedExtension = {
+  name: "katex",
+  level: "inline",
+  start: (src: string) => src.indexOf("$"),
+  tokenizer(src: string) {
+    const match = src.match(/^\$+([^$\n]+?)\$+/);
+    if (match) {
+      return {
+        type: "katex",
+        raw: match[0],
+        text: match[1].trim(),
+      };
+    }
+  },
+  renderer: (token: marked.Tokens.Generic) => {
+    return katex.renderToString(token.text, {
+      throwOnError: false,
+    });
+  },
+};
+
+// Converts self closing anchor tags into empty anchor tags, to avoid erratic wrapping behaviour
+// e.g. <a name="test"/> -> <a name="test"></a>
+const anchorMarkedExtension = {
+  name: "sanitizedAnchor",
+  level: "block",
+  start: (src: string) => src.match(/<a name="([\w]+)"\/>/)?.index,
+  tokenizer(src: string) {
+    const match = src.match(/^<a name="([\w]+)"\/>/);
+    if (match) {
+      return {
+        type: "sanitizedAnchor",
+        raw: match[0],
+        text: match[1].trim(),
+      };
+    }
+  },
+  renderer: (token: marked.Tokens.Generic) => {
+    return `<a name="${token.text}"></a>`;
+  },
+};
+
+// Overwrites the rendering of heading tokens.
+// Since there are possible non ASCII characters in headings,
+// we escape them by replacing them with dashes and,
+// trim eventual dashes on each side of the string.
+export const renderer = {
+  heading(text: string, level: 1 | 2 | 3 | 4 | 5 | 6) {
+    const escapedText = text
+      .toLowerCase()
+      .replace(/[^\w]+/g, "-")
+      .replace(/^-|-$/g, "");
+
+    return `<h${level} id="${escapedText}">${text}</h${level}>`;
+  },
+};
+
+export const markdownExtensions = [
+  emojisMarkedExtension,
+  katexMarkedExtension,
+  anchorMarkedExtension,
+];

--- a/src/router/DynamicComponentImport.svelte
+++ b/src/router/DynamicComponentImport.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import type { SvelteComponent } from "svelte";
+
+  export let path: string;
+
+  // TODO: Eventually we can restrict this glob pattern to the few components we need to import dynamically
+  const modules = import.meta.glob<boolean, string, SvelteComponent>(
+    "../**/*.svelte",
+  );
+</script>
+
+<!-- We try to resolve the import promise to a component to be rendered -->
+{#await modules[path]() then component}
+  <svelte:component this={component.default} {...$$props} />
+{/await}

--- a/src/router/Preload.svelte
+++ b/src/router/Preload.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  export let path: string;
+</script>
+
+{#await import(path) then component}
+  <svelte:component this={component.default} {...$$props} />
+{/await}

--- a/src/router/Preload.svelte
+++ b/src/router/Preload.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-  export let path: string;
-</script>
-
-{#await import(path) then component}
-  <svelte:component this={component.default} {...$$props} />
-{/await}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,6 @@ import { ethers } from "ethers";
 import twemojiModule from "twemoji";
 import md5 from "md5";
 import { BigNumber } from "ethers";
-import katex from "katex";
 import type { Wallet } from "@app/wallet";
 import { assert } from "@app/error";
 import type { EnsProfile } from "@app/base/registrations/registrar";
@@ -15,7 +14,6 @@ import {
 import { ProfileType } from "@app/profile";
 import { parseUnits } from "@ethersproject/units";
 import * as cache from "@app/cache";
-import type { marked } from "marked";
 import emojis from "@app/emojis";
 import config from "@app/config.json";
 
@@ -483,80 +481,6 @@ export const unreachable = (value: never): never => {
   throw new Error(`Unreachable code: ${value}`);
 };
 
-const emojisMarkedExtension = {
-  name: "emoji",
-  level: "inline",
-  start: (src: string) => src.indexOf(":"),
-  tokenizer(src: string) {
-    const match = src.match(/^:([\w+-]+):/);
-    if (match) {
-      return {
-        type: "emoji",
-        raw: match[0],
-        text: match[1].trim(),
-      };
-    }
-  },
-  renderer: (token: marked.Tokens.Generic) =>
-    `<span>${parseEmoji(token.text)}</span>`,
-};
-
-const katexMarkedExtension = {
-  name: "katex",
-  level: "inline",
-  start: (src: string) => src.indexOf("$"),
-  tokenizer(src: string) {
-    const match = src.match(/^\$+([^$\n]+?)\$+/);
-    if (match) {
-      return {
-        type: "katex",
-        raw: match[0],
-        text: match[1].trim(),
-      };
-    }
-  },
-  renderer: (token: marked.Tokens.Generic) =>
-    katex.renderToString(token.text, {
-      throwOnError: false,
-    }),
-};
-
-// Converts self closing anchor tags into empty anchor tags, to avoid erratic wrapping behaviour
-// e.g. <a name="test"/> -> <a name="test"></a>
-const anchorMarkedExtension = {
-  name: "sanitizedAnchor",
-  level: "block",
-  start: (src: string) => src.match(/<a name="([\w]+)"\/>/)?.index,
-  tokenizer(src: string) {
-    const match = src.match(/^<a name="([\w]+)"\/>/);
-    if (match) {
-      return {
-        type: "sanitizedAnchor",
-        raw: match[0],
-        text: match[1].trim(),
-      };
-    }
-  },
-  renderer: (token: marked.Tokens.Generic) => {
-    return `<a name="${token.text}"></a>`;
-  },
-};
-
-// Overwrites the rendering of heading tokens.
-// Since there are possible non ASCII characters in headings,
-// we escape them by replacing them with dashes and,
-// trim eventual dashes on each side of the string.
-export const renderer = {
-  heading(text: string, level: 1 | 2 | 3 | 4 | 5 | 6) {
-    const escapedText = text
-      .toLowerCase()
-      .replace(/[^\w]+/g, "-")
-      .replace(/^-|-$/g, "");
-
-    return `<h${level} id="${escapedText}">${text}</h${level}>`;
-  },
-};
-
 export function twemoji(node: HTMLElement) {
   twemojiModule.parse(node, {
     base: process.env.hashRouting ? "./" : "/",
@@ -565,9 +489,3 @@ export function twemoji(node: HTMLElement) {
     className: `txt-emoji`,
   });
 }
-
-export const markdownExtensions = [
-  emojisMarkedExtension,
-  katexMarkedExtension,
-  anchorMarkedExtension,
-];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,7 +52,6 @@ const config: UserConfig = {
           ethers: ["ethers", "@ethersproject/abstract-provider"],
           auth: ["siwe", "@walletconnect/client"],
           cache: ["lru-cache", "@stardazed/streams"],
-          markdown: ["katex", "dompurify", "marked", "@radicle/gray-matter"],
           dom: ["svelte", "pure-svg-code", "twemoji"],
         },
       },


### PR DESCRIPTION
Ok this is a test, which I think will give the page even more snappiness, instead of loading all components on start, we split all the components in separate bundles, and load/import them dynamically when needed.

This saves us around 600 KB in data resources to be transferred when landing for the first time on the page.
Also I get around 300 ms quicker `DOMContentLoaded` when visiting `base/home/Index.svelte`

I deployed the latest commit here, so you can see how it behaves
https://tubular-taiyaki-bf2c09.netlify.app

Also I moved some bigger packages like `katex` into a separate `markdown` module

For desktop computer with unthrottled bandwith the difference is not significant, but for lower connections, to download 600 KB less trims the load time a good amount.
These tests were run with the following network throttle
`150 ms TCP RTT, 1.638,4 Kbps throughput (Simulated)` similar to a slow 4G mobile connection
## Current
<img width="961" alt="app radicle xyz" src="https://user-images.githubusercontent.com/7912302/202297073-69f30d5f-9472-4905-9a34-c23d3f0eca7c.png">

## Dynamic Imports
<img width="963" alt="tubular-taiyaki" src="https://user-images.githubusercontent.com/7912302/202297061-eb20e38f-93c3-4c37-880a-c6fe71ad1826.png">