### PR TITLE
Show local seed page upon successful authentication

### DIFF
--- a/src/views/session/Index.svelte
+++ b/src/views/session/Index.svelte
@@ -18,6 +18,7 @@
 
     if (status === "success") {
       modal.show({ component: AuthenticatedModal, props: {} });
+      router.push({ resource: "seeds", params: { host: "radicle.local" } });
     } else {
       modal.show({
         component: AuthenticationErrorModal,
@@ -29,9 +30,8 @@
           ],
         },
       });
+      router.push({ resource: "home" });
     }
-
-    router.push({ resource: "home" });
   });
 </script>
 


### PR DESCRIPTION
In most cases the user will want to interact with the local seed, so it makes sense to show that page. If the auth is unsuccessful, we go to the home screen.