### PR TITLE
Fix clearing snapshot cache

### DIFF
--- a/.github/workflows/check-e2e.yml
+++ b/.github/workflows/check-e2e.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
+      actions: "write" # necessary for evicting snapshot cache
     continue-on-error: true
     strategy:
       matrix:


### PR DESCRIPTION
There was a problem with permissions introduced in https://github.com/radicle-dev/radicle-interface/pull/577.
```
Deleting Linux-snapshots cache
Error: Resource not accessible by integration
Done
```