### PR TITLE
Make sure visual diffs are generated on master

### DIFF
--- a/.github/workflows/check-visual.yml
+++ b/.github/workflows/check-visual.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   generate-visual-diffs:
     concurrency:
-      group: ${{ github.head_ref }}
+      group: ${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
     timeout-minutes: 30


### PR DESCRIPTION
Turns out we weren't regenerating visual diffs on master due to a [syntax error](https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow).
This should fix [it](https://github.com/radicle-dev/radicle-interface/actions/runs/4414906666).
```
[check-visual: .github#L1](https://github.com/radicle-dev/radicle-interface/commit/09ceeed136ce3d1599f9394914327e95b283a8bb#annotation_9671073271)
Error when evaluating 'concurrency' for job 'generate-visual-diffs'. .github/workflows/check-visual.yml (Line: 13, Col: 14): Unexpected type of value '', expected type: String.
```


