### PR TITLE
Add e2e tests for router

### DIFF
--- a/src/base/projects/View.svelte
+++ b/src/base/projects/View.svelte
@@ -48,13 +48,16 @@
         activeRoute.params.route,
         project.branches,
       );
-      router.updateProjectRoute({
-        revision,
-        path,
-        line: activeRoute.params.line,
-        hash: activeRoute.params.hash,
-        route: undefined,
-      });
+      router.updateProjectRoute(
+        {
+          revision,
+          path,
+          line: activeRoute.params.line,
+          hash: activeRoute.params.hash,
+          route: undefined,
+        },
+        { replace: true },
+      );
     }
     if (!activeRoute.params.revision) {
       // We need a revision to fetch `getRoot`.

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -21,8 +21,10 @@ export const base = window.HASH_ROUTING ? "./" : "/";
 // Gets triggered when clicking on an anchor hash tag e.g. <a href="#header"/>
 // Allows the jump to a anchor hash
 window.addEventListener("hashchange", e => {
-  const url = new URL(e.newURL);
-  updateProjectRoute({ hash: url.hash.substring(1) });
+  const route = pathToRoute(e.newURL);
+  if (route?.resource === "projects" && route.params.hash) {
+    updateProjectRoute({ hash: route.params.hash });
+  }
 });
 
 // Replaces history on any user interaction with forward and backwards buttons
@@ -62,12 +64,17 @@ export function projectLinkHref(
 
 export function updateProjectRoute(
   projectRouteParams: Partial<ProjectsParams>,
+  opts: { replace: boolean } = { replace: false },
 ) {
   const activeRoute = get(activeRouteStore);
 
   if (activeRoute.resource === "projects") {
     const updatedRoute = createProjectRoute(activeRoute, projectRouteParams);
-    push(updatedRoute);
+    if (opts.replace) {
+      replace(updatedRoute);
+    } else {
+      push(updatedRoute);
+    }
   } else {
     throw new Error(
       "Don't use project specific navigation outside of project views",

--- a/tests/e2e/landingPage.spec.ts
+++ b/tests/e2e/landingPage.spec.ts
@@ -40,10 +40,4 @@ test("show pinned projects", async ({ page }) => {
 
   // Shows latest commit.
   await expect(page.locator("text=530aabd")).toBeVisible();
-
-  // Navigate to a project.
-  await page.locator("text=source-browsing").click();
-  await expect(page).toHaveURL(
-    "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81",
-  );
 });

--- a/tests/e2e/router.hash.spec.ts
+++ b/tests/e2e/router.hash.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from "@tests/support/fixtures.js";
+import {
+  expectBackAndForwardNavigationWorks,
+  expectUrlPersistsReload,
+} from "@tests/support/router.js";
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.HASH_ROUTING = true;
+  });
+});
+
+test("navigate between landing and project page", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.APP_CONFIG = {
+      walletConnect: {
+        bridge: "https://radicle.bridge.walletconnect.org",
+      },
+      reactions: [],
+      seeds: {
+        pinned: [{ host: "0.0.0.0", emoji: "🚀" }],
+      },
+      projects: {
+        pinned: [
+          {
+            name: "source-browsing",
+            urn: "rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o",
+            seed: "0.0.0.0",
+          },
+        ],
+      },
+    };
+  });
+
+  await page.goto("/#/");
+  await expect(page).toHaveURL("/#/");
+
+  await page.locator("text=source-browsing").click();
+  await expect(page).toHaveURL(
+    "/#/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81",
+  );
+
+  await expectBackAndForwardNavigationWorks("/#/", page);
+  await expectUrlPersistsReload(page);
+});
+
+test("navigation between seed and project pages", async ({ page }) => {
+  await page.goto("/#/seeds/radicle.local");
+
+  const project = page.locator(".project");
+  await project.click();
+  await expect(page).toHaveURL(
+    "/#/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81",
+  );
+
+  await expectBackAndForwardNavigationWorks("/#/seeds/radicle.local", page);
+  await expectUrlPersistsReload(page);
+
+  await page.locator('role=button[name="Seed"]').click();
+  await expect(page).toHaveURL("/#/seeds/0.0.0.0");
+});
+
+test.describe("project page navigation", () => {
+  test("navigation between commit history and single commit", async ({
+    page,
+  }) => {
+    const projectHistoryURL =
+      "/#/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/history/530aabdcc80397af254bc488b767169b92496e81";
+    await page.goto(projectHistoryURL);
+
+    await page.locator("text=Add Markdown cheat sheet").click();
+    await expect(page).toHaveURL(
+      "/#/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/commits/530aabdcc80397af254bc488b767169b92496e81",
+    );
+
+    await expectBackAndForwardNavigationWorks(projectHistoryURL, page);
+    await expectUrlPersistsReload(page);
+  });
+
+  test("navigate between tree and commit history", async ({ page }) => {
+    const projectTreeURL =
+      "/#/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81";
+
+    await page.goto(projectTreeURL);
+    await expect(page).toHaveURL(projectTreeURL);
+
+    await page.locator('role=button[name="Commit count"]').click();
+    await expect(page).toHaveURL(
+      "/#/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/history/530aabdcc80397af254bc488b767169b92496e81",
+    );
+
+    await expectBackAndForwardNavigationWorks(projectTreeURL, page);
+    await expectUrlPersistsReload(page);
+  });
+
+  test("navigate project paths", async ({ page }) => {
+    const projectTreeURL =
+      "/#/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81";
+
+    await page.goto(projectTreeURL);
+    await expect(page).toHaveURL(projectTreeURL);
+
+    await page.locator("text=.hidden").click();
+    await expect(page).toHaveURL(`${projectTreeURL}/.hidden`);
+
+    await page.locator("text=bin/").click();
+    await page.locator("text=true").click();
+    await expect(page).toHaveURL(`${projectTreeURL}/bin/true`);
+
+    await expectBackAndForwardNavigationWorks(
+      `${projectTreeURL}/.hidden`,
+      page,
+    );
+    await expectUrlPersistsReload(page);
+  });
+
+  test("navigate project paths with a selected peer", async ({ page }) => {
+    const projectTreeURL =
+      "/#/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/remotes/hyn1mjueopwzrmb18c3zmgg8ei8qunn5wpg76ouymytfqkfxqx7bun/tree";
+
+    await page.goto(projectTreeURL);
+    await expect(page).toHaveURL(projectTreeURL);
+
+    await page.locator("text=.hidden").click();
+    await expect(page).toHaveURL(`${projectTreeURL}/main/.hidden`);
+
+    await page.locator("text=bin/").click();
+    await page.locator("text=true").click();
+    await expect(page).toHaveURL(`${projectTreeURL}/main/bin/true`);
+
+    await expectBackAndForwardNavigationWorks(
+      `${projectTreeURL}/main/.hidden`,
+      page,
+    );
+    await expectUrlPersistsReload(page);
+  });
+});

