### PR TITLE
Add `seedGit` to `getRegistration` destructuring

### DIFF
--- a/src/lib/registrar.ts
+++ b/src/lib/registrar.ts
@@ -90,8 +90,18 @@ export async function getRegistration(
     getText(resolver, "com.github"),
   ]);
 
-  const [address, avatar, url, id, seedId, seedHost, seedApi, twitter, github] =
-    meta.filter(isFulfilled).map(r => (r.value ? r.value : undefined));
+  const [
+    address,
+    avatar,
+    url,
+    id,
+    seedId,
+    seedHost,
+    seedGit,
+    seedApi,
+    twitter,
+    github,
+  ] = meta.filter(isFulfilled).map(r => (r.value ? r.value : undefined));
 
   const profile: EnsProfile = {
     name,
@@ -109,6 +119,7 @@ export async function getRegistration(
       profile.seed = new Seed({
         host: seedHost,
         id: seedId,
+        git: seedGit,
         addr: seedApi,
       });
     } catch (e: any) {


### PR DESCRIPTION
We were destructuring an array of promises into individual values, but we forgot to add `seedGit` as a new value, this gave issues for the creation of a new `EnsProfile`.

This PR originated by #584 

## Before
<img width="693" alt="Bildschirm­foto 2023-01-18 um 20 58 12" src="https://user-images.githubusercontent.com/7912302/213281946-4ff8f861-cb59-487e-a405-02a10cf283d2.png">

## After
<img width="678" alt="Bildschirm­foto 2023-01-18 um 20 58 02" src="https://user-images.githubusercontent.com/7912302/213281964-ee5bb4c2-a93c-4e50-b33a-d90d1dc1b52d.png">

Signed-off-by: Sebastian Martinez <me@sebastinez.dev>