### PR TITLE
Update patch state from proposed to open

### DIFF
--- a/src/lib/patch.ts
+++ b/src/lib/patch.ts
@@ -58,8 +58,22 @@ export interface Merge {
 
 export type PatchState =
   | { status: "draft" }
-  | { status: "proposed" }
+  | { status: "open" }
   | { status: "archived" };
+
+export function groupPatches(patches: Patch[]): {
+  open: Patch[];
+  draft: Patch[];
+  archived: Patch[];
+} {
+  return patches.reduce(
+    (acc, patch) => {
+      acc[patch.state.status].push(patch);
+      return acc;
+    },
+    { open: [] as Patch[], draft: [] as Patch[], archived: [] as Patch[] },
+  );
+}
 
 export class Patch {
   id: string;

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -28,7 +28,7 @@ export interface ProjectInfo {
   defaultBranch: string;
   delegates: string[];
   patches: {
-    proposed: number;
+    open: number;
     draft: number;
     archived: number;
   };
@@ -134,7 +134,7 @@ export class Project implements ProjectInfo {
   peers: Peer[];
   branches: Branches;
   patches: {
-    proposed: number;
+    open: number;
     draft: number;
     archived: number;
   };

--- a/src/views/projects/Header.svelte
+++ b/src/views/projects/Header.svelte
@@ -135,7 +135,7 @@
     active={activeRoute.params.view.resource === "patches"}
     clickable
     on:click={() => toggleContent("patches", false)}>
-    <span class="txt-bold">{project.patches.proposed ?? 0}</span>
+    <span class="txt-bold">{project.patches.open ?? 0}</span>
     patch(es)
   </HeaderToggleLabel>
   <HeaderToggleLabel ariaLabel="Contributor count">

--- a/src/views/projects/Patch.svelte
+++ b/src/views/projects/Patch.svelte
@@ -233,7 +233,7 @@
           <Badge variant="foreground">
             {patch.state.status}
           </Badge>
-        {:else if patch.state.status === "proposed"}
+        {:else if patch.state.status === "open"}
           <Badge variant="positive">
             {patch.state.status}
           </Badge>

--- a/src/views/projects/Patch/PatchTeaser.svelte
+++ b/src/views/projects/Patch/PatchTeaser.svelte
@@ -91,7 +91,7 @@
   .draft {
     background-color: var(--color-foreground-3);
   }
-  .proposed {
+  .open {
     background-color: var(--color-positive);
   }
   .archived {
@@ -109,7 +109,7 @@
     <div
       class="state-icon"
       class:draft={patch.state.status === "draft"}
-      class:proposed={patch.state.status === "proposed"}
+      class:open={patch.state.status === "open"}
       class:archived={patch.state.status === "archived"} />
   </div>
   <div class="column-left">

--- a/src/views/projects/View.svelte
+++ b/src/views/projects/View.svelte
@@ -35,7 +35,7 @@
   $: issueFilter = (searchParams.get("state") as IssueStatus) || "open";
   $: patchTabFilter =
     (searchParams.get("tab") as "activity" | "commits") || "activity";
-  $: patchFilter = (searchParams.get("state") as PatchStatus) || "proposed";
+  $: patchFilter = (searchParams.get("state") as PatchStatus) || "open";
 
   const getProject = async (id: string, seed: string, peer?: string) => {
     const project = await proj.Project.get(id, seed, peer);


### PR DESCRIPTION
- Changes the patch state from `proposed` to `open`
- Adds the `TabBar` back to patches

This will be needed once the heartwood PR https://github.com/radicle-dev/heartwood/pull/499 gets merged