### PR TITLE
Fix flaky visual tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ public/twemoji/*.svg
 # Integration Tests
 tests/tmp/**/*
 tests/artifacts/**/*
+tests/visual/snapshots/**/*
 
 # Mac OS
 .DS_Store

--- a/tests/e2e/project/commit.spec.ts
+++ b/tests/e2e/project/commit.spec.ts
@@ -13,7 +13,7 @@ test("navigation from commit list", async ({ page }) => {
 });
 
 test("relative timestamps", async ({ page }) => {
-  page.addInitScript(() => {
+  await page.addInitScript(() => {
     window.initializeTestStubs = () => {
       window.e2eTestStubs.FakeTimers.install({
         now: new Date("November 24 2022 12:00:00").valueOf(),

--- a/tests/e2e/project/commits.spec.ts
+++ b/tests/e2e/project/commits.spec.ts
@@ -98,7 +98,7 @@ test("verified badge", async ({ page }) => {
 });
 
 test("relative timestamps", async ({ page }) => {
-  page.addInitScript(() => {
+  await page.addInitScript(() => {
     window.initializeTestStubs = () => {
       window.e2eTestStubs.FakeTimers.install({
         now: new Date("November 24 2022 12:00:00").valueOf(),

--- a/tests/visual/landingPage.spec.ts
+++ b/tests/visual/landingPage.spec.ts
@@ -6,6 +6,6 @@ test.use({
 
 test("landing page", async ({ page }) => {
   await page.addInitScript(appConfigWithFixture);
-  await page.goto("/");
+  await page.goto("/", { waitUntil: "networkidle" });
   await expect(page).toHaveScreenshot();
 });

--- a/tests/visual/project.spec.ts
+++ b/tests/visual/project.spec.ts
@@ -1,18 +1,40 @@
 import { test, expect, projectFixtureUrl } from "@tests/support/fixtures.js";
 
 test("source tree page", async ({ page }) => {
-  await page.goto(projectFixtureUrl);
+  await page.goto(projectFixtureUrl, { waitUntil: "networkidle" });
   await expect(page).toHaveScreenshot();
 });
 
 test("commits page", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.initializeTestStubs = () => {
+      window.e2eTestStubs.FakeTimers.install({
+        now: new Date("November 24 2022 12:00:00").valueOf(),
+        shouldClearNativeTimers: true,
+        shouldAdvanceTime: false,
+      });
+    };
+  });
+
   await page.goto(
     `${projectFixtureUrl}/remotes/hyn1mjueopwzrmb18c3zmgg8ei8qunn5wpg76ouymytfqkfxqx7bun/history`,
+    { waitUntil: "networkidle" },
   );
+
   await expect(page).toHaveScreenshot({ fullPage: true });
 });
 
 test("commit page", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.initializeTestStubs = () => {
+      window.e2eTestStubs.FakeTimers.install({
+        now: new Date("November 24 2022 12:00:00").valueOf(),
+        shouldClearNativeTimers: true,
+        shouldAdvanceTime: false,
+      });
+    };
+  });
+
   await page.goto(
     `${projectFixtureUrl}/remotes/hyn1mjueopwzrmb18c3zmgg8ei8qunn5wpg76ouymytfqkfxqx7bun/commits/d6318f7f3d9c15b8ac6dd52267c53220d00f0982`,
   );
@@ -20,6 +42,8 @@ test("commit page", async ({ page }) => {
 });
 
 test("markdown rendering", async ({ page }) => {
-  await page.goto(`${projectFixtureUrl}/tree/main/markdown/cheatsheet.md`);
+  await page.goto(`${projectFixtureUrl}/tree/main/markdown/cheatsheet.md`, {
+    waitUntil: "networkidle",
+  });
   await expect(page).toHaveScreenshot({ fullPage: true });
 });

--- a/tests/visual/seed.spec.ts
+++ b/tests/visual/seed.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@tests/support/fixtures.js";
 
 test("seed page", async ({ page }) => {
-  await page.goto("/seeds/radicle.local");
+  await page.goto("/seeds/radicle.local", { waitUntil: "networkidle" });
   await expect(page).toHaveScreenshot();
 });


### PR DESCRIPTION
Forgot to mock time in some places. Some tests would run too fast locally and the snapshots would end up showing a loading state, hence the added `{ waitUntil: "networkidle" }`.