### PR TITLE
Fix a couple of markdown styles

### DIFF
--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -253,6 +253,12 @@
     padding-left: 1.25rem;
     margin-bottom: 1rem;
   }
+  .markdown :global(li > ul) {
+    margin-bottom: 0rem;
+  }
+  .markdown :global(li > ol) {
+    margin-bottom: 0rem;
+  }
   .markdown :global(table) {
     margin: 1.5rem 0;
     border-collapse: collapse;

--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -173,9 +173,10 @@
   }
 
   .markdown :global(blockquote) {
+    color: var(--color-foreground-6);
     border-left: 0.3rem solid var(--color-foreground-4);
     padding: 0 0 0 1rem;
-    margin: 0 0 0.625rem 0;
+    margin: 1rem 0 1rem 0;
   }
 
   .markdown :global(strong) {
@@ -190,7 +191,7 @@
   .markdown :global(code) {
     font-family: var(--font-family-monospace);
     font-size: var(--font-size-regular);
-    color: var(--color-foreground);
+    color: var(--color-foreground-6);
     background-color: var(--color-foreground-2);
     border-radius: 0.5rem;
     padding: 0.125rem 0.25rem;


### PR DESCRIPTION
It looks like there was maybe a regression at some point (I guess [here](https://github.com/radicle-dev/radicle-interface/commit/569b6601341af8cd9fb31232bf6bde4ecd1c8a25)) and we lost the colors on the code and blockquote blocks. This adds them back. We also give blockquotes some padding like regular paragraphs.

Edit: how can I fix the visual test failure?

Signed-off-by: Alexis Sellier <self@cloudhead.io>