### PR TITLE
Document legacy IPFS deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,13 @@ You will also see any lint errors in the console.
 
 Builds a static copy of your site to the `build/` folder.
 Your app is ready to be deployed!
+
+## Deployments
+
+Latest production deployment 👉 https://app.radicle.xyz
+
+If you want to connect to pre-heartwood seed nodes, you can run the app locally
+via the legacy IPFS deployment. To do so, you'll have to run
+[IPFS](https://ipfs.tech).
+
+Legacy deployment 👉 http://bafybeid2fxbb3zpbttnunrzm74v7l3qxtgxathiv5ucykh2ojm4dbyqdwi.ipfs.localhost:8080/#/


### PR DESCRIPTION
We deployed the app at https://github.com/radicle-dev/radicle-interface/commit/7a3244b43c909a6cd272166363cf126c0292a7c1 with an informative message that's always present in the header on IPFS. This allows users to access the old pre-heartwood seeds if they want by running an IPFS node locally (via the IPFS desktop app).

Rendered [README.md](https://github.com/radicle-dev/radicle-interface/blob/466f72002fc9bf21f90dab98cfa71130a3d2c4c6/README.md).

Closes https://github.com/radicle-dev/radicle-interface/issues/616.

<img width="1840" alt="Screenshot 2023-02-15 at 17 57 00" src="https://user-images.githubusercontent.com/158411/219098799-29d73d47-9518-4d82-ba83-a655afe9940d.png">
