### PR TITLE
Update script/radicle-httpd tag

### DIFF
--- a/scripts/run-httpd-with-fixtures
+++ b/scripts/run-httpd-with-fixtures
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-REV=a5811e43a74043e3bf1e706720bac3ec01b079c4
+REV=1f55d7a32750b3e63c56aad00370411b90420a29
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 FIXTURE=$REPO_ROOT/tests/fixtures/seeds/palm-heartwood.tar.bz2


### PR DESCRIPTION
What's on the tin

Based on the latest tag on gcr.io
https://console.cloud.google.com/artifacts/docker/radicle-services/us/gcr.io/radicle-httpd/sha256:9e98db0ab92d3a195563cba42c6f6ac4f438a11f450dccc0b82108c8b2f24457