### PR TITLE
Make commit header and diff wrapping more similar to GH

### DIFF
--- a/src/views/projects/Commit.svelte
+++ b/src/views/projects/Commit.svelte
@@ -36,6 +36,7 @@
   }
   .description {
     margin: 0.5rem 0 1rem 0;
+    white-space: pre-wrap;
   }
   .sha1 {
     color: var(--color-foreground-5);

--- a/src/views/projects/SourceBrowser/FileDiff.svelte
+++ b/src/views/projects/SourceBrowser/FileDiff.svelte
@@ -21,7 +21,6 @@
   .changeset-file {
     border: 1px solid var(--color-foreground-4);
     border-radius: var(--border-radius-small);
-    min-width: var(--content-min-width);
     margin-bottom: 2rem;
     line-height: 1.5rem;
   }
@@ -65,6 +64,9 @@
     border-collapse: collapse;
     margin: 0.5rem 0;
   }
+  tr.diff-line {
+    vertical-align: top;
+  }
   tr.diff-line[data-type="+"] > * {
     color: var(--color-positive);
   }
@@ -94,7 +96,8 @@
     padding: 0 0.75rem 0 0.5rem;
   }
   td.diff-line-content {
-    white-space: pre;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
     width: 100%;
     padding-right: 0.5rem;
   }


### PR DESCRIPTION
Currently we didn't wrap the commit header description, and also the changesets had no wrapping in them.
So this forces the wrapping, which at least for diffs isn't the nicest wrapping, but it beats, horizontal scrolling on a mobile device..

![Screenshot from 2023-03-13 21-27-48](https://user-images.githubusercontent.com/7912302/224824831-6a326340-407a-4703-bbea-a5082de0e07e.png)
![Screenshot from 2023-03-13 21-28-11](https://user-images.githubusercontent.com/7912302/224824840-65db9eaa-fe58-4b05-8ef2-0bbf6d28a887.png)

Closes #623 