### PR TITLE
Use radicle-httpd from our public download location

### DIFF
--- a/.github/workflows/check-e2e.yml
+++ b/.github/workflows/check-e2e.yml
@@ -9,10 +9,6 @@ on:
 
 jobs:
   check-e2e:
-    permissions:
-      contents: "read"
-      id-token: "write"
-      actions: "write" # necessary for evicting snapshot cache
     continue-on-error: true
     strategy:
       matrix:
@@ -58,20 +54,11 @@ jobs:
         if: steps.playwright-dep-cache.outputs.cache-hit != 'true'
         run: npx playwright install chromium firefox
 
-      - id: auth
-        uses: google-github-actions/auth@v1
-        with:
-          workload_identity_provider: "projects/281042598092/locations/global/workloadIdentityPools/github-actions/providers/google-cloud"
-          service_account: "github-actions@radicle-services.iam.gserviceaccount.com"
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
-
       - name: Start http-api test server
         run: |
           if [ ${{ matrix.browser }} = "heartwood" ]; then
             mkdir -p tests/artifacts
-            ./scripts/run-httpd-with-fixtures --non-interactive --binary 2>&1 | tee tests/artifacts/httpd-${{ matrix.browser }}.log &
+            ./scripts/run-httpd-with-fixtures --non-interactive --download 2>&1 | tee tests/artifacts/httpd-${{ matrix.browser }}.log &
           else
             ./scripts/run-http-api-with-fixtures --non-interactive --detach
           fi

--- a/scripts/run-httpd-with-fixtures
+++ b/scripts/run-httpd-with-fixtures
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 REV=a5811e43a74043e3bf1e706720bac3ec01b079c4
@@ -7,19 +7,19 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 FIXTURE=$REPO_ROOT/tests/fixtures/seeds/palm-heartwood.tar.bz2
 WORKSPACE=$REPO_ROOT/tests/tmp/palm
 PASSPHRASE=asdf
-CONTAINER_NAME=radicle-httpd-with-fixtures
-HTTP_API_BINARY=radicle-httpd
+BINARY_PATH="$REPO_ROOT/tests/tmp"
+BINARY_NAME=radicle-httpd
+OS=$(uname)
 
 show_usage() {
   echo
-  echo "Starts a radicle-httpd backend with test fixtures."
+  echo "Starts a ${BINARY_NAME} backend with test fixtures."
   echo
   echo "USAGE:"
-  echo "  run-httpd-with-fixtures [-b|d|h|n]"
+  echo "  run-httpd-with-fixtures [-d|h|n]"
   echo
   echo "OPTIONS:"
-  echo "  -b --binary            Use a ${HTTP_API_BINARY} binary that is in PATH to avoid using Docker."
-  echo "  -d --detach            Daemonize the docker process."
+  echo "  -d --download          Download and use a precompiled binary."
   echo "  -h --help              Print this Help."
   echo "  -n --non-interactive   Run in non-interactive mode, no user prompts."
   echo
@@ -51,59 +51,13 @@ prepare_workspace() {
   tar -xf $FIXTURE -C $WORKSPACE
 }
 
-run_docker() {
-  echo "Starting docker at container $CONTAINER_NAME at $REV"
-  echo "  RAD_HOME=$WORKSPACE RAD_PASSPHRASE=$PASSPHRASE radicle-http"
-  echo
-
-  exec docker run \
-    --init \
-    --publish 8080:8080 \
-    --rm \
-    --name $CONTAINER_NAME \
-    --volume $WORKSPACE:/app/radicle \
-    "$@" \
-    --env "RAD_HOME=/app/radicle" \
-    --env "RAD_PASSPHRASE=$PASSPHRASE" \
-    "gcr.io/radicle-services/radicle-httpd:$REV"
-}
-
-run_binary() {
-  if [ "$CI" = true ]; then
-    local binaries_dir="$REPO_ROOT/tests/tmp"
-    gsutil cp "gs://heartwood-artifacts/${REV}/x86_64-unknown-linux-musl/radicle-httpd" "$binaries_dir"
-    chmod a+x "${binaries_dir}/radicle-httpd"
-    export PATH="$binaries_dir:$PATH"
-  fi
-
-  if ! [ -x "$(command -v $HTTP_API_BINARY)" ]; then
-    echo
-    echo "Couldn't find the $HTTP_API_BINARY binary in your PATH."
-    echo "You can compile it from source:"
-    echo "  👉 https://github.com/radicle-dev/heartwood"
-    echo
-    exit 1
-  fi
-
-  echo
-  echo "Starting $HTTP_API_BINARY"
-  echo "  RAD_HOME=$WORKSPACE $HTTP_API_BINARY"
-  echo
-
-  RAD_HOME=$WORKSPACE RAD_PASSPHRASE=$PASSPHRASE $HTTP_API_BINARY
-}
-
-BINARY=false
 NON_INTERACTIVE=false
-DETACH=false
+DOWNLOAD=false
 
 while [ $# -ne 0 ]; do
   case "$1" in
-    --binary | -b)
-      BINARY=true
-      ;;
-    --detach | -d)
-      DETACH=true
+    --download | -d)
+      DOWNLOAD=true
       ;;
     --non-interactive | -n)
       NON_INTERACTIVE=true
