### PR TITLE
Small CI improvements

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   check-build:
-    if: github.event.pull_request.merged == false
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
@@ -25,10 +24,12 @@ jobs:
         run: npm run build
       - name: Run Playwright build smoke test
         run: npm run test:e2e -- --project chromium --config playwright.buildSmoke.config.ts
-      - uses: actions/upload-artifact@v3
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: test-artifacts-${{ runner.os }}
           retention-days: 30
+          if-no-files-found: "ignore"
           path: |
             tests/artifacts/**/*

--- a/.github/workflows/check-e2e.yml
+++ b/.github/workflows/check-e2e.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   check-e2e:
-    if: github.event.pull_request.merged == false
     continue-on-error: true
     strategy:
       matrix:
@@ -33,14 +32,14 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
 
-      - name: Cache snapshots (generate on master, load on pull_request)
+      - name: Cache Playwright visual snapshots
         uses: actions/cache@v3
         id: playwright-snapshot-cache
         with:
           path: tests/visual/snapshots/**/*
           key: ${{ runner.os }}-snapshots
 
-      - name: Install Playwright with deps unless cached
+      - name: Install Playwright browsers and OS dependencies if cache miss
         if: steps.playwright-dep-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
@@ -59,10 +58,12 @@ jobs:
             npm run test:e2e -- --project ${{ matrix.browser }};
           fi
 
-      - uses: actions/upload-artifact@v3
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: test-artifacts-${{ runner.os }}
           retention-days: 30
+          if-no-files-found: "ignore"
           path: |
             tests/artifacts/**/*

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   check-format:
-    if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node

--- a/.github/workflows/check-unit-test.yml
+++ b/.github/workflows/check-unit-test.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   check-unit-test:
-    if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   check:
-    if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,8 +41,9 @@ const config: PlaywrightTestConfig = {
     },
     {
       name: "visual",
+      timeout: 60_000,
       expect: {
-        timeout: 16_000,
+        timeout: 30_000,
         toHaveScreenshot: {
           threshold: 0.1,
           scale: "device",


### PR DESCRIPTION
CI seems to take longer for the big markdown screenshot diff (usually around 22s).
Ignore warnings about there being no artifacts to upload.