### PR TITLE
Fix ABI used in vesting page

### DIFF
--- a/src/base/vesting/vesting.ts
+++ b/src/base/vesting/vesting.ts
@@ -61,7 +61,7 @@ export async function getInfo(
 
   const tokenContract = new ethers.Contract(
     token,
-    ethereumContractAbis.vesting,
+    ethereumContractAbis.token,
     wallet.provider,
   );
   const symbol = await tokenContract.symbol();


### PR DESCRIPTION
It's a typo, while cleaning up config