### PR TITLE
Safari and mobile Safari tweaks

### DIFF
--- a/src/App/Header/Search.svelte
+++ b/src/App/Header/Search.svelte
@@ -133,9 +133,9 @@
       }}
       on:submit={search}
       placeholder="Search a name…">
-      <div slot="left">
+      <svelte:fragment slot="left">
         <Icon name="magnifying-glass" />
-      </div>
+      </svelte:fragment>
     </TextInput>
   </div>
 </div>

--- a/src/components/Floating.svelte
+++ b/src/components/Floating.svelte
@@ -9,12 +9,11 @@
 
 <script lang="ts">
   export let disabled = false;
-  export let overlay = false;
 
   let expanded = false;
   let thisComponent: HTMLDivElement;
 
-  function clickOutside(ev: MouseEvent) {
+  function clickOutside(ev: MouseEvent | TouchEvent) {
     if (!$focused?.contains(ev.target as HTMLDivElement)) {
       closeFocused();
     }
@@ -35,21 +34,12 @@
 </script>
 
 <style>
-  .overlay {
-    background-color: #00000075;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-
   .toggle {
     user-select: none;
   }
 </style>
 
-<svelte:window on:click={clickOutside} />
+<svelte:window on:click={clickOutside} on:touchstart={clickOutside} />
 
 <div bind:this={thisComponent}>
   <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -61,10 +51,6 @@
   </div>
 
   {#if expanded}
-    {#if overlay}
-      <!-- svelte-ignore a11y-click-events-have-key-events -->
-      <div class="overlay" on:click={toggle} />
-    {/if}
     <slot name="modal" />
   {/if}
 </div>


### PR DESCRIPTION
- search icon alignment
<img width="305" alt="Screenshot 2023-02-14 at 17 19 14" src="https://user-images.githubusercontent.com/158411/218795862-8085c8ce-cfa6-4dcd-a581-eba45253db52.png">
<img width="306" alt="Screenshot 2023-02-14 at 17 19 18" src="https://user-images.githubusercontent.com/158411/218795864-66279d6f-f8d1-41b5-a704-a70446d29771.png">

- clicking outside a dropdown now closes it properly

https://user-images.githubusercontent.com/158411/218795989-58641f60-c909-4ac0-845a-ecf0e222b7e6.MP4

