### PR TITLE
Lower image diff threshold

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,7 +45,7 @@ const config: PlaywrightTestConfig = {
       expect: {
         timeout: 30_000,
         toHaveScreenshot: {
-          threshold: 0.1,
+          threshold: 0.01,
           scale: "device",
           animations: "disabled",
         },


### PR DESCRIPTION
The threshold is expressed a percentage, so on full-page screenshots it depends on how big the entire screenshot is. We want to catch smaller changes. The threshold was too high to catch the rounded corners change in a full-page screenshot.