--- a/tests/e2e/router.history.spec.ts
+++ b/tests/e2e/router.history.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from "@tests/support/fixtures.js";
+import {
+  expectBackAndForwardNavigationWorks,
+  expectUrlPersistsReload,
+} from "@tests/support/router.js";
+
+test("navigate between landing and project page", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.APP_CONFIG = {
+      walletConnect: {
+        bridge: "https://radicle.bridge.walletconnect.org",
+      },
+      reactions: [],
+      seeds: {
+        pinned: [{ host: "0.0.0.0", emoji: "🚀" }],
+      },
+      projects: {
+        pinned: [
+          {
+            name: "source-browsing",
+            urn: "rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o",
+            seed: "0.0.0.0",
+          },
+        ],
+      },
+    };
+  });
+
+  await page.goto("/");
+  await expect(page).toHaveURL("/");
+
+  await page.locator("text=source-browsing").click();
+  await expect(page).toHaveURL(
+    "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81",
+  );
+
+  await expectBackAndForwardNavigationWorks("/", page);
+  await expectUrlPersistsReload(page);
+});
+
+test("navigation between seed and project pages", async ({ page }) => {
+  await page.goto("/seeds/radicle.local");
+
+  const project = page.locator(".project");
+  await project.click();
+  await expect(page).toHaveURL(
+    "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81",
+  );
+
+  await expectBackAndForwardNavigationWorks("/seeds/radicle.local", page);
+  await expectUrlPersistsReload(page);
+
+  await page.locator('role=button[name="Seed"]').click();
+  await expect(page).toHaveURL("/seeds/0.0.0.0");
+});
+
+test.describe("project page navigation", () => {
+  test("navigation between commit history and single commit", async ({
+    page,
+  }) => {
+    const projectHistoryURL =
+      "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/history/530aabdcc80397af254bc488b767169b92496e81";
+    await page.goto(projectHistoryURL);
+
+    await page.locator("text=Add Markdown cheat sheet").click();
+    await expect(page).toHaveURL(
+      "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/commits/530aabdcc80397af254bc488b767169b92496e81",
+    );
+
+    await expectBackAndForwardNavigationWorks(projectHistoryURL, page);
+    await expectUrlPersistsReload(page);
+  });
+
+  test("navigate between tree and commit history", async ({ page }) => {
+    const projectTreeURL =
+      "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81";
+
+    await page.goto(projectTreeURL);
+    await expect(page).toHaveURL(projectTreeURL);
+
+    await page.locator('role=button[name="Commit count"]').click();
+    await expect(page).toHaveURL(
+      "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/history/530aabdcc80397af254bc488b767169b92496e81",
+    );
+
+    await expectBackAndForwardNavigationWorks(projectTreeURL, page);
+    await expectUrlPersistsReload(page);
+  });
+
+  test("navigate project paths", async ({ page }) => {
+    const projectTreeURL =
+      "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81";
+
+    await page.goto(projectTreeURL);
+    await expect(page).toHaveURL(projectTreeURL);
+
+    await page.locator("text=.hidden").click();
+    await expect(page).toHaveURL(`${projectTreeURL}/.hidden`);
+
+    await page.locator("text=bin/").click();
+    await page.locator("text=true").click();
+    await expect(page).toHaveURL(`${projectTreeURL}/bin/true`);
+
+    await expectBackAndForwardNavigationWorks(
+      `${projectTreeURL}/.hidden`,
+      page,
+    );
+    await expectUrlPersistsReload(page);
+  });
+
+  test("navigate project paths with a selected peer", async ({ page }) => {
+    const projectTreeURL =
+      "seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/remotes/hyn1mjueopwzrmb18c3zmgg8ei8qunn5wpg76ouymytfqkfxqx7bun/tree";
+
+    await page.goto(projectTreeURL);
+    await expect(page).toHaveURL(projectTreeURL);
+
+    await page.locator("text=.hidden").click();
+    await expect(page).toHaveURL(`${projectTreeURL}/main/.hidden`);
+
+    await page.locator("text=bin/").click();
+    await page.locator("text=true").click();
+    await expect(page).toHaveURL(`${projectTreeURL}/main/bin/true`);
+
+    await expectBackAndForwardNavigationWorks(
+      `${projectTreeURL}/main/.hidden`,
+      page,
+    );
+    await expectUrlPersistsReload(page);
+  });
+});

