### PR TITLE
Add httpd session route

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,6 +10,7 @@
 
   import NotFound from "@app/components/NotFound.svelte";
   import Home from "@app/views/home/Index.svelte";
+  import Session from "@app/views/session/Index.svelte";
   import Projects from "@app/views/projects/View.svelte";
   import Seeds from "@app/views/seeds/Routes.svelte";
 
@@ -56,6 +57,8 @@
       <Home />
     {:else if $activeRouteStore.resource === "seeds"}
       <Seeds host={$activeRouteStore.params.host} />
+    {:else if $activeRouteStore.resource === "session"}
+      <Session activeRoute={$activeRouteStore} />
     {:else if $activeRouteStore.resource === "projects"}
       <Projects activeRoute={$activeRouteStore} />
     {:else if $activeRouteStore.resource === "404"}

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -181,6 +181,20 @@ function pathToRoute(path: string): Route | null {
       }
       return null;
     }
+    case "session": {
+      const id = segments.shift();
+      if (id) {
+        return {
+          resource: "session",
+          params: {
+            id,
+            signature: url.searchParams.get("sig") ?? "",
+            publicKey: url.searchParams.get("pk") ?? "",
+          },
+        };
+      }
+      return { resource: "home" };
+    }
     case "": {
       return { resource: "home" };
     }
@@ -193,6 +207,8 @@ function pathToRoute(path: string): Route | null {
 export function routeToPath(route: Route) {
   if (route.resource === "home") {
     return "/";
+  } else if (route.resource === "session") {
+    return `/session?id=${route.params.id}&sig=${route.params.signature}&pk=${route.params.publicKey}`;
   } else if (route.resource === "seeds") {
     return `/seeds/${route.params.host}`;
   } else if (route.resource === "projects") {

--- a/src/lib/router/definitions.ts
+++ b/src/lib/router/definitions.ts
@@ -1,6 +1,10 @@
 export type Route =
   | ProjectRoute
   | { resource: "home" }
+  | {
+      resource: "session";
+      params: { id: string; signature: string; publicKey: string };
+    }
   | { resource: "404"; params: { url: string } }
   | { resource: "seeds"; params: { host: string } };
 

--- a/src/views/session/Index.svelte
+++ b/src/views/session/Index.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import type { Route } from "@app/lib/router/definitions";
+
+  import * as router from "@app/lib/router";
+  import Loading from "@app/components/Loading.svelte";
+
+  export let activeRoute: Extract<Route, { resource: "session" }>;
+
+  async function createSession() {
+    const { id, signature, publicKey } = activeRoute.params;
+
+    const request = await fetch(`http://0.0.0.0:8080/api/v1/sessions/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sig: signature, pk: publicKey }),
+    });
+    if (request.ok) {
+      window.sessionStorage.setItem("session_id", id);
+    }
+    // We currently push once logged in users to the landing page,
+    // we should trigger some notification to inform the user what happened
+    router.push({ resource: "home" });
+  }
+</script>
+
+{#await createSession()}
+  <Loading center />
+{/await}


### PR DESCRIPTION
This PR adds a session route with the following spec
```
/session/<sessionId>&sig=<Signature>&pk=<PublicKey>
```
This route gets shown in the cli when `rad web` is called to authenticate the web client with the httpd.

Once the web client lands on this route it sends the session id, signature and public key to the httpd to authenticate the session, and then stores the authenticated session id in the sessionStorage to keep persistance between page reloads.