### PR TITLE
Enable the @typescript-eslint/no-floating-promises rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,8 @@
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2020,
-    "sourceType": "module"
+    "sourceType": "module",
+    "project": ["./tsconfig.json"]
   },
   "plugins": ["svelte3", "@typescript-eslint"],
   "overrides": [
@@ -49,6 +50,7 @@
     ],
     "eol-last": ["error"],
     "key-spacing": ["error"],
+    "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/object-curly-spacing": ["error", "always"],
     "@typescript-eslint/type-annotation-spacing": ["error"],
     "@typescript-eslint/naming-convention": [

--- a/tests/e2e/project.spec.ts
+++ b/tests/e2e/project.spec.ts
@@ -72,7 +72,7 @@ test("show source tree at specific revision", async ({ page }) => {
   await expect(page.getByTitle("Current branch")).toContainText(
     "335dd6dc89b535a4a31e9422c803199bb6b0a09a",
   );
-  expect(page.locator(".source-tree")).toHaveText("bin/ src/");
+  await expect(page.locator(".source-tree")).toHaveText("bin/ src/");
   await expectCounts({ commits: 2, contributors: 1 }, page);
 });
 

--- a/tests/support/globalSetup.ts
+++ b/tests/support/globalSetup.ts
@@ -3,7 +3,7 @@ import type { FullConfig } from "@playwright/test";
 import { seedPort, seedRemote } from "@tests/support/fixtures.js";
 
 export default async function globalSetup(_config: FullConfig): Promise<void> {
-  assertHttpApiRunning();
+  await assertHttpApiRunning();
 }
 
 // Assert that the test http-api is running. If it is not running, throw an

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@tsconfig/svelte/tsconfig.json",
-  "include": ["src", "tests", "httpd-client"],
+  "include": ["src", "tests", "httpd-client", "./*.js", "./*.ts"],
   "exclude": ["node_modules/*"],
   "compilerOptions": {
     "target": "es2020",


### PR DESCRIPTION
This will help us catch forgotten `await`s and let's us avoid nasty race conditions.

The only drawback is that it's slower:

Without the rule:
```
./scripts/check  15.52s user 1.06s system 188% cpu 8.817 total
```

With the rule:
```
./scripts/check  26.91s user 3.14s system 184% cpu 16.307 total
```