--- a/tests/e2e/seed.spec.ts
+++ b/tests/e2e/seed.spec.ts
@@ -44,18 +44,3 @@ test("seed projects", async ({ page }) => {
     ).toBeVisible();
   }
 });
-
-test("navigation between seed and project pages", async ({ page }) => {
-  await page.goto("/seeds/radicle.local");
-  const project = page.locator(".project");
-
-  // Navigate to a project.
-  await project.click();
-  await expect(page).toHaveURL(
-    "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81",
-  );
-
-  // Navigate back to seed.
-  await page.locator('role=button[name="Seed"]').click();
-  await expect(page).toHaveURL("/seeds/0.0.0.0");
-});

--- a/tests/support/router.ts
+++ b/tests/support/router.ts
@@ -1,0 +1,21 @@
+import type { Page } from "@playwright/test";
+import { expect } from "@tests/support/fixtures.js";
+
+// Reloads the current page and verifies that the URL stays correct
+export const expectUrlPersistsReload = async (page: Page) => {
+  const url = page.url();
+  await page.reload();
+  await expect(page).toHaveURL(url);
+};
+
+// Navigates back, checks the URL and navigates forward back to the initial page
+export const expectBackAndForwardNavigationWorks = async (
+  beforeURL: string,
+  page: Page,
+) => {
+  const currentURL = page.url();
+  await page.goBack();
+  await expect(page).toHaveURL(beforeURL);
+  await page.goForward();
+  await expect(page).toHaveURL(currentURL);
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,22 @@ import pluginRewriteAll from "vite-plugin-rewrite-all";
 import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 
+function defineConstants() {
+  const constants = {
+    VITEST: process.env.VITEST !== undefined,
+    PLAYWRIGHT: process.env.PLAYWRIGHT_TEST_BASE_URL !== undefined,
+  };
+
+  // Don't overwrite HASH_ROUTING in Playwright tests, so we can control it
+  // from within the tests.
+  if (process.env.PLAYWRIGHT_TEST_BASE_URL !== undefined) {
+    return constants;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    return { ...constants, HASH_ROUTING: Boolean(process.env.HASH_ROUTING) };
+  }
+}
+
 export default defineConfig({
   optimizeDeps: {
     exclude: ["@pedrouid/environment", "@pedrouid/iso-crypto"],
@@ -53,10 +69,5 @@ export default defineConfig({
     },
   },
 
-  define: {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    HASH_ROUTING: Boolean(process.env.HASH_ROUTING),
-    VITEST: process.env.VITEST !== undefined,
-    PLAYWRIGHT: process.env.PLAYWRIGHT_TEST_BASE_URL !== undefined,
-  },
+  define: defineConstants(),
 });


### PR DESCRIPTION
This PR is based on top of the `rudolfs/playwright` PR.
It removes some navigation testing from the original PR and adds support for testing hash route navigation.

Fixes also some found bugs that started showing in particular on the hash routing.

With future PRs I'll be adding more tests for the router but I think its a nice start.

Creates a conditional vite config, to allow the testing of the hash router, we want to avoid that vite overwrites `window.HASH_ROUTING` with the `define` section in the vite config