### PR TITLE
Always pass diff step and show the status as a comment

### DIFF
--- a/.github/workflows/check-e2e.yml
+++ b/.github/workflows/check-e2e.yml
@@ -12,22 +12,11 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        browser: [chromium, firefox, visual]
+        browser: [chromium, firefox]
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Evict playwright snapshot cache when pushing to master
-        run: |
-          if [ ${{ matrix.browser }} = "visual" ] && [ ${{ github.ref }} = "refs/heads/master" ]; then
-            echo "Deleting ${{ runner.os }}-snapshots cache"
-            gh extension install actions/gh-actions-cache
-            gh actions-cache delete ${{ runner.os }}-snapshots --confirm || true
-            echo "Done"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v3
         with:
@@ -43,13 +32,6 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
 
-      - name: Cache Playwright visual snapshots
-        uses: actions/cache@v3
-        id: playwright-snapshot-cache
-        with:
-          path: tests/visual/snapshots/**/*
-          key: ${{ runner.os }}-snapshots
-
       - name: Install Playwright browsers
         if: steps.playwright-dep-cache.outputs.cache-hit != 'true'
         run: npx playwright install chromium firefox
@@ -60,28 +42,7 @@ jobs:
           ./scripts/run-httpd-with-fixtures --non-interactive --download 2>&1 | tee tests/artifacts/httpd-${{ matrix.browser }}.log &
 
       - name: Run Playwright tests
-        run: |
-          if [ ${{ matrix.browser }} = "visual" ] && [ ${{ github.ref }} = "refs/heads/master" ]; then
-            npm run test:e2e -- --project ${{ matrix.browser }} --update-snapshots;
-          else
-            npm run test:e2e -- --project ${{ matrix.browser }};
-          fi
-
-      # If a build succeeds, clear any artifacts from failed retries, so they
-      # don't end up in the visual diff archive.
-      - name: Cleanup artifacts
-        if: success()
-        run: |
-          rm -rf tests/artifacts/*
-
-      # We don't care about logs in visual snapshot tests, only the images.
-      - name: Cleanup artifacts
-        if: always()
-        run: |
-          if [ ${{ matrix.browser }} = "visual" ]; then
-            shopt -s globstar;
-            rm -rf tests/artifacts/**/*.log;
-          fi
+        run: npm run test:e2e -- --project ${{ matrix.browser }};
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/check-visual.yml
+++ b/.github/workflows/check-visual.yml
@@ -1,0 +1,130 @@
+name: check-visual
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  generate-visual-diffs:
+    concurrency:
+      group: ${{ github.head_ref }}
+      cancel-in-progress: true
+
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Evict playwright snapshot cache when pushing to master
+        run: |
+          if [ ${{ github.ref }} = "refs/heads/master" ]; then
+            echo "Deleting ${{ runner.os }}-snapshots cache"
+            gh extension install actions/gh-actions-cache
+            gh actions-cache delete ${{ runner.os }}-snapshots --confirm || true
+            echo "Done"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18.12.1"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v3
+        id: playwright-dep-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
+      - name: Cache Playwright visual snapshots
+        uses: actions/cache@v3
+        id: playwright-snapshot-cache
+        with:
+          path: tests/visual/snapshots/**/*
+          key: ${{ runner.os }}-snapshots
+
+      - name: Install Playwright browsers
+        if: steps.playwright-dep-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium firefox
+
+      - name: Start http-api test server
+        run: |
+          mkdir -p tests/artifacts;
+          ./scripts/run-httpd-with-fixtures --non-interactive --download 2>&1 | tee tests/artifacts/httpd-visual.log &
+
+      - name: Run Playwright tests
+        run: |
+          if [ ${{ github.ref }} = "refs/heads/master" ]; then
+            npm run test:e2e -- --project visual --update-snapshots || true;
+          else
+            npm run test:e2e -- --project visual || true;
+          fi
+
+      # We don't care about logs in visual snapshot tests, only the images.
+      - name: Cleanup artifacts
+        if: always()
+        run: |
+          shopt -s globstar;
+          rm -rf tests/artifacts/**/*.log;
+
+      - name: Upload artifacts
+        id: artifacts
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-artifacts-${{ runner.os }}
+          retention-days: 30
+          if-no-files-found: "ignore"
+          path: |
+            tests/artifacts/**/*
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "**Visual diff results for latest changes**"
+
+      - name: Check for artifacts
+        id: check_artifacts
+        run: |
+          if find ./tests/artifacts/**/*.png; then
+            echo "present=true" >> $GITHUB_OUTPUT
+          else
+            echo "present=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create or update comment
+        if: github.ref != 'refs/heads/master' && steps.check_artifacts.outputs.present == 'false'
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            **Visual diff results for latest changes**
+
+              ✅ There are no visual differences between `master` and this branch.
+          edit-mode: replace
+
+      - name: Create or update comment
+        if: github.ref != 'refs/heads/master' && steps.check_artifacts.outputs.present == 'true'
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            **Visual diff results for latest changes**
+
+            ⚠️ There are visual differences between `master` and this branch.
+            👉 [Latest diff snapshots](https://github.com/radicle-dev/radicle-interface/actions/runs/4363103344).
+            - [ ] The visual changes were intentional.
+
+          edit-mode: replace


### PR DESCRIPTION
Splits out the visual diffs into a separate workflow and adds a Github bot that adds a comment about the visual diff status. It edits the existing comment if there is one.

<img width="960" alt="Screenshot 2023-03-08 at 12 09 44" src="https://user-images.githubusercontent.com/158411/223698344-57bf4145-f820-4bdc-8dff-ef748133c4fe.png">

<img width="939" alt="Screenshot 2023-03-08 at 12 21 46" src="https://user-images.githubusercontent.com/158411/223700625-6cdac5b4-1647-4e32-bd77-68cb30341c5d.png">

