### PR TITLE
Download radicle-httpd executable for e2e tests

### DIFF
--- a/.github/workflows/check-e2e.yml
+++ b/.github/workflows/check-e2e.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   check-e2e:
+    permissions:
+      contents: "read"
+      id-token: "write"
     continue-on-error: true
     strategy:
       matrix:
@@ -54,10 +57,20 @@ jobs:
         if: steps.playwright-dep-cache.outputs.cache-hit != 'true'
         run: npx playwright install chromium firefox
 
+      - id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: "projects/281042598092/locations/global/workloadIdentityPools/github-actions/providers/google-cloud"
+          service_account: "github-actions@radicle-services.iam.gserviceaccount.com"
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
       - name: Start http-api test server
         run: |
           if [ ${{ matrix.browser }} = "heartwood" ]; then
-            ./scripts/run-httpd-with-fixtures --non-interactive --detach
+            mkdir -p tests/artifacts
+            ./scripts/run-httpd-with-fixtures --non-interactive --binary 2>&1 | tee tests/artifacts/httpd-${{ matrix.browser }}.log &
           else
             ./scripts/run-http-api-with-fixtures --non-interactive --detach
           fi

--- a/scripts/run-httpd-with-fixtures
+++ b/scripts/run-httpd-with-fixtures
@@ -49,9 +49,6 @@ prepare_workspace() {
   echo "Unpacking fixture $FIXTURE"
   mkdir -p $WORKSPACE
   tar -xf $FIXTURE -C $WORKSPACE
-  if [ "$CI" = true ]; then
-    sudo chown -R 0:0 $WORKSPACE
-  fi
 }
 
 run_docker() {
@@ -72,6 +69,13 @@ run_docker() {
 }
 
 run_binary() {
+  if [ $CI = true ]; then
+    local binaries_dir="$REPO_ROOT/tests/tmp"
+    gsutil cp "gs://heartwood-artifacts/${REV}/radicle-httpd" "$binaries_dir"
+    chmod a+x "${binaries_dir}/radicle-httpd"
+    export PATH="$binaries_dir:$PATH"
+  fi
+
   if ! [ -x "$(command -v $HTTP_API_BINARY)" ]; then
     echo
     echo "Couldn't find the $HTTP_API_BINARY binary in your PATH."


### PR DESCRIPTION
~~Demonstrates how to obtain `radicle-httpd` binary for e2e tests.~~
Uses a statically linked `radicle-httpd` executable to run e2e tests in CI (i.e. no Docker).