### PR TITLE
Add postinstall scripts to build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "start": "vite",
     "start:ipfs": "HASH_ROUTING=1 vite --base ./",
     "serve": "vite preview",
-    "build": "vite build",
+    "build": "vite build && scripts/copy-katex-assets && scripts/install-twemoji-assets",
     "build:ipfs": "HASH_ROUTING=1 vite build --base ./",
     "postinstall": "scripts/copy-katex-assets && scripts/install-twemoji-assets",
     "check": "scripts/check",

--- a/scripts/copy-katex-assets
+++ b/scripts/copy-katex-assets
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
+echo "Copying katex assets into bundle directory"
+
 cp -r node_modules/katex/dist/katex.min.css public/katex.min.css
 cp -r node_modules/katex/dist/fonts/* public/fonts/


### PR DESCRIPTION
Since Netlify has issues with triggering the `postinstall` script.
We should be able to trigger the postinstall scripts during the build step, so we don't miss it.