### PR TITLE
Clean up pinned projects

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -13,21 +13,6 @@
   "projects": {
     "pinned": [
       {
-        "name": "radicle-cli",
-        "id": "rad:git:hnrkmg77m8tfzj4gi4pa4mbhgysfgzwntjpao",
-        "seed": "clients.radicle.xyz"
-      },
-      {
-        "name": "radicle-interface",
-        "id": "rad:git:hnrkjajuucc6zp5eknt3s9xykqsrus44cjimy",
-        "seed": "clients.radicle.xyz"
-      },
-      {
-        "name": "radicle-client-services",
-        "id": "rad:git:hnrkk9c4zt9thuxhwi1ukxqcrs5tmhbtcsony",
-        "seed": "clients.radicle.xyz"
-      },
-      {
         "name": "solmate",
         "id": "rad:git:hnrkbgczcfh9ycjtdfynmqyg478bqrso1hnty",
         "seed": "willow.radicle.garden"
@@ -60,11 +45,6 @@
       {
         "name": "tmyxer",
         "id": "rad:git:hnrkp5jgfxwxrffjsp148fyzdc457pa9ja38y",
-        "seed": "pine.radicle.garden"
-      },
-      {
-        "name": "pax",
-        "id": "rad:git:hnrkffdfm4et8c4g1ebpbkjj46nagyiepmu5o",
         "seed": "pine.radicle.garden"
       },
       {


### PR DESCRIPTION
clients.radicle.xyz got migrated to Heartwood. Removed pax to have an even number of projects and they align in two rows.

<img width="1840" alt="Screenshot 2023-02-15 at 11 19 31" src="https://user-images.githubusercontent.com/158411/219000203-03fcee87-9c6b-4ea7-8e67-2ba4783aa05e.png">
