### PR TITLE
Pluralize values instead of parenthesis

### DIFF
--- a/src/lib/pluralize.ts
+++ b/src/lib/pluralize.ts
@@ -1,0 +1,16 @@
+export const pluralRules = {
+  file: "files",
+  insertion: "insertions",
+  deletion: "deletions",
+  commit: "commits",
+  issue: "issues",
+  contributor: "contributors",
+  patch: "patches",
+} as const;
+
+export function pluralize(
+  singular: keyof typeof pluralRules,
+  count: number,
+): string {
+  return count === 1 ? singular : pluralRules[singular];
+}

--- a/src/views/projects/Header.svelte
+++ b/src/views/projects/Header.svelte
@@ -10,6 +10,7 @@
   import PeerSelector from "@app/views/projects/PeerSelector.svelte";
   import { closeFocused } from "@app/components/Floating.svelte";
   import { config } from "@app/lib/config";
+  import { pluralize } from "@app/lib/pluralize";
 
   export let activeRoute: ProjectRoute;
   export let project: Project;
@@ -120,7 +121,7 @@
     active={activeRoute.params.view.resource === "history"}
     on:click={() => toggleContent("history", true)}>
     <span class="txt-bold">{tree.stats.commits}</span>
-    commit(s)
+    {pluralize("commit", tree.stats.commits)}
   </HeaderToggleLabel>
   <HeaderToggleLabel
     ariaLabel="Issue count"
@@ -128,7 +129,7 @@
     clickable
     on:click={() => toggleContent("issues", false)}>
     <span class="txt-bold">{project.issues.open ?? 0}</span>
-    issue(s)
+    {pluralize("issue", project.issues.open)}
   </HeaderToggleLabel>
   <HeaderToggleLabel
     ariaLabel="Patch count"
@@ -136,10 +137,10 @@
     clickable
     on:click={() => toggleContent("patches", false)}>
     <span class="txt-bold">{project.patches.open ?? 0}</span>
-    patch(es)
+    {pluralize("patch", project.patches.open)}
   </HeaderToggleLabel>
   <HeaderToggleLabel ariaLabel="Contributor count">
     <span class="txt-bold">{tree.stats.contributors}</span>
-    contributor(s)
+    {pluralize("contributor", tree.stats.contributors)}
   </HeaderToggleLabel>
 </header>

--- a/src/views/projects/SourceBrowser/Changeset.svelte
+++ b/src/views/projects/SourceBrowser/Changeset.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import type { Diff, DiffStats } from "@app/lib/diff";
+
   import FileDiff from "@app/views/projects/SourceBrowser/FileDiff.svelte";
+  import { pluralize } from "@app/lib/pluralize";
 
   export let diff: Diff;
   export let stats: DiffStats;
@@ -9,13 +11,15 @@
     const s = [];
 
     if (modified.length) {
-      s.push(`${modified.length} file(s) changed`);
+      s.push(
+        `${modified.length} ${pluralize("file", modified.length)} changed`,
+      );
     }
     if (added.length) {
-      s.push(`${added.length} file(s) added`);
+      s.push(`${added.length} ${pluralize("file", added.length)} added`);
     }
     if (deleted.length) {
-      s.push(`${deleted.length} file(s) deleted`);
+      s.push(`${deleted.length} ${pluralize("file", deleted.length)} deleted`);
     }
     return s.join(", ");
   };
@@ -37,9 +41,15 @@
 <div class="changeset-summary">
   <span>{diffDescription(diff)}</span>
   with
-  <span class="additions">{stats.insertions} insertion(s)</span>
+  <span class="additions">
+    {stats.insertions}
+    {pluralize("insertion", stats.insertions)}
+  </span>
   and
-  <span class="deletions">{stats.deletions} deletion(s)</span>
+  <span class="deletions">
+    {stats.deletions}
+    {pluralize("deletion", stats.deletions)}
+  </span>
 </div>
 <div class="diff-listing">
   {#each diff.added as file}

--- a/tests/e2e/project.spec.ts
+++ b/tests/e2e/project.spec.ts
@@ -15,11 +15,15 @@ async function expectCounts(
   page: Page,
 ) {
   await expect(page.locator('role=button[name="Commit count"]')).toContainText(
-    `${params.commits} commit(s)`,
+    `${params.commits} ${params.commits === 1 ? "commit" : "commits"}`,
   );
   await expect(
     page.locator('role=button[name="Contributor count"]'),
-  ).toContainText(`${params.contributors} contributor(s)`);
+  ).toContainText(
+    `${params.contributors} ${
+      params.contributors === 1 ? "contributor" : "contributors"
+    }`,
+  );
 }
 
 test("navigate to project", async ({ page }) => {

--- a/tests/e2e/project/commit.spec.ts
+++ b/tests/e2e/project/commit.spec.ts
@@ -49,9 +49,7 @@ test("modified file", async ({ page }) => {
 
   // Diff header.
   await expect(
-    page.locator(
-      "text=1 file(s) changed with 1 insertion(s) and 4 deletion(s)",
-    ),
+    page.locator("text=1 file changed with 1 insertion and 4 deletions"),
   ).toBeVisible();
 
   // Diff.
@@ -64,7 +62,7 @@ test("created file", async ({ page }) => {
     `${projectFixtureUrl}/remotes/${bobRemote}/commits/d6318f7f3d9c15b8ac6dd52267c53220d00f0982`,
   );
   await expect(
-    page.locator("text=1 file(s) added with 9 insertion(s) and 0 deletion(s)"),
+    page.locator("text=1 file added with 9 insertions and 0 deletions"),
   ).toBeVisible();
   await expect(page.locator("text=subconscious.txt added")).toBeVisible();
 });
@@ -74,9 +72,7 @@ test("deleted file", async ({ page }) => {
     `${projectFixtureUrl}/remotes/${bobRemote}/commits/cd13c2d9a8a930d64a82b6134b44d1b872e33662`,
   );
   await expect(
-    page.locator(
-      "text=1 file(s) deleted with 0 insertion(s) and 1 deletion(s)",
-    ),
+    page.locator("text=1 file deleted with 0 insertions and 1 deletion"),
   ).toBeVisible();
   await expect(page.locator("text=.hidden deleted")).toBeVisible();
 });


### PR DESCRIPTION
Ok I think this is a nice way of doing it without using a library, and with a nice function signature.

Closes #650 