### PR TITLE
Add route support to vesting feature

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -16,7 +16,7 @@
   import Projects from "@app/base/projects/View.svelte";
   import Registrations from "@app/base/registrations/Routes.svelte";
   import Seeds from "@app/base/seeds/Routes.svelte";
-  import Vesting from "@app/base/vesting/Index.svelte";
+  import Vesting from "@app/base/vesting/Routes.svelte";
 
   initialize();
 
@@ -105,7 +105,7 @@
           session={$session}
           activeRoute={$activeRouteStore} />
       {:else if $activeRouteStore.resource === "vesting"}
-        <Vesting {wallet} session={$session} />
+        <Vesting {wallet} session={$session} activeRoute={$activeRouteStore} />
       {:else if $activeRouteStore.resource === "projects"}
         <Projects {wallet} activeRoute={$activeRouteStore} />
       {:else if $activeRouteStore.resource === "profile"}

--- a/src/base/vesting/Form.svelte
+++ b/src/base/vesting/Form.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import type { Wallet } from "@app/wallet";
+
+  import * as utils from "@app/utils";
+  import * as router from "@app/router";
+  import Button from "@app/Button.svelte";
+  import TextInput from "@app/TextInput.svelte";
+  import { state, getInfo } from "./vesting";
+
+  export let wallet: Wallet;
+
+  let contractAddress = "";
+
+  $: valid = utils.isAddress(contractAddress);
+  $: validationMessage =
+    contractAddress !== "" && !valid
+      ? "Please enter a valid Ethereum address."
+      : "";
+
+  const loadContract = async () => {
+    state.set("loading");
+    try {
+      const info = await getInfo(contractAddress, wallet);
+      router.push({
+        resource: "vesting",
+        params: {
+          view: {
+            resource: "view",
+            params: { contract: contractAddress, info },
+          },
+        },
+      });
+    } catch (error) {
+      validationMessage =
+        "Couldn't load contract, check dev console for details.";
+      console.error(error);
+    }
+    state.set("idle");
+  };
+</script>
+
+<style>
+  main {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    height: 100%;
+    justify-content: center;
+    padding-bottom: 24vh;
+    padding-top: 5rem;
+    width: 38rem;
+  }
+  .title {
+    color: var(--color-secondary);
+    font-size: var(--font-size-medium);
+  }
+  .form {
+    display: flex;
+    gap: 1rem;
+  }
+</style>
+
+<svelte:head>
+  <title>Radicle &ndash; Vesting</title>
+</svelte:head>
+
+<main>
+  <div class="title">
+    Your Radicle <span class="txt-bold">vesting contract</span>
+  </div>
+
+  <div class="form">
+    <TextInput
+      autofocus
+      placeholder="Enter vesting contract address"
+      {valid}
+      {validationMessage}
+      loading={$state === "loading"}
+      disabled={$state === "loading"}
+      on:submit={loadContract}
+      bind:value={contractAddress} />
+
+    <Button
+      on:click={loadContract}
+      variant="primary"
+      waiting={$state === "loading"}
+      disabled={!valid || $state === "loading"}>
+      Load
+    </Button>
+  </div>
+</main>

