### PR TITLE
Check if there is a final new line in the blob content

### DIFF
--- a/src/base/projects/Blob.svelte
+++ b/src/base/projects/Blob.svelte
@@ -18,7 +18,8 @@
 
   const lastCommit = blob.info.lastCommit;
   const lines = blob.binary ? 0 : (blob.content.match(/\n/g) || []).length;
-  const lineNumbers = Array(lines)
+  const hasFinalNewline = blob.content.endsWith("\n");
+  const lineNumbers = Array(hasFinalNewline ? lines : lines + 1)
     .fill(0)
     .map((_, index) => (index + 1).toString());
   const parentDir = blob.path


### PR DESCRIPTION
There are repos that have files with a missing new final line aka the last line hasn't a line break `\n` at the end of the file.
So we weren't counting that last line.
To avoid this missing line we should add 1 to the amount of lines in that case.

This should be probably something solved on the backend once we get more information on the source code..