### PR TITLE
Update the ReverseRegistrar contract address.

### DIFF
--- a/src/lib/ethereum/networks/goerli.json
+++ b/src/lib/ethereum/networks/goerli.json
@@ -10,7 +10,7 @@
     "faucet": "0xc627191d2BB8839eAcbb7191f9500B84d201A066"
   },
   "reverseRegistrar": {
-    "address": "0xD5610A08E370051a01fdfe4bB3ddf5270af1aA48"
+    "address": "0x9a879320A9F7ad2BBb02063d67baF5551D6BD8B0"
   },
   "alchemy": { "key": "1T6h-0rxu7SRzKEtmukIoxaJOXazLDNs" }
 }


### PR DESCRIPTION
ENS has deployed on the 20th of September 2022 new contracts which can be seen here.
https://discuss.ens.domains/t/namewrapper-updates-including-testnet-deployment-addresses/14505

This commit updates the ReverseRegistrar contract which allow users to create their reverse records again

Signed-off-by: Sebastian Martinez <me@sebastinez.dev>