### PR TITLE
Add visual snapshot tests

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build app
       run: npm run build
     - name: Run Playwright build smoke test
-      run: npm run test:e2e -- --project chromium --config playwright.buildSmoke.config.ts tests/e2e/buildSmoke.spec.ts
+      run: npm run test:e2e -- --project chromium --config playwright.buildSmoke.config.ts
     - uses: actions/upload-artifact@v3
       if: always()
       with:

--- a/.github/workflows/check-e2e.yml
+++ b/.github/workflows/check-e2e.yml
@@ -2,57 +2,66 @@ name: check-e2e
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
     branches:
-    - master
+      - master
 
 jobs:
   check-e2e:
+    continue-on-error: true
     strategy:
       matrix:
-        browser: [chromium, firefox]
+        browser: [chromium, firefox, visual]
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: '18.12.1'
-    - name: Install dependencies
-      run: npm ci
-    - name: Get npm cache directory
-      id: npm-cache-dir
-      run: |
-        echo "::set-output name=dir::$(npm config get cache)"
-    - name: Get Playwright version
-      id: playwright-version
-      run: |
-        echo "::set-output name=version::$(node -p "require('@playwright/test/package.json').version")"
-    - uses: actions/cache@v3
-      name: Check if Playwright browser is cached
-      id: playwright-cache
-      with:
-        path: ${{ steps.npm-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-Playwright-${{steps.playwright-version.outputs.version}}
-    - name: Install Playwright browser if not cached
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: npx playwright install --with-deps
-      env:
-        PLAYWRIGHT_BROWSERS_PATH: ${{steps.npm-cache-dir.outputs.dir}}
-    - name: Install OS dependencies of Playwright if cache hit
-      if: steps.playwright-cache.outputs.cache-hit == 'true'
-      run: npx playwright install-deps
-    - name: Start http-api test server
-      run: ./scripts/run-http-api-with-fixtures --non-interactive --detach
-    - name: Run Playwright tests
-      run: npm run test:e2e -- --project ${{ matrix.browser }}
-      env:
-        PLAYWRIGHT_BROWSERS_PATH: ${{steps.npm-cache-dir.outputs.dir}}
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: test-artifacts-${{ runner.os }}
-        retention-days: 30
-        path: |
-          tests/artifacts/**/*
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18.12.1"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v3
+        id: playwright-dep-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
+      - name: Cache snapshots (generate on master, load on pull_request)
+        uses: actions/cache@v3
+        id: playwright-snapshot-cache
+        with:
+          path: tests/visual/snapshots/**/*
+          key: ${{ runner.os }}-snapshots
+
+      - name: Install Playwright with deps unless cached
+        if: steps.playwright-dep-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
+
+      - name: Install only Playwright OS dependencies if cache hit
+        if: steps.playwright-dep-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps
+
+      - name: Start http-api test server
+        run: ./scripts/run-http-api-with-fixtures --non-interactive --detach
+
+      - name: Run Playwright tests
+        run: |
+              if [ ${{ matrix.browser }} = "visual" ] && [ ${{ github.ref }} = "refs/heads/master" ]; then
+                npm run test:e2e -- --project ${{ matrix.browser }} --update-snapshots;
+              else
+                npm run test:e2e -- --project ${{ matrix.browser }};
+              fi
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-artifacts-${{ runner.os }}
+          retention-days: 30
+          path: |
+            tests/artifacts/**/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build/
+/build/
 node_modules/
 NOTES
 

--- a/playwright.buildSmoke.config.ts
+++ b/playwright.buildSmoke.config.ts
@@ -4,6 +4,7 @@ import base from "./playwright.config.js";
 
 const config: PlaywrightTestConfig = {
   ...base,
+  testDir: "./tests/build",
   use: {
     ...base.use,
     baseURL: "http://localhost:4173",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,12 +3,12 @@ import { devices } from "@playwright/test";
 
 const config: PlaywrightTestConfig = {
   testDir: "./tests/e2e",
+  outputDir: "./tests/artifacts",
   timeout: 30_000,
   expect: {
     timeout: 8000,
   },
   fullyParallel: true,
-  outputDir: "./tests/artifacts",
   workers: process.env.CI ? 1 : undefined,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
@@ -37,6 +37,27 @@ const config: PlaywrightTestConfig = {
       name: "webkit",
       use: {
         ...devices["Desktop Safari"],
+      },
+    },
+    {
+      name: "visual",
+      expect: {
+        timeout: 16_000,
+        toHaveScreenshot: {
+          threshold: 0.1,
+          scale: "device",
+          animations: "disabled",
+        },
+      },
+      testDir: "./tests/visual",
+      snapshotDir: "./tests/visual/snapshots",
+      retries: 0,
+      use: {
+        ...devices["Desktop Chrome"],
+        actionTimeout: 0,
+        deviceScaleFactor: 2,
+        baseURL: "http://localhost:3000",
+        trace: "off",
       },
     },
   ],

--- a/tests/build/smoke.spec.ts
+++ b/tests/build/smoke.spec.ts
@@ -1,11 +1,6 @@
 import { test, expect } from "@tests/support/fixtures.js";
 
-test("exceptions in production build", async ({ page, browserName }) => {
-  // It's enough to check this once.
-  if (browserName !== "chromium") {
-    test.skip();
-  }
-
+test("exceptions in production build", async ({ page }) => {
   await page.goto("/");
   // Wait for scripts to finish executing, there might be exceptions that
   // happen after the page has been painted.

--- a/tests/e2e/hashRouter.spec.ts
+++ b/tests/e2e/hashRouter.spec.ts
@@ -1,4 +1,9 @@
-import { test, expect, appConfigWithFixture } from "@tests/support/fixtures.js";
+import {
+  test,
+  expect,
+  appConfigWithFixture,
+  projectFixtureUrl,
+} from "@tests/support/fixtures.js";
 import {
   expectBackAndForwardNavigationWorks,
   expectUrlPersistsReload,
@@ -18,7 +23,7 @@ test("navigate between landing and project page", async ({ page }) => {
 
   await page.locator("text=source-browsing").click();
   await expect(page).toHaveURL(
-    "/#/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81",
+    `/#${projectFixtureUrl}/tree/530aabdcc80397af254bc488b767169b92496e81`,
   );
 
   await expectBackAndForwardNavigationWorks("/#/", page);
@@ -31,7 +36,7 @@ test("navigation between seed and project pages", async ({ page }) => {
   const project = page.locator(".project");
   await project.click();
   await expect(page).toHaveURL(
-    "/#/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81",
+    `/#${projectFixtureUrl}/tree/530aabdcc80397af254bc488b767169b92496e81`,
   );
 
   await expectBackAndForwardNavigationWorks("/#/seeds/radicle.local", page);
@@ -45,13 +50,12 @@ test.describe("project page navigation", () => {
   test("navigation between commit history and single commit", async ({
     page,
   }) => {
-    const projectHistoryURL =
-      "/#/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/history/530aabdcc80397af254bc488b767169b92496e81";
+    const projectHistoryURL = `/#${projectFixtureUrl}/history/530aabdcc80397af254bc488b767169b92496e81`;
     await page.goto(projectHistoryURL);
 
     await page.locator("text=Add Markdown cheat sheet").click();
     await expect(page).toHaveURL(
-      "/#/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/commits/530aabdcc80397af254bc488b767169b92496e81",
+      `/#${projectFixtureUrl}/commits/530aabdcc80397af254bc488b767169b92496e81`,
     );
 
     await expectBackAndForwardNavigationWorks(projectHistoryURL, page);
@@ -59,15 +63,14 @@ test.describe("project page navigation", () => {
   });
 
   test("navigate between tree and commit history", async ({ page }) => {
-    const projectTreeURL =
-      "/#/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81";
+    const projectTreeURL = `/#${projectFixtureUrl}/tree/530aabdcc80397af254bc488b767169b92496e81`;
 
     await page.goto(projectTreeURL);
     await expect(page).toHaveURL(projectTreeURL);
 
     await page.locator('role=button[name="Commit count"]').click();
     await expect(page).toHaveURL(
-      "/#/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/history/530aabdcc80397af254bc488b767169b92496e81",
+      `/#${projectFixtureUrl}/history/530aabdcc80397af254bc488b767169b92496e81`,
     );
 
     await expectBackAndForwardNavigationWorks(projectTreeURL, page);
@@ -75,8 +78,7 @@ test.describe("project page navigation", () => {
   });
 
   test("navigate project paths", async ({ page }) => {
-    const projectTreeURL =
-      "/#/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81";
+    const projectTreeURL = `/#${projectFixtureUrl}/tree/530aabdcc80397af254bc488b767169b92496e81`;
 
     await page.goto(projectTreeURL);
     await expect(page).toHaveURL(projectTreeURL);
@@ -96,8 +98,7 @@ test.describe("project page navigation", () => {
   });
 
   test("navigate project paths with a selected peer", async ({ page }) => {
-    const projectTreeURL =
-      "/#/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/remotes/hyn1mjueopwzrmb18c3zmgg8ei8qunn5wpg76ouymytfqkfxqx7bun/tree";
+    const projectTreeURL = `/#${projectFixtureUrl}/remotes/hyn1mjueopwzrmb18c3zmgg8ei8qunn5wpg76ouymytfqkfxqx7bun/tree`;
 
     await page.goto(projectTreeURL);
     await expect(page).toHaveURL(projectTreeURL);

--- a/tests/e2e/hashRouter.spec.ts
+++ b/tests/e2e/hashRouter.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@tests/support/fixtures.js";
+import { test, expect, appConfigWithFixture } from "@tests/support/fixtures.js";
 import {
   expectBackAndForwardNavigationWorks,
   expectUrlPersistsReload,
@@ -11,26 +11,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test("navigate between landing and project page", async ({ page }) => {
-  await page.addInitScript(() => {
-    window.APP_CONFIG = {
-      walletConnect: {
-        bridge: "https://radicle.bridge.walletconnect.org",
-      },
-      reactions: [],
-      seeds: {
-        pinned: [{ host: "0.0.0.0", emoji: "🚀" }],
-      },
-      projects: {
-        pinned: [
-          {
-            name: "source-browsing",
-            urn: "rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o",
-            seed: "0.0.0.0",
-          },
-        ],
-      },
-    };
-  });
+  await page.addInitScript(appConfigWithFixture);
 
   await page.goto("/#/");
   await expect(page).toHaveURL("/#/");

--- a/tests/e2e/historyRouter.spec.ts
+++ b/tests/e2e/historyRouter.spec.ts
@@ -1,30 +1,11 @@
-import { test, expect } from "@tests/support/fixtures.js";
+import { test, expect, appConfigWithFixture } from "@tests/support/fixtures.js";
 import {
   expectBackAndForwardNavigationWorks,
   expectUrlPersistsReload,
 } from "@tests/support/router.js";
 
 test("navigate between landing and project page", async ({ page }) => {
-  await page.addInitScript(() => {
-    window.APP_CONFIG = {
-      walletConnect: {
-        bridge: "https://radicle.bridge.walletconnect.org",
-      },
-      reactions: [],
-      seeds: {
-        pinned: [{ host: "0.0.0.0", emoji: "🚀" }],
-      },
-      projects: {
-        pinned: [
-          {
-            name: "source-browsing",
-            urn: "rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o",
-            seed: "0.0.0.0",
-          },
-        ],
-      },
-    };
-  });
+  await page.addInitScript(appConfigWithFixture);
 
   await page.goto("/");
   await expect(page).toHaveURL("/");

--- a/tests/e2e/historyRouter.spec.ts
+++ b/tests/e2e/historyRouter.spec.ts
@@ -1,4 +1,9 @@
-import { test, expect, appConfigWithFixture } from "@tests/support/fixtures.js";
+import {
+  test,
+  expect,
+  appConfigWithFixture,
+  projectFixtureUrl,
+} from "@tests/support/fixtures.js";
 import {
   expectBackAndForwardNavigationWorks,
   expectUrlPersistsReload,
@@ -12,7 +17,7 @@ test("navigate between landing and project page", async ({ page }) => {
 
   await page.locator("text=source-browsing").click();
   await expect(page).toHaveURL(
-    "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81",
+    `${projectFixtureUrl}/tree/530aabdcc80397af254bc488b767169b92496e81`,
   );
 
   await expectBackAndForwardNavigationWorks("/", page);
@@ -25,7 +30,7 @@ test("navigation between seed and project pages", async ({ page }) => {
   const project = page.locator(".project");
   await project.click();
   await expect(page).toHaveURL(
-    "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81",
+    `${projectFixtureUrl}/tree/530aabdcc80397af254bc488b767169b92496e81`,
   );
 
   await expectBackAndForwardNavigationWorks("/seeds/radicle.local", page);
@@ -39,13 +44,12 @@ test.describe("project page navigation", () => {
   test("navigation between commit history and single commit", async ({
     page,
   }) => {
-    const projectHistoryURL =
-      "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/history/530aabdcc80397af254bc488b767169b92496e81";
+    const projectHistoryURL = `${projectFixtureUrl}/history/530aabdcc80397af254bc488b767169b92496e81`;
     await page.goto(projectHistoryURL);
 
     await page.locator("text=Add Markdown cheat sheet").click();
     await expect(page).toHaveURL(
-      "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/commits/530aabdcc80397af254bc488b767169b92496e81",
+      `${projectFixtureUrl}/commits/530aabdcc80397af254bc488b767169b92496e81`,
     );
 
     await expectBackAndForwardNavigationWorks(projectHistoryURL, page);
@@ -53,15 +57,14 @@ test.describe("project page navigation", () => {
   });
 
   test("navigate between tree and commit history", async ({ page }) => {
-    const projectTreeURL =
-      "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81";
+    const projectTreeURL = `${projectFixtureUrl}/tree/530aabdcc80397af254bc488b767169b92496e81`;
 
     await page.goto(projectTreeURL);
     await expect(page).toHaveURL(projectTreeURL);
 
     await page.locator('role=button[name="Commit count"]').click();
     await expect(page).toHaveURL(
-      "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/history/530aabdcc80397af254bc488b767169b92496e81",
+      `${projectFixtureUrl}/history/530aabdcc80397af254bc488b767169b92496e81`,
     );
 
     await expectBackAndForwardNavigationWorks(projectTreeURL, page);
@@ -69,8 +72,7 @@ test.describe("project page navigation", () => {
   });
 
   test("navigate project paths", async ({ page }) => {
-    const projectTreeURL =
-      "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/530aabdcc80397af254bc488b767169b92496e81";
+    const projectTreeURL = `${projectFixtureUrl}/tree/530aabdcc80397af254bc488b767169b92496e81`;
 
     await page.goto(projectTreeURL);
     await expect(page).toHaveURL(projectTreeURL);
@@ -90,8 +92,7 @@ test.describe("project page navigation", () => {
   });
 
   test("navigate project paths with a selected peer", async ({ page }) => {
-    const projectTreeURL =
-      "seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/remotes/hyn1mjueopwzrmb18c3zmgg8ei8qunn5wpg76ouymytfqkfxqx7bun/tree";
+    const projectTreeURL = `${projectFixtureUrl}/remotes/hyn1mjueopwzrmb18c3zmgg8ei8qunn5wpg76ouymytfqkfxqx7bun/tree`;
 
     await page.goto(projectTreeURL);
     await expect(page).toHaveURL(projectTreeURL);

--- a/tests/e2e/landingPage.spec.ts
+++ b/tests/e2e/landingPage.spec.ts
@@ -1,30 +1,11 @@
-import { test, expect } from "@tests/support/fixtures.js";
+import { test, expect, appConfigWithFixture } from "@tests/support/fixtures.js";
 
 test.use({
   customAppConfig: true,
 });
 
 test("show pinned projects", async ({ page }) => {
-  await page.addInitScript(() => {
-    window.APP_CONFIG = {
-      walletConnect: {
-        bridge: "https://radicle.bridge.walletconnect.org",
-      },
-      reactions: [],
-      seeds: {
-        pinned: [{ host: "0.0.0.0", emoji: "🚀" }],
-      },
-      projects: {
-        pinned: [
-          {
-            name: "source-browsing",
-            urn: "rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o",
-            seed: "0.0.0.0",
-          },
-        ],
-      },
-    };
-  });
+  await page.addInitScript(appConfigWithFixture);
   await page.goto("/");
   await expect(
     page.locator("text=Explore projects on the Radicle network."),

--- a/tests/e2e/project.spec.ts
+++ b/tests/e2e/project.spec.ts
@@ -1,9 +1,6 @@
 import type { Page } from "@playwright/test";
-import { test, expect } from "@tests/support/fixtures.js";
+import { test, expect, projectFixtureUrl } from "@tests/support/fixtures.js";
 import { expectUrlPersistsReload } from "@tests/support/router";
-
-const sourceBrowsingFixture =
-  "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o";
 
 async function expectCounts(
   params: { commits: number; contributors: number },
@@ -18,7 +15,7 @@ async function expectCounts(
 }
 
 test("navigate to project", async ({ page }) => {
-  await page.goto(sourceBrowsingFixture);
+  await page.goto(projectFixtureUrl);
 
   // Header.
   {
@@ -54,7 +51,7 @@ test("navigate to project", async ({ page }) => {
 });
 
 test("show source tree at specific revision", async ({ page }) => {
-  await page.goto(sourceBrowsingFixture);
+  await page.goto(projectFixtureUrl);
   await page.locator('role=button[name="Commit count"]').click();
 
   await page
@@ -70,7 +67,7 @@ test("show source tree at specific revision", async ({ page }) => {
 });
 
 test("source file highlighting", async ({ page }) => {
-  await page.goto(sourceBrowsingFixture);
+  await page.goto(projectFixtureUrl);
 
   await page.getByText("src/").click();
   await page.getByText("true.c").click();
@@ -82,7 +79,7 @@ test("source file highlighting", async ({ page }) => {
 });
 
 test("navigate line numbers", async ({ page }) => {
-  await page.goto(`${sourceBrowsingFixture}/tree/main/markdown/cheatsheet.md`);
+  await page.goto(`${projectFixtureUrl}/tree/main/markdown/cheatsheet.md`);
   await page.locator('role=button[name="Raw"]').click();
 
   await page.locator('[href="#L5"]').click();
@@ -108,7 +105,7 @@ test("navigate line numbers", async ({ page }) => {
 });
 
 test("navigate deep file hierarchies", async ({ page }) => {
-  await page.goto(sourceBrowsingFixture);
+  await page.goto(projectFixtureUrl);
 
   const sourceTree = page.locator(".source-tree");
 
@@ -151,7 +148,7 @@ test("navigate deep file hierarchies", async ({ page }) => {
 });
 
 test("files with special characters in the filename", async ({ page }) => {
-  await page.goto(sourceBrowsingFixture);
+  await page.goto(projectFixtureUrl);
 
   const sourceTree = page.locator(".source-tree");
   await sourceTree.getByText("special/").click();
@@ -195,7 +192,7 @@ test("files with special characters in the filename", async ({ page }) => {
 });
 
 test("binary files", async ({ page }) => {
-  await page.goto(sourceBrowsingFixture);
+  await page.goto(projectFixtureUrl);
 
   await page.getByText("bin/").click();
   await page.getByText("true").click();
@@ -204,7 +201,7 @@ test("binary files", async ({ page }) => {
 });
 
 test("hidden files", async ({ page }) => {
-  await page.goto(sourceBrowsingFixture);
+  await page.goto(projectFixtureUrl);
 
   await page.getByText(".hidden").click();
 
@@ -212,7 +209,7 @@ test("hidden files", async ({ page }) => {
 });
 
 test("markdown files", async ({ page }) => {
-  await page.goto(`${sourceBrowsingFixture}/tree/main/markdown/cheatsheet.md`);
+  await page.goto(`${projectFixtureUrl}/tree/main/markdown/cheatsheet.md`);
 
   await expect(
     page.locator("text=This is intended as a quick reference and showcase."),
@@ -240,7 +237,7 @@ test("markdown files", async ({ page }) => {
 });
 
 test("peer and branch switching", async ({ page }) => {
-  await page.goto(sourceBrowsingFixture);
+  await page.goto(projectFixtureUrl);
 
   // Alice's peer.
   {
@@ -319,7 +316,7 @@ test("peer and branch switching", async ({ page }) => {
 });
 
 test("clone modal", async ({ page }) => {
-  await page.goto(sourceBrowsingFixture);
+  await page.goto(projectFixtureUrl);
 
   await page.getByText("Clone").click();
   await expect(
@@ -335,7 +332,7 @@ test("clone modal", async ({ page }) => {
 });
 
 test("only one modal can be open at a time", async ({ page }) => {
-  await page.goto(sourceBrowsingFixture);
+  await page.goto(projectFixtureUrl);
 
   await page.getByTitle("Change peer").click();
   await page.locator("text=alice hyn1mj").click();

--- a/tests/e2e/project/commit.spec.ts
+++ b/tests/e2e/project/commit.spec.ts
@@ -1,11 +1,9 @@
-import { test, expect } from "@tests/support/fixtures.js";
+import { test, expect, projectFixtureUrl } from "@tests/support/fixtures.js";
 
-const sourceBrowsingFixture =
-  "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o";
-const modifiedFileFixture = `${sourceBrowsingFixture}/remotes/hyy1k6ggg45pi7ip7ksyn1wt1ob4w5zh1awtg4qu3cxmbh5mws8pj1/commits/0be0f0302269b362be0bfe72aa4843eceaac5e3f`;
+const modifiedFileFixture = `${projectFixtureUrl}/remotes/hyy1k6ggg45pi7ip7ksyn1wt1ob4w5zh1awtg4qu3cxmbh5mws8pj1/commits/0be0f0302269b362be0bfe72aa4843eceaac5e3f`;
 
 test("navigation from commit list", async ({ page }) => {
-  await page.goto(sourceBrowsingFixture);
+  await page.goto(projectFixtureUrl);
   await page.getByTitle("Change peer").click();
   await page.locator("text=bob hyy1k6").click();
   await page.locator('role=button[name="Commit count"]').click();
@@ -55,7 +53,7 @@ test("modified file", async ({ page }) => {
 
 test("created file", async ({ page }) => {
   await page.goto(
-    `${sourceBrowsingFixture}/remotes/hyn1mjueopwzrmb18c3zmgg8ei8qunn5wpg76ouymytfqkfxqx7bun/commits/d6318f7f3d9c15b8ac6dd52267c53220d00f0982`,
+    `${projectFixtureUrl}/remotes/hyn1mjueopwzrmb18c3zmgg8ei8qunn5wpg76ouymytfqkfxqx7bun/commits/d6318f7f3d9c15b8ac6dd52267c53220d00f0982`,
   );
   await expect(
     page.locator("text=1 file(s) created with 9 addition(s) and 0 deletion(s)"),
@@ -65,7 +63,7 @@ test("created file", async ({ page }) => {
 
 test("deleted file", async ({ page }) => {
   await page.goto(
-    `${sourceBrowsingFixture}/remotes/hyn1mjueopwzrmb18c3zmgg8ei8qunn5wpg76ouymytfqkfxqx7bun/commits/cd13c2d9a8a930d64a82b6134b44d1b872e33662`,
+    `${projectFixtureUrl}/remotes/hyn1mjueopwzrmb18c3zmgg8ei8qunn5wpg76ouymytfqkfxqx7bun/commits/cd13c2d9a8a930d64a82b6134b44d1b872e33662`,
   );
   await expect(
     page.locator("text=1 file(s) deleted with 0 addition(s) and 1 deletion(s)"),
@@ -75,7 +73,7 @@ test("deleted file", async ({ page }) => {
 
 test("navigation to source tree at specific revision", async ({ page }) => {
   await page.goto(
-    `${sourceBrowsingFixture}/commits/0801aceeab500033f8d608778218657bd626ef73`,
+    `${projectFixtureUrl}/commits/0801aceeab500033f8d608778218657bd626ef73`,
   );
 
   // Go to source tree at this revision.
@@ -84,7 +82,7 @@ test("navigation to source tree at specific revision", async ({ page }) => {
     page.locator("text=Add a deeply nested directory tree"),
   ).toBeVisible();
   await expect(page).toHaveURL(
-    `${sourceBrowsingFixture}/tree/0801aceeab500033f8d608778218657bd626ef73/deep/directory/hierarchy/is/entirely/possible/in/git/repositories/.gitkeep`,
+    `${projectFixtureUrl}/tree/0801aceeab500033f8d608778218657bd626ef73/deep/directory/hierarchy/is/entirely/possible/in/git/repositories/.gitkeep`,
   );
   await expect(page.getByTitle("Current branch")).toContainText(
     "0801aceeab500033f8d608778218657bd626ef73",

--- a/tests/e2e/project/commits.spec.ts
+++ b/tests/e2e/project/commits.spec.ts
@@ -1,10 +1,7 @@
-import { test, expect } from "@tests/support/fixtures.js";
-
-const sourceBrowsingFixture =
-  "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o";
+import { test, expect, projectFixtureUrl } from "@tests/support/fixtures.js";
 
 test("peer and branch switching", async ({ page }) => {
-  await page.goto(sourceBrowsingFixture);
+  await page.goto(projectFixtureUrl);
   await page.locator('role=button[name="Commit count"]').click();
 
   // Alice's peer.
@@ -79,7 +76,7 @@ test("peer and branch switching", async ({ page }) => {
 });
 
 test("verified badge", async ({ page }) => {
-  await page.goto(sourceBrowsingFixture);
+  await page.goto(projectFixtureUrl);
   await page.locator('role=button[name="Commit count"]').click();
 
   await page.getByTitle("Change peer").click();
@@ -111,7 +108,7 @@ test("relative timestamps", async ({ page }) => {
     };
   });
 
-  await page.goto(sourceBrowsingFixture);
+  await page.goto(projectFixtureUrl);
   await page.locator('role=button[name="Commit count"]').click();
 
   await page.getByTitle("Change peer").click();

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,7 +1,6 @@
-import { test, expect } from "@tests/support/fixtures.js";
+import { test, expect, projectFixtureUrl } from "@tests/support/fixtures.js";
 
-const sourceBrowsingFixture =
-  "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o/tree/main/src/true.c";
+const sourceBrowsingFixture = `${projectFixtureUrl}/tree/main/src/true.c`;
 
 test("default settings", async ({ page }) => {
   await page.goto(sourceBrowsingFixture);

--- a/tests/support/fixtures.ts
+++ b/tests/support/fixtures.ts
@@ -139,7 +139,10 @@ export const test = base.extend<{
     await Fs.mkdir(stateDir, { recursive: true });
 
     await use(stateDir);
-    if (process.env.CI && testInfo.status === "passed") {
+    if (
+      process.env.CI &&
+      (testInfo.status === "passed" || testInfo.status === "skipped")
+    ) {
       await Fs.rm(stateDir, { recursive: true });
     }
   },

--- a/tests/support/fixtures.ts
+++ b/tests/support/fixtures.ts
@@ -156,3 +156,24 @@ function log(text: string, label: string, outputLog: Stream.Writable) {
     console.log(output);
   }
 }
+
+export function appConfigWithFixture() {
+  window.APP_CONFIG = {
+    walletConnect: {
+      bridge: "https://radicle.bridge.walletconnect.org",
+    },
+    reactions: [],
+    seeds: {
+      pinned: [{ host: "0.0.0.0", emoji: "🚀" }],
+    },
+    projects: {
+      pinned: [
+        {
+          name: "source-browsing",
+          urn: "rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o",
+          seed: "0.0.0.0",
+        },
+      ],
+    },
+  };
+}

--- a/tests/support/fixtures.ts
+++ b/tests/support/fixtures.ts
@@ -177,3 +177,6 @@ export function appConfigWithFixture() {
     },
   };
 }
+
+export const projectFixtureUrl =
+  "/seeds/0.0.0.0/rad:git:hnrkgd7sjt79k4j59ddh11ooxg18rk7soej8o";

--- a/tests/visual/landingPage.spec.ts
+++ b/tests/visual/landingPage.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect, appConfigWithFixture } from "@tests/support/fixtures.js";
+
+test.use({
+  customAppConfig: true,
+});
+
+test("landing page", async ({ page }) => {
+  await page.addInitScript(appConfigWithFixture);
+  await page.goto("/");
+  await expect(page).toHaveScreenshot();
+});

--- a/tests/visual/project.spec.ts
+++ b/tests/visual/project.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect, projectFixtureUrl } from "@tests/support/fixtures.js";
+
+test("source tree page", async ({ page }) => {
+  await page.goto(projectFixtureUrl);
+  await expect(page).toHaveScreenshot();
+});
+
+test("commits page", async ({ page }) => {
+  await page.goto(
+    `${projectFixtureUrl}/remotes/hyn1mjueopwzrmb18c3zmgg8ei8qunn5wpg76ouymytfqkfxqx7bun/history`,
+  );
+  await expect(page).toHaveScreenshot({ fullPage: true });
+});
+
+test("commit page", async ({ page }) => {
+  await page.goto(
+    `${projectFixtureUrl}/remotes/hyn1mjueopwzrmb18c3zmgg8ei8qunn5wpg76ouymytfqkfxqx7bun/commits/d6318f7f3d9c15b8ac6dd52267c53220d00f0982`,
+  );
+  await expect(page).toHaveScreenshot({ fullPage: true });
+});
+
+test("markdown rendering", async ({ page }) => {
+  await page.goto(`${projectFixtureUrl}/tree/main/markdown/cheatsheet.md`);
+  await expect(page).toHaveScreenshot({ fullPage: true });
+});

--- a/tests/visual/seed.spec.ts
+++ b/tests/visual/seed.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from "@tests/support/fixtures.js";
+
+test("seed page", async ({ page }) => {
+  await page.goto("/seeds/radicle.local");
+  await expect(page).toHaveScreenshot();
+});


### PR DESCRIPTION
We abuse the Github cache action to store generated snapshots when pushing to master and then load them in pull requests and run the visual tests against it. This way we don't have to commit the images to the repository and always get visual diffs against the latest master.

Here's how the proposed workflow could look like:

- When this check fails, it means that there are visual differences in the proposed pull request.

  <img width="838" alt="Screenshot 2022-12-15 at 21 01 59" src="https://user-images.githubusercontent.com/158411/207955835-c1080775-bbae-4b46-86c5-a309649a0959.png">

- In this case the reviewer has to download the artifacts and check that the visual changes are not regressions, but intentional changes.

  <img width="1840" alt="Screenshot 2022-12-15 at 21 03 37" src="https://user-images.githubusercontent.com/158411/207956172-bc96aa2e-1719-4034-911a-22f54b475145.png">

- In this case it seems like there is a visual regression that was not intended:

  ![landing-page-1-actual](https://user-images.githubusercontent.com/158411/207955731-b15a5314-37ad-4434-b1c9-b58927d216e5.png)
  ![landing-page-1-diff](https://user-images.githubusercontent.com/158411/207955736-fdea156f-be85-44ec-9755-2519d4a3fe4b.png)
  ![landing-page-1-expected](https://user-images.githubusercontent.com/158411/207955740-95074058-e3f3-4c70-9571-09c52dcb17df.png)

- We ask the PR author to fix the problem
- Author fixes the issue, pushes the changes and the check passes
- We merge to master and the snapshots automatically get updated in case the tests got adjusted

A potential follow up could be to push the failed test images to GCP and link them in a PR comment automatically, so we don't have to download the zip file and inspect it.

An example run: https://github.com/rudolfs/radicle-interface/pull/5.