--- a/src/base/vesting/Routes.svelte
+++ b/src/base/vesting/Routes.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import type { Wallet } from "@app/wallet";
+  import type { VestingRoute } from "@app/router/definitions";
+  import type { Session } from "@app/session";
+
+  import Form from "@app/base/vesting/Form.svelte";
+  import View from "@app/base/vesting/View.svelte";
+
+  export let activeRoute: VestingRoute;
+  export let wallet: Wallet;
+  export let session: Session | null;
+</script>
+
+{#if activeRoute.params.view.resource === "form"}
+  <Form {wallet} />
+{:else if activeRoute.params.view.resource === "view"}
+  <View
+    {wallet}
+    {session}
+    info={activeRoute.params.view.params.info}
+    contractAddress={activeRoute.params.view.params.contract} />
+{/if}

--- a/src/base/vesting/vesting.ts
+++ b/src/base/vesting/vesting.ts
@@ -15,6 +15,9 @@ export interface VestingInfo {
   totalVesting: string;
   withdrawableBalance: string;
   withdrawn: string;
+  cliffPeriod: string;
+  vestingStartTime: string;
+  vestingPeriod: string;
 }
 
 export const state = writable<
@@ -58,6 +61,9 @@ export async function getInfo(
   const withdrawable = await contract.withdrawableBalance();
   const withdrawn = await contract.withdrawn();
   const total = await contract.totalVestingAmount();
+  const vestingStartTime = await contract.vestingStartTime();
+  const vestingPeriod = await contract.vestingPeriod();
+  const cliffPeriod = await contract.cliffPeriod();
 
   const tokenContract = new ethers.Contract(
     token,
@@ -67,11 +73,14 @@ export async function getInfo(
   const symbol = await tokenContract.symbol();
 
   return {
-    token: token,
-    symbol: symbol,
-    beneficiary: beneficiary,
+    token,
+    symbol,
+    beneficiary,
     totalVesting: utils.formatBalance(total),
     withdrawableBalance: utils.formatBalance(withdrawable),
     withdrawn: utils.formatBalance(withdrawn),
+    vestingStartTime,
+    vestingPeriod,
+    cliffPeriod,
   };
 }

--- a/src/router/definitions.ts
+++ b/src/router/definitions.ts
@@ -1,12 +1,14 @@
+import type { VestingInfo } from "@app/base/vesting/vesting";
+
 export type Route =
   | FaucetRoute
   | ProjectRoute
   | RegistrationRoute
+  | VestingRoute
   | { resource: "home" }
   | { resource: "404"; params: { url: string } }
   | { resource: "profile"; params: { addressOrName: string } }
-  | { resource: "seeds"; params: { host: string } }
-  | { resource: "vesting" };
+  | { resource: "seeds"; params: { host: string } };
 
 export interface ProjectsParams {
   urn: string;
@@ -27,6 +29,12 @@ export interface ProjectsParams {
   route?: string;
   search?: string;
   seed?: string;
+}
+
+export interface VestingParams {
+  view:
+    | { resource: "form" }
+    | { resource: "view"; params: { contract: string; info?: VestingInfo } };
 }
 
 export interface FaucetParams {
@@ -56,6 +64,7 @@ export interface RegistrationParams {
 
 export type ProjectRoute = { resource: "projects"; params: ProjectsParams };
 export type FaucetRoute = { resource: "faucet"; params: FaucetParams };
+export type VestingRoute = { resource: "vesting"; params: VestingParams };
 export type RegistrationRoute = {
   resource: "registrations";
   params: RegistrationParams;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -189,8 +189,16 @@ function pathToRoute(path: string): Route | null {
       }
       return { resource: "faucet", params: { view: { resource: "form" } } };
     }
-    case "vesting":
-      return { resource: "vesting" };
+    case "vesting": {
+      const contract = segments.shift();
+      if (contract) {
+        return {
+          resource: "vesting",
+          params: { view: { resource: "view", params: { contract } } },
+        };
+      }
+      return { resource: "vesting", params: { view: { resource: "form" } } };
+    }
     case "seeds": {
       const host = segments.shift();
       if (host) {
@@ -276,7 +284,11 @@ export function routeToPath(route: Route) {
       return `/faucet/withdraw?amount=${route.params.view.params.amount}`;
     }
   } else if (route.resource === "vesting") {
-    return "/vesting";
+    if (route.params.view.resource === "form") {
+      return "/vesting";
+    } else if (route.params.view.resource === "view") {
+      return `/vesting/${route.params.view.params.contract}`;
+    }
   } else if (route.resource === "seeds") {
     return `/seeds/${route.params.host}`;
   } else if (route.resource === "projects") {

--- a/tests/unit/router.test.ts
+++ b/tests/unit/router.test.ts
@@ -9,7 +9,7 @@ describe("routeToPath", () => {
   test.each([
     { input: { resource: "home" }, output: "/", description: "Home Route" },
     {
-      input: { resource: "vesting" },
+      input: { resource: "vesting", params: { view: { resource: "form" } } },
       output: "/vesting",
       description: "Vesting Route",
     },
@@ -124,7 +124,7 @@ describe("pathToRoute", () => {
     { input: "/", output: { resource: "home" }, description: "Home Route" },
     {
       input: "/vesting",
-      output: { resource: "vesting" },
+      output: { resource: "vesting", params: { view: { resource: "form" } } },
       description: "Vesting Route",
     },
     {


### PR DESCRIPTION
This allows people to either search for their vesting contract through the search form or visit directly `vesting/<contract address>`

Was not able to test withdraw functionality, but this PR does not touch it, so should be fine.

Small example on the functionality

https://user-images.githubusercontent.com/7912302/203993327-8d2d0e8b-da1a-4001-97dc-945045cb6368.mov

