### PR TITLE
Fix flaky visual landing page spec

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install chromium
       - name: Build app
         run: npm run build
       - name: Run Playwright build smoke test

--- a/.github/workflows/check-e2e.yml
+++ b/.github/workflows/check-e2e.yml
@@ -50,13 +50,9 @@ jobs:
           path: tests/visual/snapshots/**/*
           key: ${{ runner.os }}-snapshots
 
-      - name: Install Playwright browsers and OS dependencies if cache miss
+      - name: Install Playwright browsers
         if: steps.playwright-dep-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
-
-      - name: Install only Playwright OS dependencies if cache hit
-        if: steps.playwright-dep-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps
+        run: npx playwright install chromium firefox
 
       - name: Start http-api test server
         run: |

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -18,7 +18,7 @@ declare global {
     //   src/config.ts
     APP_CONFIG: Config;
     // eslint-disable-next-line @typescript-eslint/ban-types
-    initializeTestStubs: Function;
+    initializeTestStubs?: Function;
     e2eTestStubs: {
       FakeTimers: FakeTimers;
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
-if (window.PLAYWRIGHT) import("@app/lib/e2eTestStubs");
+import * as FakeTimers from "@sinonjs/fake-timers";
+
+if (window.PLAYWRIGHT && window.initializeTestStubs !== undefined) {
+  window.e2eTestStubs = {
+    FakeTimers: FakeTimers,
+  };
+  window.initializeTestStubs();
+}
+
 import App from "@app/App.svelte";
 
 const app = new App({

--- a/src/lib/e2eTestStubs.ts
+++ b/src/lib/e2eTestStubs.ts
@@ -1,8 +1,0 @@
-import * as FakeTimers from "@sinonjs/fake-timers";
-
-if (typeof window.initializeTestStubs === "function") {
-  window.e2eTestStubs = {
-    FakeTimers: FakeTimers,
-  };
-  window.initializeTestStubs();
-}


### PR DESCRIPTION
Current working theory: the dynamic import made the timer stubs load in the wrong order sometimes.
Not a 100% sure tho. 🤷 

This also removes the playwright deps install steps from the jobs. Apparently the tests work just fine without them. Saves us some build time.