### PR TITLE
Improve `formatRadicleId` util fn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radicle/gray-matter": "4.1.0",
         "@wooorm/starry-night": "^1.5.0",
+        "bs58": "^5.0.0",
         "buffer": "^6.0.3",
         "dompurify": "^2.4.3",
         "hast-util-to-dom": "^3.1.1",
@@ -1087,6 +1088,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base-x": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1135,6 +1141,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "dependencies": {
+        "base-x": "^4.0.0"
       }
     },
     "node_modules/buffer": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@radicle/gray-matter": "4.1.0",
     "@wooorm/starry-night": "^1.5.0",
+    "bs58": "^5.0.0",
     "buffer": "^6.0.3",
     "dompurify": "^2.4.3",
     "hast-util-to-dom": "^3.1.1",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,7 @@
+import bs58 from "bs58";
 import md5 from "md5";
 import twemojiModule from "twemoji";
 
-import { assert } from "@app/lib/error";
 import { base } from "@app/lib/router";
 import { config } from "@app/lib/config";
 
@@ -47,7 +47,10 @@ export function formatSeedId(id: string): string {
 }
 
 export function formatRadicleId(id: string): string {
-  assert(isRadicleId(id));
+  if (!isRadicleId(id)) {
+    console.warn("Received Radicle id isn't valid");
+    return id;
+  }
 
   if (window.HEARTWOOD) {
     return id.substring(0, 10) + "…" + id.substring(id.length - 6, id.length);
@@ -163,7 +166,13 @@ export const formatTimestamp = (
 // Check whether the input is a Radicle ID.
 export function isRadicleId(input: string): boolean {
   if (window.HEARTWOOD) {
-    return /^rad:[a-zA-Z0-9]+$/.test(input);
+    if (!input.startsWith("z")) {
+      return false;
+    }
+    const hex = bs58.decode(input.substring(1));
+    // This checks also that the first 2 bytes are equal
+    // to the ed25519 public key type used.
+    return hex.byteLength === 34 && hex[0] === 237 && hex[1] === 1;
   } else {
     return /^rad:[a-z]+:[a-zA-Z0-9]+$/.test(input);
   }

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -20,8 +20,8 @@ describe("Format functions", () => {
 
   test("formatRadicleId", () => {
     if (process.env.HEARTWOOD) {
-      expect(utils.formatRadicleId("rad:zKtT7DmF9H34KkvcKj9PHW19WzjT")).toEqual(
-        "rad:zKtT7D…19WzjT",
+      expect(utils.formatRadicleId("zKtT7DmF9H34KkvcKj9PHW19WzjT")).toEqual(
+        "zKtT7D…19WzjT",
       );
     } else {
       expect(
@@ -30,10 +30,10 @@ describe("Format functions", () => {
     }
   });
 
-  test("formatRadicleId throw when wrong ID", () => {
-    expect(() =>
+  test("formatRadicleId return original input when wrong ID", () => {
+    expect(
       utils.formatRadicleId("hnrkemobagsicpf9sr95o3g551otspcd84c9o"),
-    ).toThrow();
+    ).toEqual("hnrkemobagsicpf9sr95o3g551otspcd84c9o");
   });
 
   test.each([


### PR DESCRIPTION
- Improves detection of Heartwood Radicle ids.
- Instead of throwing an error if the input isn't a Radicle id we return the original input and display a dev console warning

Signed-off-by: Sebastian Martinez <me@sebastinez.dev>