### PR TITLE
Cache playwright binaries

### DIFF
--- a/.github/workflows/check-e2e.yml
+++ b/.github/workflows/check-e2e.yml
@@ -15,12 +15,34 @@ jobs:
         node-version: '18.12.1'
     - name: Install dependencies
       run: npm ci
-    - name: Install Playwright Browsers
+    - name: Get npm cache directory
+      id: npm-cache-dir
+      run: |
+        echo "::set-output name=dir::$(npm config get cache)"
+    - name: Get Playwright version
+      id: playwright-version
+      run: |
+        echo "::set-output name=version::$(node -p "require('@playwright/test/package.json').version")"
+    - uses: actions/cache@v3
+      name: Check if Playwright browser is cached
+      id: playwright-cache
+      with:
+        path: ${{ steps.npm-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-Playwright-${{steps.playwright-version.outputs.version}}
+    - name: Install Playwright browser if not cached
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
       run: npx playwright install --with-deps
+      env:
+        PLAYWRIGHT_BROWSERS_PATH: ${{steps.npm-cache-dir.outputs.dir}}
+    - name: Install OS dependencies of Playwright if cache hit
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      run: npx playwright install-deps
     - name: Start http-api test server
       run: ./scripts/run-http-api-with-fixtures --non-interactive --detach
     - name: Run Playwright tests
       run: npm run test:e2e -- --project ${{ matrix.browser }}
+      env:
+        PLAYWRIGHT_BROWSERS_PATH: ${{steps.npm-cache-dir.outputs.dir}}
     - uses: actions/upload-artifact@v3
       if: always()
       with:


### PR DESCRIPTION
## First commit that installs Playwright browsers
Running `npx playwright install --with-deps`
<img width="878" alt="Bildschirm­foto 2022-12-01 um 21 03 41" src="https://user-images.githubusercontent.com/7912302/205148697-7a024b01-8900-4405-8288-4bad814066a5.png">

## With the Playwright browsers installed it skips the installment and only install OS dependencies
Running `npx playwright install-deps`
<img width="867" alt="Bildschirm­foto 2022-12-01 um 21 09 22" src="https://user-images.githubusercontent.com/7912302/205149732-530195b4-cca6-4eed-9f40-65a0b8047496.png">
