### PR TITLE
Add footnotes support to markdown

### DIFF
--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -8,15 +8,12 @@
   import { toDom } from "hast-util-to-dom";
 
   import { base } from "@app/lib/router";
+  import { getImageMime, isUrl, twemoji, scrollIntoView } from "@app/lib/utils";
   import { highlight } from "@app/lib/syntax";
   import {
     markdownExtensions as extensions,
     renderer,
-    getImageMime,
-    isUrl,
-    twemoji,
-    scrollIntoView,
-  } from "@app/lib/utils";
+  } from "@app/lib/markdown";
 
   export let content: string;
   export let doc = matter(content);
@@ -183,6 +180,12 @@
     font-weight: var(--font-weight-medium);
   }
 
+  .markdown :global(.footnote-ref > a),
+  .markdown :global(a.ref-arrow) {
+    border-bottom: none;
+    color: unset;
+  }
+
   .markdown :global(img) {
     border-style: none;
     max-width: 100%;
@@ -309,6 +312,6 @@
   </div>
 {/if}
 
-<div class="markdown" bind:this={container} use:twemoji>
+<div class="markdown" bind:this={container} use:twemoji={{ exclude: ["21a9"] }}>
   {@html render(doc.content)}
 </div>

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,136 @@
+import emojis from "@app/lib/emojis";
+import katex from "katex";
+import { marked } from "marked";
+
+const emojisMarkedExtension = {
+  name: "emoji",
+  level: "inline",
+  start: (src: string) => src.indexOf(":"),
+  tokenizer(src: string) {
+    const match = src.match(/^:([\w+-]+):/);
+    if (match) {
+      return {
+        type: "emoji",
+        raw: match[0],
+        text: match[1].trim(),
+      };
+    }
+  },
+  renderer: (token: marked.Tokens.Generic) => {
+    return `<span>${
+      token.text in emojis ? emojis[token.text] : token.text
+    }</span>`;
+  },
+};
+
+const katexMarkedExtension = {
+  name: "katex",
+  level: "inline",
+  start: (src: string) => src.indexOf("$"),
+  tokenizer(src: string) {
+    const match = src.match(/^\$+([^$\n]+?)\$+/);
+    if (match) {
+      return {
+        type: "katex",
+        raw: match[0],
+        text: match[1].trim(),
+      };
+    }
+  },
+  renderer: (token: marked.Tokens.Generic) =>
+    katex.renderToString(token.text, {
+      throwOnError: false,
+    }),
+};
+const footnotePrefix = "marked-fn";
+const referencePrefix = "marked-fnref";
+const referenceMatch = /^\[\^([^\]]+)\](?!\()/;
+
+const footnoteReferenceMarkedExtension = {
+  name: "footnote-ref",
+  level: "inline",
+  start: (src: string) => referenceMatch.test(src),
+  tokenizer(src: string) {
+    const match = src.match(referenceMatch);
+    if (match) {
+      return {
+        type: "footnote-ref",
+        raw: match[0],
+        text: match[1].trim(),
+      };
+    }
+  },
+  renderer: (token: marked.Tokens.Generic) => {
+    return `<sup class="footnote-ref" id="${referencePrefix}:${token.text}"><a href="#${footnotePrefix}:${token.text}">[${token.text}]</a></sup>`;
+  },
+};
+const footnoteMatch = /^\[\^([^\]]+)\]:\s([\S]*)/;
+const footnoteMarkedExtension = {
+  name: "footnote",
+  level: "block",
+  start: (src: string) => footnoteMatch.test(src),
+  tokenizer(src: string) {
+    const match = src.match(footnoteMatch);
+    if (match) {
+      return {
+        type: "footnote",
+        raw: match[0],
+        reference: match[1].trim(),
+        text: match[2].trim(),
+      };
+    }
+  },
+  renderer: (token: marked.Tokens.Generic) => {
+    return `<p class="txt-small" id="${footnotePrefix}:${token.reference}">${
+      token.reference
+    }. ${marked.parseInline(
+      token.text,
+    )} <a class="txt-tiny ref-arrow" href="#${referencePrefix}:${
+      token.reference
+    }">↩</a></p>`;
+  },
+};
+
+// Converts self closing anchor tags into empty anchor tags, to avoid erratic wrapping behaviour
+// e.g. <a name="test"/> -> <a name="test"></a>
+const anchorMarkedExtension = {
+  name: "sanitizedAnchor",
+  level: "block",
+  start: (src: string) => src.match(/<a name="([\w]+)"\/>/)?.index,
+  tokenizer(src: string) {
+    const match = src.match(/^<a name="([\w]+)"\/>/);
+    if (match) {
+      return {
+        type: "sanitizedAnchor",
+        raw: match[0],
+        text: match[1].trim(),
+      };
+    }
+  },
+  renderer: (token: marked.Tokens.Generic) => {
+    return `<a name="${token.text}"></a>`;
+  },
+};
+
+// Overwrites the rendering of heading tokens.
+// Since there are possible non ASCII characters in headings,
+// we escape them by replacing them with dashes and,
+// trim eventual dashes on each side of the string.
+export const renderer = {
+  heading(text: string, level: 1 | 2 | 3 | 4 | 5 | 6) {
+    const escapedText = text
+      .toLowerCase()
+      .replace(/[^\w]+/g, "-")
+      .replace(/^-|-$/g, "");
+
+    return `<h${level} id="${escapedText}">${text}</h${level}>`;
+  },
+};
+
+export const markdownExtensions = [
+  anchorMarkedExtension,
+  emojisMarkedExtension,
+  footnoteMarkedExtension,
+  footnoteReferenceMarkedExtension,
+  katexMarkedExtension,
+];

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -37,23 +37,6 @@ describe("Format functions", () => {
   });
 
   test.each([
-    {
-      input: "seedling",
-      expected: "🌱",
-    },
-    {
-      input: "+1",
-      expected: "👍",
-    },
-    {
-      input: "radicle",
-      expected: "radicle",
-    },
-  ])("parseEmoji $input => $expected", ({ input, expected }) => {
-    expect(utils.parseEmoji(input)).toEqual(expected);
-  });
-
-  test.each([
     { commit: "a8a6a979a6261a2ec1ea85fc9a65a4a30aa22cc8", expected: "a8a6a97" },
     { commit: "a8a6a97", expected: "a8a6a97" },
   ])("formatCommit $commit => $expected", ({ commit, expected }) => {


### PR DESCRIPTION
This PR adds support for footnotes in markdown.

It does so by adding two more markdown extensions:
- One for the inline footnote reference.
- And the other for the footnotes at the end of the document.

~~There is still some work left, I would like to wrap the footnotes at the end of the document inside some `<section>` to get a specific styling applied.
Also there are some edge cases I would like to fix.~~
This can be revisited in a different PR if needed, for now this solves the issue at hand.

This PR will eventually close #575 

### Pictures for reference:
<img width="991" alt="Bildschirm­foto 2023-01-05 um 11 22 44" src="https://user-images.githubusercontent.com/7912302/210757790-a8bfb2d1-af27-4755-a6e2-8ad70af1261f.png">
<img width="865" alt="Bildschirm­foto 2023-01-13 um 14 09 06" src="https://user-images.githubusercontent.com/7912302/212327367-b605ab48-c8c3-423c-af4d-15a9f275a9a6.png">

