### PR TITLE
Fix patch review schema

### DIFF
--- a/httpd-client/lib/project/patch.ts
+++ b/httpd-client/lib/project/patch.ts
@@ -73,14 +73,14 @@ type Verdict = "accept" | "reject";
 
 export interface Review {
   verdict?: Verdict | null;
-  comment?: string;
+  comment?: string | null;
   inline: CodeComment[];
   timestamp: number;
 }
 
 const reviewSchema = strictObject({
-  verdict: optional(union([literal("accept"), literal("reject")])).nullable(),
-  comment: optional(string()),
+  verdict: optional(union([literal("accept"), literal("reject")]).nullable()),
+  comment: optional(string().nullable()),
   inline: array(codeCommentSchema),
   timestamp: number(),
 }) satisfies ZodSchema<Review>;


### PR DESCRIPTION
There was another field that should have been nullable.

<img width="1840" alt="Screenshot 2023-04-26 at 10 42 35" src="https://user-images.githubusercontent.com/158411/234520447-077a7027-019f-480e-82e9-be03b3c12386.png">
