### PR TITLE
Don't expand search bar on mobile

### DIFF
--- a/src/App/Header.svelte
+++ b/src/App/Header.svelte
@@ -62,7 +62,9 @@
   </div>
 
   <div class="right">
-    <Connect />
+    <div class="layout-desktop">
+      <Connect />
+    </div>
     <Floating>
       <div slot="toggle">
         <button class="toggle" name="Settings">
@@ -71,14 +73,5 @@
       </div>
       <SettingsDropdown slot="modal" />
     </Floating>
-    <div class="layout-mobile">
-      <Floating>
-        <div slot="toggle">
-          <span style="transform: scale(1.2);">
-            <Icon name="ellipsis" />
-          </span>
-        </div>
-      </Floating>
-    </div>
   </div>
 </header>

--- a/src/App/Header/Search.svelte
+++ b/src/App/Header/Search.svelte
@@ -16,14 +16,13 @@
   }>();
 
   export let input = "";
+
   let loading = false;
   let shaking = false;
+  let expanded = false;
 
   // Clears search input on user navigation.
   router.historyStore.subscribe(() => (input = ""));
-
-  const collapsedWidth = 13;
-  const expandedWidth = 20;
 
   function shake() {
     shaking = true;
@@ -69,7 +68,7 @@
         });
       }
       dispatch("finished");
-      searchBarWidth = collapsedWidth;
+      expanded = false;
     } else {
       unreachable(searchResult);
     }
@@ -77,7 +76,6 @@
   }
 
   $: valid = input !== "";
-  $: searchBarWidth = collapsedWidth;
 </script>
 
 <style>
@@ -106,24 +104,33 @@
   }
   .search {
     transition: all 0.2s;
+    width: 13rem;
+  }
+  .expanded {
+    width: 20rem;
   }
   @media (max-width: 720px) {
-    .search {
-      display: none;
+    .expanded {
+      width: 13rem;
     }
   }
 </style>
 
-<div class="search" style:width={`${searchBarWidth}rem`}>
+<div class="search" class:expanded>
   <div class="search-bar" class:shaking>
     <TextInput
       valid={input !== ""}
       {loading}
       disabled={loading}
       bind:value={input}
-      on:focus={() => (searchBarWidth = expandedWidth)}
-      on:blur={() =>
-        input === "" ? (searchBarWidth = collapsedWidth) : undefined}
+      on:focus={() => {
+        expanded = true;
+      }}
+      on:blur={() => {
+        if (input === "") {
+          expanded = false;
+        }
+      }}
       on:submit={search}
       placeholder="Search a name…">
       <div slot="left">


### PR DESCRIPTION
Also don't show the connect button in the mobile layout. We don't support running nodes on mobile anyway.
On desktop still expand and contract the search bar depending on focus.

Mobile:
<img width="324" alt="Screenshot 2023-02-13 at 17 53 38" src="https://user-images.githubusercontent.com/158411/218521102-f76724b6-4556-4619-ac11-6a4fb65dbf8e.png">

Desktop:
<img width="1840" alt="Screenshot 2023-02-13 at 17 55 21" src="https://user-images.githubusercontent.com/158411/218521549-6e379e96-f691-48a2-a326-389de8bb3ed0.png">
