### PR TITLE
Skip objects in front-matter

### DIFF
--- a/src/Markdown.svelte
+++ b/src/Markdown.svelte
@@ -22,7 +22,9 @@
   export let getImage: (path: string) => Promise<proj.Blob>;
   export let hash: string | null = null;
 
-  const frontMatter = Object.entries(doc.data);
+  const frontMatter = Object.entries(doc.data).filter(
+    ([, val]) => typeof val === "string" || typeof val === "number",
+  );
   marked.use({ extensions, renderer });
 
   let container: HTMLElement;


### PR DESCRIPTION
This PR closes #540 

It filters out any `Object.entries` that are either `string` or `number`