### PR TITLE
Rename issue/patch APIs

### DIFF
--- a/src/components/Authorship.svelte
+++ b/src/components/Authorship.svelte
@@ -17,11 +17,15 @@
 
   onMount(async () => {
     if (author.profile?.ens?.name) {
-      profile = await Profile.get(
-        author.profile.ens.name,
-        ProfileType.Minimal,
-        wallet,
-      );
+      try {
+        profile = await Profile.get(
+          author.profile.ens.name,
+          ProfileType.Minimal,
+          wallet,
+        );
+      } catch {
+        // Ignore profile not found.
+      }
     }
   });
 </script>

--- a/src/lib/diff.ts
+++ b/src/lib/diff.ts
@@ -41,7 +41,7 @@ export const lineSign = (line: LineDiff): string => {
 };
 
 export enum LineDiffType {
-  Addition = "insertion",
+  Addition = "addition",
   Context = "context",
   Deletion = "deletion",
 }

--- a/src/lib/issue.ts
+++ b/src/lib/issue.ts
@@ -14,7 +14,7 @@ export interface IIssue {
   state: State;
   comment: Comment;
   discussion: Thread[];
-  labels: Label[];
+  tags: Tag[];
   timestamp: number;
 }
 
@@ -37,7 +37,7 @@ export interface Comment<R = null> {
 
 export type Thread = Comment<Comment[]>;
 
-export type Label = string;
+export type Tag = string;
 
 export function groupIssues(issues: Issue[]): {
   open: Issue[];
@@ -59,7 +59,7 @@ export class Issue {
   state: State;
   comment: Comment;
   discussion: Thread[];
-  labels: Label[];
+  tags: Tag[];
   timestamp: number;
 
   constructor(issue: IIssue) {
@@ -69,7 +69,7 @@ export class Issue {
     this.state = issue.state;
     this.comment = issue.comment;
     this.discussion = issue.discussion;
-    this.labels = issue.labels;
+    this.tags = issue.tags;
     this.timestamp = issue.timestamp;
   }
 

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -289,9 +289,6 @@ export class Project implements ProjectInfo {
       for (const file of result.diff[kind]) {
         for (const hunk of file.diff.hunks) {
           for (const line of hunk.lines) {
-            if (line["type"] === "addition") {
-              line["type"] = "insertion";
-            }
             if (line["lineNumOld"]) {
               line["lineNoOld"] = line["lineNumOld"];
               delete line["lineNumOld"];

--- a/src/views/projects/Issue.svelte
+++ b/src/views/projects/Issue.svelte
@@ -150,14 +150,14 @@
     </div>
     <div class="metadata layout-desktop">
       <div class="metadata-section">
-        <div class="metadata-section-header">Labels</div>
+        <div class="metadata-section-header">Tags</div>
         <div class="metadata-section-body">
-          {#if issue.labels?.length}
-            {#each issue.labels as label}
-              <span class="label">{label}</span>
+          {#if issue.tags?.length}
+            {#each issue.tags as tag}
+              <span class="label">{tag}</span>
             {/each}
           {:else}
-            <div class="metadata-section-empty">No labels.</div>
+            <div class="metadata-section-empty">No tags.</div>
           {/if}
         </div>
       </div>

--- a/src/views/projects/Patch/PatchTimeline.svelte
+++ b/src/views/projects/Patch/PatchTimeline.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Wallet } from "@app/lib/wallet";
-  import { type Patch, TimelineType } from "@app/lib/patch";
+  import { Patch, TimelineType } from "@app/lib/patch";
   import { formatSeedId } from "@app/lib/utils";
   import { canonicalize } from "@app/lib/utils";
   import Comment from "@app/components/Comment.svelte";


### PR DESCRIPTION
To reduce the scope of #515.

The legacy seeds don't have any working issues, so I didn't bother to write any translation.
This fixes patch browsing, there was a regression.

Test it against: http://127.0.0.1:3000/seeds/clients.radicle.xyz/rad:git:hnrkq5sti58yw41szighu565oprgt5eduhmhy/patches/hnrkkktb1dyt9gkuufzuax1uzdoueiskxzrto
