### PR TITLE
Fix relative markdown file links

### DIFF
--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -5,7 +5,8 @@
   import { onMount } from "svelte";
   import { toDom } from "hast-util-to-dom";
 
-  import { base } from "@app/lib/router";
+  import * as utils from "@app/lib/utils";
+  import { base, updateProjectRoute, activeRouteStore } from "@app/lib/router";
   import { isUrl, twemoji, scrollIntoView, canonicalize } from "@app/lib/utils";
   import { highlight } from "@app/lib/syntax";
   import {
@@ -29,6 +30,20 @@
   const render = (content: string): string =>
     // eslint-disable-next-line @typescript-eslint/naming-convention
     dompurify.sanitize(marked.parse(content), { SANITIZE_DOM: false });
+
+  function navigateToMarkdownLink(event: any) {
+    if (event.target.matches(".file-link")) {
+      event.preventDefault();
+      if ($activeRouteStore.resource === "projects") {
+        updateProjectRoute({
+          path: utils.canonicalize(
+            event.target.getAttribute("href"),
+            $activeRouteStore.params.path ?? "",
+          ),
+        });
+      }
+    }
+  }
 
   onMount(async () => {
     // Don't underline <a> tags that contain images.
@@ -54,6 +69,11 @@
         i.setAttribute("src", `${rawPath}/${canonicalize(imagePath, path)}`);
       }
     }
+
+    const fileAnchorTags = document.querySelectorAll(".file-link");
+    fileAnchorTags.forEach(anchorTag => {
+      anchorTag.addEventListener("click", navigateToMarkdownLink);
+    });
 
     // Replaces code blocks in the background with highlighted code.
     const prefix = "language-";

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,6 +1,7 @@
 import emojis from "@app/lib/emojis";
 import katex from "katex";
 import { marked } from "marked";
+import { isUrl } from "./utils";
 
 const emojisMarkedExtension = {
   name: "emoji",
@@ -135,6 +136,14 @@ export const renderer = {
       "\n",
     )}</div>`;
     return `<li>${liContent}</li>`;
+  },
+  link(href: string, _title: string, text: string) {
+    // If the link is not a URL nor starts with a #, we add the file-link class to it,
+    // so we're able to query it in the Markdown component.
+    if (!isUrl(href) && !href.startsWith("#")) {
+      return `<a href="${href}" class="file-link">${text}</a>`;
+    }
+    return `<a href="${href}">${text}</a>`;
   },
 };
 


### PR DESCRIPTION
This PR should close #682, #645

It adds a `.file-link` class to eventual relative file links inside markdowns that also aren't hash anchor links.
Then we are able in the `Markdown` component to query those elements and call `updateProjectRoute` with the new path

This is something I would like to write a e2e test about.. But I'll wait for CLI tooling, since it needs changes to the seed fixture and I think that can wait.