### PR TITLE
Patch states fallback to disable and show default if undefined

### DIFF
--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -31,7 +31,7 @@ export interface ProjectInfo {
     open: number;
     draft: number;
     archived: number;
-    merged: number;
+    merged?: number;
   };
   issues: {
     open: number;
@@ -138,7 +138,7 @@ export class Project implements ProjectInfo {
     open: number;
     draft: number;
     archived: number;
-    merged: number;
+    merged?: number;
   };
   issues: {
     open: number;

--- a/src/views/projects/Patches.svelte
+++ b/src/views/projects/Patches.svelte
@@ -29,8 +29,11 @@
     disabled: boolean;
   }>((s: PatchStatus) => ({
     value: s,
-    title: `${project.patches[s]} ${s}`,
-    disabled: project.patches[s] === 0,
+    title:
+      project.patches[s] !== undefined
+        ? `${project.patches[s]} ${s}`
+        : `0 ${s}`,
+    disabled: project.patches[s] === 0 || project.patches[s] === undefined,
   }));
   $: filteredPatches = groupPatches(patches)[status];
   $: sortedPatches = filteredPatches.sort(


### PR DESCRIPTION
To avoid showing `undefined <patch state>` fallback to 0 and disable it

![image](https://user-images.githubusercontent.com/7912302/229526075-4782d55c-785c-49ea-9e85-cc8ec72d6ce3.png)
<img width="653" alt="Bildschirmfoto 2023-04-03 um 15 37 22" src="https://user-images.githubusercontent.com/7912302/229526418-563dd7d3-e27d-4ceb-82dc-e6edff0b43dd.png">
