### PR TITLE
Run GitHub CI only if push against master or push to PR but not both

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -1,5 +1,11 @@
 name: check-build
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   check-build:

--- a/.github/workflows/check-e2e.yml
+++ b/.github/workflows/check-e2e.yml
@@ -1,5 +1,11 @@
 name: check-e2e
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   check-e2e:

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -1,5 +1,11 @@
 name: check-format
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   check-format:

--- a/.github/workflows/check-unit-test.yml
+++ b/.github/workflows/check-unit-test.yml
@@ -1,5 +1,11 @@
 name: check-unit-test
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   check-unit-test:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,5 +1,11 @@
 name: check
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   check:


### PR DESCRIPTION
This PR changes the event triggers for the GitHub CI to

```
on:
  push:
    branches:
    - master
  pull_request:
    branches:
    - master
```

This changes the behaviour to only run the checks when either a push is being made to the `master` branch or updates to a pull_request but not both

Closes #517 