@@ -117,6 +71,36 @@ while [ $# -ne 0 ]; do
   shift
 done
 
+if [ "$DOWNLOAD" = true ]; then
+  CACHED_BINARY_NAME="$BINARY_NAME-${REV:0:7}"
+
+  if ! [ -x "$(command -v $BINARY_PATH/$CACHED_BINARY_NAME)" ]; then
+    echo "Downloading $BINARY_NAME"
+    case "$OS" in
+      Darwin)  curl -s "https://storage.googleapis.com/heartwood-artifacts/${REV}/aarch64-apple-darwin/radicle-httpd" --output "$BINARY_PATH/$CACHED_BINARY_NAME" ;;
+      Linux)   curl -s "https://storage.googleapis.com/heartwood-artifacts/${REV}/x86_64-unknown-linux-musl/radicle-httpd" --output "$BINARY_PATH/$CACHED_BINARY_NAME" ;;
+      *)       echo "There are no precompiled binaries for your OS: $OS, compile radicle-httpd manually and make sure it's in PATH." && exit 1 ;;
+    esac
+
+    chmod a+x "$BINARY_PATH/$CACHED_BINARY_NAME"
+  fi
+
+  export PATH="$BINARY_PATH:$PATH"
+  BINARY_NAME=$CACHED_BINARY_NAME
+fi
+
+if ! [ -x "$(command -v $BINARY_NAME)" ]; then
+  echo
+  echo "Couldn't find $BINARY_NAME binary in your PATH."
+  echo
+  echo "You can download it with the --download option, or"
+  echo "compile it from source:"
+  echo
+  echo "  👉 https://github.com/radicle-dev/heartwood"
+  echo
+  exit 1
+fi
+
 if [ "$NON_INTERACTIVE" = true ]; then
   rm -rf $WORKSPACE
   prepare_workspace
@@ -125,12 +109,9 @@ else
   prepare_workspace
 fi
 
-if [ "$BINARY" = true ]; then
-  run_binary
-else
-  if [ "$DETACH" = true ]; then
-    run_docker --detach
-  else
-    run_docker
-  fi
-fi
+echo
+echo "Starting $BINARY_NAME"
+echo "  RAD_HOME=$WORKSPACE RAD_PASSPHRASE=$PASSPHRASE $BINARY_NAME"
+echo
+
+RAD_HOME=$WORKSPACE RAD_PASSPHRASE=$PASSPHRASE $BINARY_NAME


### PR DESCRIPTION
```
$ ./scripts/run-httpd-with-fixtures --download --non-interactive

Downloading radicle-httpd

Unpacking fixture /Users/rudolfs/work/radicle-interface/tests/fixtures/seeds/palm-heartwood.tar.bz2

Starting radicle-httpd-a5811e4
  RAD_HOME=/Users/rudolfs/work/radicle-interface/tests/tmp/palm RAD_PASSPHRASE=asdf radicle-httpd-a5811e4

2023-01-31T15:48:57.833117Z  INFO radicle_httpd: version 0.1.0-a5811e4
2023-01-31T15:48:57.836700Z  INFO radicle_httpd: git version 2.39.0
2023-01-31T15:48:57.837572Z  INFO radicle_httpd: using radicle home at /Users/rudolfs/work/radicle-interface/tests/tmp/palm
2023-01-31T15:48:57.838592Z  INFO radicle_httpd: listening on http://0.0.0.0:8080
```

If no option is specified, we use the `radicle-httpd` binary that is in `PATH`.
Downloaded binaries are cached so we don't download it every time the script is run.