### PR TITLE
Improve patch timeline and add description

### DIFF
--- a/httpd-client/index.ts
+++ b/httpd-client/index.ts
@@ -1,5 +1,11 @@
 import type { BaseUrl } from "./lib/fetcher.js";
-import type { Blob, Project, Remote, Tree } from "./lib/project.js";
+import type {
+  Blob,
+  Project,
+  Remote,
+  Tree,
+  DiffResponse,
+} from "./lib/project.js";
 import type { Comment } from "./lib/project/comment.js";
 import type {
   Commit,
@@ -9,7 +15,13 @@ import type {
   HunkLine,
 } from "./lib/project/commit.js";
 import type { Issue, IssueState } from "./lib/project/issue.js";
-import type { Merge, Patch, PatchState, Review } from "./lib/project/patch.js";
+import type {
+  Merge,
+  Patch,
+  PatchState,
+  Review,
+  Revision,
+} from "./lib/project/patch.js";
 import type { RequestOptions, Method } from "./lib/fetcher.js";
 import type { ZodSchema } from "zod";
 
@@ -27,6 +39,7 @@ export type {
   CommitHeader,
   Diff,
   DiffAddedDeletedModifiedChangeset,
+  DiffResponse,
   HunkLine,
   Issue,
   IssueState,
@@ -36,6 +49,7 @@ export type {
   Project,
   Remote,
   Review,
+  Revision,
   Tree,
 };
 

--- a/httpd-client/lib/project.ts
+++ b/httpd-client/lib/project.ts
@@ -153,7 +153,7 @@ const remoteSchema = strictObject({
 
 const remotesSchema = array(remoteSchema) satisfies ZodSchema<Remote[]>;
 
-interface DiffResponse {
+export interface DiffResponse {
   commits: CommitHeader[];
   diff: Diff;
 }

--- a/httpd-client/lib/project/patch.ts
+++ b/httpd-client/lib/project/patch.ts
@@ -85,7 +85,7 @@ const reviewSchema = strictObject({
   timestamp: number(),
 }) satisfies ZodSchema<Review>;
 
-interface Revision {
+export interface Revision {
   id: string;
   description: string;
   base: string;

--- a/scripts/run-httpd-with-fixtures
+++ b/scripts/run-httpd-with-fixtures
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-REV=414477a31676d5e75efa7f3e8dc6624bcf2b2e52
+REV=b29321dbf7999ec7ec9b7ac9192071e512ada407
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 FIXTURE=$REPO_ROOT/tests/fixtures/seeds/palm.tar.bz2

--- a/src/components/Authorship.svelte
+++ b/src/components/Authorship.svelte
@@ -15,7 +15,7 @@
   .authorship {
     display: inline-flex;
     align-items: center;
-    color: var(--color-foreground-6);
+    color: inherit;
     padding: 0.125rem 0;
     gap: 0.25rem;
   }
@@ -29,7 +29,7 @@
   }
 </style>
 
-<span class="authorship txt-tiny" title={relativeTimestamp(timestamp)}>
+<span class="authorship txt-tiny">
   {#if !noAvatar}
     <Avatar inline nodeId={authorId} />
   {/if}
@@ -39,14 +39,16 @@
   <span class="id layout-mobile">
     {formatNodeId(authorId).replace("did:key:", "")}
   </span>
-  <span class="body">
-    {#if !caption}
-      <slot />
-    {:else}
+  {#if !caption}
+    <slot />
+  {:else}
+    <span class="body">
       {caption}
-    {/if}
-  </span>
+    </span>
+  {/if}
   {#if timestamp}
-    {formatTimestamp(timestamp)}
+    <span title={relativeTimestamp(timestamp)}>
+      {formatTimestamp(timestamp)}
+    </span>
   {/if}
 </span>

--- a/src/components/Comment.svelte
+++ b/src/components/Comment.svelte
@@ -20,13 +20,12 @@
 
 <style>
   .comment {
-    margin-bottom: 1rem;
     display: flex;
   }
   .card {
     flex: 1;
-    border: 1px solid var(--color-foreground-4);
     border-radius: var(--border-radius);
+    background-color: var(--color-foreground-1);
   }
   .card-header {
     display: flex;
@@ -37,7 +36,7 @@
   }
   .card-body {
     font-size: var(--font-size-small);
-    padding: 0rem 1rem 1rem 1rem;
+    padding: 0 1rem 1rem 1rem;
   }
   .actions {
     display: flex;
@@ -52,12 +51,7 @@
 <div class="comment" {id}>
   <div class="card">
     <div class="card-header">
-      <div class="layout-desktop">
-        <Authorship {caption} {authorId} {timestamp} />
-      </div>
-      <div class="layout-mobile">
-        <Authorship {authorId} {timestamp} />
-      </div>
+      <Authorship {caption} {authorId} {timestamp} />
       <div class="actions">
         {#if showReplyIcon}
           <Button

--- a/src/components/Dropdown.svelte
+++ b/src/components/Dropdown.svelte
@@ -57,7 +57,7 @@
       on:click={() => onSelect(item)}
       title={item.title}>
       <slot name="item" {item}>
-        {item.value}
+        {item.title}
         {#if item.badge}
           <Badge variant="primary">{item.badge}</Badge>
         {/if}

--- a/src/components/ErrorMessage.svelte
+++ b/src/components/ErrorMessage.svelte
@@ -8,11 +8,14 @@
 <style>
   .error {
     padding: 1rem;
+    font-size: var(--font-size-regular);
+    font-family: var(--font-family-sans-serif);
     color: var(--color-negative);
     border-radius: var(--border-radius);
     background-color: var(--color-negative-3);
     display: flex;
     align-items: center;
+    width: 100%;
   }
   .stack-trace {
     display: flex;

--- a/src/components/InlineMarkdown.svelte
+++ b/src/components/InlineMarkdown.svelte
@@ -6,7 +6,7 @@
   import { twemoji } from "@app/lib/utils";
 
   export let content: string;
-  export let fontSize: "small" | "medium" = "small";
+  export let fontSize: "tiny" | "small" | "medium" = "small";
 
   marked.use({
     renderer,
@@ -34,6 +34,7 @@
   class="markdown"
   use:twemoji
   class:txt-medium={fontSize === "medium"}
-  class:txt-small={fontSize === "small"}>
+  class:txt-small={fontSize === "small"}
+  class:txt-tiny={fontSize === "tiny"}>
   {@html render(content)}
 </span>

--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -280,6 +280,10 @@
   .markdown :global(.list-content) {
     margin: 1rem 0;
   }
+  /* Allows the parent to specify its own bottom margin */
+  .markdown :global(:last-child) {
+    margin-bottom: 0;
+  }
   .markdown :global(li > ul) {
     margin-bottom: 0rem;
   }

--- a/src/components/TextInput.svelte
+++ b/src/components/TextInput.svelte
@@ -14,8 +14,6 @@
   export let disabled: boolean = false;
   export let loading: boolean = false;
   export let valid: boolean = false;
-  // Changes the background color to the background of the page
-  export let transparent: boolean = false;
   export let validationMessage: string | undefined = undefined;
 
   const dispatch = createEventDispatcher<{
@@ -73,9 +71,6 @@
   input[disabled] {
     color: var(--color-secondary);
     cursor: not-allowed;
-  }
-  .transparent {
-    background: var(--color-background) !important;
   }
   .regular {
     border: 1px solid var(--color-secondary);
@@ -148,7 +143,6 @@
     </div>
 
     <input
-      class:transparent
       class:regular={variant === "regular"}
       class:form={variant === "form"}
       style:padding-left={leftContainerWidth

--- a/src/components/Thread.svelte
+++ b/src/components/Thread.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script lang="ts" strictEvents>
   import type { Comment } from "@httpd-client";
 
   import Button from "@app/components/Button.svelte";
@@ -10,7 +10,6 @@
 
   export let thread: { root: Comment; replies: Comment[] };
   export let rawPath: string;
-  export let isDescription = false;
   export let showReplyTextarea = false;
 
   let replyText = "";
@@ -53,6 +52,7 @@
 <style>
   .reply {
     margin-left: 3rem;
+    margin-top: 1rem;
   }
   .actions {
     display: flex;
@@ -62,14 +62,16 @@
   }
 </style>
 
-<CommentComponent
-  {rawPath}
-  id={root.id}
-  authorId={root.author.id}
-  timestamp={root.timestamp}
-  body={root.body}
-  showReplyIcon={Boolean($sessionStore) && !isDescription}
-  on:toggleReply={toggleReply} />
+<div style:margin-top="1rem">
+  <CommentComponent
+    {rawPath}
+    id={root.id}
+    authorId={root.author.id}
+    timestamp={root.timestamp}
+    body={root.body}
+    showReplyIcon={Boolean($sessionStore)}
+    on:toggleReply={toggleReply} />
+</div>
 {#each replies as reply}
   <div class="reply">
     <CommentComponent

--- a/src/views/projects/Cob/AssigneeInput.svelte
+++ b/src/views/projects/Cob/AssigneeInput.svelte
@@ -11,7 +11,7 @@
   const dispatch = createEventDispatcher<{ save: string[] }>();
 
   export let action: "create" | "edit" | "view";
-  export let edit: boolean = false;
+  export let editInProgress: boolean = false;
   export let assignees: string[] = [];
 
   let updatedAssignees: string[] = assignees;
@@ -45,9 +45,6 @@
 </script>
 
 <style>
-  .metadata-section {
-    margin-bottom: 4rem;
-  }
   .header {
     display: flex;
     gap: 1rem;
@@ -75,28 +72,28 @@
   }
 </style>
 
-<div class="metadata-section">
+<div>
   <div class="header">
     <span>Assignees</span>
     {#if action === "edit"}
-      {#if !edit}
+      {#if editInProgress}
         <Button
           size="tiny"
           variant="text"
           on:click={() => {
-            edit = !edit;
+            dispatch("save", updatedAssignees);
+            editInProgress = !editInProgress;
           }}>
-          edit
+          save
         </Button>
       {:else}
         <Button
           size="tiny"
           variant="text"
           on:click={() => {
-            dispatch("save", updatedAssignees);
-            edit = !edit;
+            editInProgress = !editInProgress;
           }}>
-          save
+          edit
         </Button>
       {/if}
     {/if}
@@ -105,7 +102,7 @@
     {#each updatedAssignees as assignee, key (assignee)}
       <Chip
         on:remove={removeAssignee}
-        removeable={edit || action === "create"}
+        removeable={editInProgress || action === "create"}
         {key}>
         <div class="chip-content">
           <Avatar inline nodeId={assignee} />
@@ -116,7 +113,7 @@
       <div class="empty">No assignees</div>
     {/each}
   </div>
-  {#if edit || action === "create"}
+  {#if editInProgress || action === "create"}
     <div style:margin-bottom="1rem">
       <TextInput
         bind:value={inputValue}

--- a/src/views/projects/Cob/CobHeader.svelte
+++ b/src/views/projects/Cob/CobHeader.svelte
@@ -1,8 +1,7 @@
 <script lang="ts" strictEvents>
   import { createEventDispatcher } from "svelte";
 
-  import { formatObjectId } from "@app/lib/utils";
-
+  import * as utils from "@app/lib/utils";
   import Button from "@app/components/Button.svelte";
   import Clipboard from "@app/components/Clipboard.svelte";
   import InlineMarkdown from "@app/components/InlineMarkdown.svelte";
@@ -19,76 +18,58 @@
 
 <style>
   header {
-    background: var(--color-foreground-1);
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
     border-radius: var(--border-radius);
-    margin-bottom: 1rem;
+    border: 1px solid var(--color-foreground-3);
     padding: 1rem;
-  }
-  .summary {
-    display: flex;
-    flex-direction: row;
-    gap: 1rem;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 0.5rem;
-    padding-right: 0.5rem;
-  }
-  .summary-title {
-    display: flex;
-    flex-direction: row;
-    align-items: baseline;
-    gap: 0.5rem;
-    width: 90%;
-  }
-  .id {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    font-size: var(--font-size-tiny);
-    font-family: var(--font-family-monospace);
-    color: var(--color-foreground-6);
   }
   .title {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  .summary-state {
+  .subtitle {
     display: flex;
     flex-direction: row;
-    gap: 1rem;
-    border-radius: var(--border-radius);
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    font-size: var(--font-size-tiny);
+    font-family: var(--font-family-monospace);
+    color: var(--color-foreground-6);
+  }
+  .summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+  .id {
+    display: flex;
+    align-items: center;
+  }
+  .description {
+    font-size: var(--font-size-small);
+    margin-top: 1rem;
   }
 </style>
 
 <header>
-  <div class="summary">
-    <div class="summary-title txt-medium">
-      {#if editable}
-        <TextInput transparent variant="form" bind:value={title} />
-      {:else}
-        {#if title}
-          <div class="title">
-            <InlineMarkdown fontSize="medium" content={title} />
-          </div>
-        {:else}
-          <span class="txt-missing">No title</span>
-        {/if}
-        <slot name="revision" />
-        {#if id}
-          <div class="id">
-            <div class="layout-desktop">{id}</div>
-            <div class="layout-mobile">
-              {formatObjectId(id)}
-            </div>
-            <Clipboard small text={id} />
-          </div>
-        {/if}
-      {/if}
-    </div>
+  <div class="summary txt-medium">
+    {#if editable}
+      <TextInput variant="form" placeholder="Title" bind:value={title} />
+    {:else if title}
+      <div class="title">
+        <InlineMarkdown fontSize="medium" content={title} />
+      </div>
+    {:else}
+      <span class="txt-missing">No title</span>
+    {/if}
     {#if action === "edit"}
       <Button
-        variant="text"
+        variant="foreground"
         size="small"
         on:click={() => {
           editable = !editable;
@@ -102,7 +83,17 @@
       </Button>
     {/if}
   </div>
-  <div class="summary-state">
+  <div class="subtitle">
     <slot name="state" />
+    {#if id}
+      <div class="id">
+        {utils.formatObjectId(id)}
+        <Clipboard text={id} small />
+      </div>
+    {/if}
+    <slot name="author" />
+  </div>
+  <div class="description">
+    <slot name="description" />
   </div>
 </header>

--- a/src/views/projects/Cob/Revision.svelte
+++ b/src/views/projects/Cob/Revision.svelte
@@ -1,0 +1,263 @@
+<script lang="ts">
+  import type { BaseUrl, DiffResponse } from "@httpd-client";
+  import type { Timeline } from "@app/views/projects/Patch.svelte";
+
+  import * as utils from "@app/lib/utils";
+  import { onMount } from "svelte";
+  import { HttpdClient } from "@httpd-client";
+
+  import Authorship from "@app/components/Authorship.svelte";
+  import Avatar from "@app/components/Avatar.svelte";
+  import Clipboard from "@app/components/Clipboard.svelte";
+  import CommentComponent from "@app/components/Comment.svelte";
+  import DiffStatBadge from "@app/components/DiffStatBadge.svelte";
+  import ErrorMessage from "@app/components/ErrorMessage.svelte";
+  import Icon from "@app/components/Icon.svelte";
+  import InlineMarkdown from "@app/components/InlineMarkdown.svelte";
+  import ProjectLink from "@app/components/ProjectLink.svelte";
+  import ThreadComponent from "@app/components/Thread.svelte";
+
+  export let authorId: string;
+  export let baseUrl: BaseUrl;
+  export let expanded: boolean = true;
+  export let patchId: string;
+  export let projectHead: string;
+  export let projectId: string;
+  export let revisionBase: string;
+  export let revisionId: string;
+  export let revisionOid: string;
+  export let revisionTimestamp: number;
+  export let timelines: Timeline[];
+
+  const api = new HttpdClient(baseUrl);
+
+  function formatVerdict(revision: string, verdict?: string | null) {
+    switch (verdict) {
+      case "accept":
+        return `accepted revision ${utils.formatObjectId(revision)}`;
+      case "reject":
+        return `rejected revision ${utils.formatObjectId(revision)}`;
+      default:
+        return `left a comment on revision ${utils.formatObjectId(revision)}`;
+    }
+  }
+
+  let response: DiffResponse | undefined = undefined;
+  let error: any | undefined = undefined;
+
+  onMount(async () => {
+    try {
+      response = await api.project.getDiff(
+        projectId,
+        revisionBase,
+        revisionOid,
+      );
+    } catch (err: any) {
+      error = err;
+    }
+  });
+</script>
+
+<style>
+  .action {
+    background-color: var(--color-foreground-1);
+    border-radius: var(--border-radius);
+    padding: 0.5rem 1rem;
+  }
+  .action-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .merge {
+    color: var(--color-primary);
+    background-color: var(--color-primary-3);
+  }
+  .positive-review {
+    color: var(--color-positive);
+    background-color: var(--color-positive-3);
+  }
+  .revision {
+    border: 1px solid var(--color-foreground-3);
+    border-radius: var(--border-radius-small);
+    margin-bottom: 1rem;
+  }
+  .revision-header {
+    height: 3rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: none;
+    padding: 1rem;
+    padding-right: 1.5rem;
+  }
+  .revision-name {
+    display: flex;
+    user-select: none;
+  }
+  .revision-data {
+    gap: 0.5rem;
+    display: flex;
+  }
+  .revision-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 0 1.5rem;
+    margin-bottom: 1rem;
+    border-radius: var(--border-radius-small);
+  }
+  .expand-button {
+    margin-right: 0.5rem;
+    user-select: none;
+    cursor: pointer;
+  }
+  .commit-event {
+    color: var(--color-foreground-6);
+    padding: 0.5rem 0.5rem 0.5rem 1rem;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .commit-event span {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+</style>
+
+<div class="revision">
+  <div class="revision-header">
+    <div class="revision-name">
+      <div class="expand-button">
+        <Icon
+          name={expanded ? "chevron-down" : "chevron-right"}
+          on:click={() => (expanded = !expanded)} />
+      </div>
+      <span>
+        Revision {utils.formatObjectId(revisionId)}
+      </span>
+      <Clipboard text={revisionId} small />
+    </div>
+    <div class="txt-small" />
+    <div class="revision-data">
+      {#if response?.diff.stats}
+        {@const { insertions, deletions } = response.diff.stats}
+        <DiffStatBadge {insertions} {deletions} />
+      {/if}
+      <span class="layout-desktop txt-small">
+        {utils.formatTimestamp(revisionTimestamp)}
+      </span>
+    </div>
+  </div>
+  {#if expanded}
+    <div class="revision-body">
+      {#each timelines as element}
+        {#if element.type === "thread"}
+          <ThreadComponent
+            rawPath={utils.getRawBasePath(projectId, baseUrl, projectHead)}
+            thread={element.inner}
+            on:reply />
+        {:else if element.type === "revision"}
+          {@const caption =
+            patchId === element.inner.id
+              ? "opened this patch"
+              : `updated to ${utils.formatObjectId(element.inner.id)}`}
+          {#if element.inner.description}
+            <CommentComponent
+              {caption}
+              {authorId}
+              timestamp={element.timestamp}
+              rawPath={utils.getRawBasePath(projectId, baseUrl, projectHead)}
+              body={element.inner.description} />
+          {:else}
+            <div class="action txt-tiny">
+              <Authorship {authorId} timestamp={element.timestamp}>
+                {caption}
+              </Authorship>
+            </div>
+          {/if}
+          {#if response?.commits}
+            <div class="action txt-tiny">
+              {#each response.commits as commit}
+                <div class="commit-event">
+                  <span>
+                    <Avatar inline nodeId={authorId} />
+                    <ProjectLink
+                      projectParams={{
+                        view: { resource: "commits" },
+                        revision: commit.id,
+                        search: undefined,
+                      }}>
+                      <InlineMarkdown
+                        content={commit.summary}
+                        fontSize="tiny" />
+                    </ProjectLink>
+                  </span>
+                  <span>
+                    {utils.formatCommit(commit.id)}
+                  </span>
+                </div>
+              {/each}
+            </div>
+          {/if}
+          {#if error}
+            <div class="txt-monospace">
+              <ErrorMessage
+                message="Failed to load diff for this revision."
+                stackTrace={error.stack.toString()} />
+            </div>
+          {/if}
+        {:else if element.type === "merge"}
+          <div class="action merge layout-desktop txt-tiny">
+            <div class="action-content">
+              <Authorship
+                authorId={element.inner.node}
+                timestamp={element.timestamp}>
+                merged
+                {utils.formatCommit(element.inner.commit)}
+              </Authorship>
+            </div>
+          </div>
+          <div class="action merge layout-mobile txt-tiny">
+            <div class="action-content">
+              <Authorship authorId={element.inner.node}>
+                merged
+                {utils.formatCommit(element.inner.commit)}
+              </Authorship>
+            </div>
+          </div>
+        {:else if element.type === "review"}
+          {@const [revisionId, author, review] = element.inner}
+          <div
+            class="action layout-desktop txt-tiny"
+            class:positive-review={element.inner[2].verdict === "accept"}>
+            <div class="action-content">
+              <Authorship authorId={author} timestamp={element.timestamp}>
+                {formatVerdict(revisionId, review.verdict)}
+              </Authorship>
+            </div>
+          </div>
+          <div
+            class="layout-mobile txt-tiny"
+            class:positive-review={element.inner[2].verdict === "accept"}>
+            <div class="action-content">
+              <Authorship authorId={author}>
+                {formatVerdict(revisionId, review.verdict)}
+              </Authorship>
+            </div>
+          </div>
+          {#if review.comment}
+            <CommentComponent
+              caption="left a comment"
+              authorId={author}
+              timestamp={review.timestamp}
+              rawPath={utils.getRawBasePath(projectId, baseUrl, projectHead)}
+              body={review.comment} />
+          {/if}
+        {/if}
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/src/views/projects/Cob/TagInput.svelte
+++ b/src/views/projects/Cob/TagInput.svelte
@@ -8,7 +8,7 @@
   const dispatch = createEventDispatcher<{ save: string[] }>();
 
   export let action: "create" | "edit" | "view" = "view";
-  export let edit: boolean = false;
+  export let editInProgress: boolean = false;
   export let tags: string[] = [];
 
   let updatedTags: string[] = tags;
@@ -42,9 +42,6 @@
 </script>
 
 <style>
-  .metadata-section {
-    margin-bottom: 4rem;
-  }
   .metadata-section-header {
     display: flex;
     gap: 1rem;
@@ -70,28 +67,28 @@
   }
 </style>
 
-<div class="metadata-section">
+<div>
   <div class="metadata-section-header">
     <span>Tags</span>
     {#if action === "edit"}
-      {#if !edit}
+      {#if editInProgress}
         <Button
           size="tiny"
           variant="text"
           on:click={() => {
-            edit = !edit;
+            dispatch("save", updatedTags);
+            editInProgress = !editInProgress;
           }}>
-          edit
+          save
         </Button>
       {:else}
         <Button
           size="tiny"
           variant="text"
           on:click={() => {
-            dispatch("save", updatedTags);
-            edit = !edit;
+            editInProgress = !editInProgress;
           }}>
-          save
+          edit
         </Button>
       {/if}
     {/if}
@@ -100,7 +97,7 @@
     {#each updatedTags as tag, key (tag)}
       <Chip
         on:remove={removeTag}
-        removeable={edit || action === "create"}
+        removeable={editInProgress || action === "create"}
         {key}>
         <div class="tag">{tag}</div>
       </Chip>
@@ -108,7 +105,7 @@
       <div class="metadata-section-empty">No tags</div>
     {/each}
   </div>
-  {#if edit || action === "create"}
+  {#if editInProgress || action === "create"}
     <div style:margin-bottom="1rem">
       <TextInput
         bind:value={inputValue}

--- a/src/views/projects/Commit/CommitTeaser.svelte
+++ b/src/views/projects/Commit/CommitTeaser.svelte
@@ -47,7 +47,6 @@
   }
   .browse {
     display: flex;
-    z-index: 10;
     width: 100%;
     height: 100%;
   }

--- a/src/views/projects/View.svelte
+++ b/src/views/projects/View.svelte
@@ -34,7 +34,7 @@
   $: searchParams = new URLSearchParams(activeRoute.params.search || "");
   $: issueFilter = (searchParams.get("state") as IssueStatus) || "open";
   $: patchTabFilter =
-    (searchParams.get("tab") as "activity" | "commits") || "activity";
+    (searchParams.get("tab") as "activity" | "commits" | "files") || "activity";
   $: patchFilter = (searchParams.get("state") as PatchStatus) || "open";
   $: baseUrl = utils.extractBaseUrl(activeRoute.params.hostnamePort);
   $: api = new HttpdClient(baseUrl);
@@ -254,13 +254,15 @@
         {#await api.project.getPatchById(project.id, activeRoute.params.view.params.patch)}
           <Loading center />
         {:then patch}
+          {@const latestRevision = patch.revisions[patch.revisions.length - 1]}
           <Patch
+            {patch}
             {baseUrl}
             projectId={project.id}
             projectHead={project.head}
-            revision={activeRoute.params.view.params.revision}
-            currentTab={patchTabFilter}
-            {patch} />
+            revision={activeRoute.params.view.params.revision ??
+              latestRevision.id}
+            currentTab={patchTabFilter} />
         {:catch e}
           <div class="message">
             <ErrorMessage message="Couldn't load patch." stackTrace={e} />

--- a/tests/e2e/project.spec.ts
+++ b/tests/e2e/project.spec.ts
@@ -267,9 +267,9 @@ test("peer and branch switching", async ({ page }) => {
     await page.getByTitle("Change peer").click();
     await page.locator(`text=${aliceRemote}`).click();
     await expect(page.getByTitle("Change peer")).toHaveText(
-      ` did:key:${aliceRemote.substring(8).substring(0, 6)}…${aliceRemote.slice(
-        -6,
-      )} `,
+      `  did:key:${aliceRemote
+        .substring(8)
+        .substring(0, 6)}…${aliceRemote.slice(-6)} delegate`,
     );
     await expect(
       page.locator(

--- a/tests/e2e/project/commits.spec.ts
+++ b/tests/e2e/project/commits.spec.ts
@@ -15,9 +15,9 @@ test("peer and branch switching", async ({ page }) => {
     await page.getByTitle("Change peer").click();
     await page.locator(`text=${aliceRemote}`).click();
     await expect(page.getByTitle("Change peer")).toHaveText(
-      ` did:key:${aliceRemote.substring(8).substring(0, 6)}…${aliceRemote.slice(
-        -6,
-      )} `,
+      `  did:key:${aliceRemote
+        .substring(8)
+        .substring(0, 6)}…${aliceRemote.slice(-6)} delegate`,
     );
 
     await expect(page.getByText("Thursday, November 17, 2022")).toBeVisible();


### PR DESCRIPTION
Ok this PR tackles a few design issues

## New patch landing
With revision independent activity timeline, and some items have moved into and out of the patch header, like description, revision selector.
Also added commits to patch activity timeline.
<img width="1028" alt="Bildschirmfoto 2023-05-05 um 13 24 27" src="https://user-images.githubusercontent.com/7912302/236445458-fbce8d86-8b2b-4425-88b5-c1dac7ffe551.png">

## Revision Selector in Files and Commits
<img width="1058" alt="Bildschirmfoto 2023-05-05 um 13 25 07" src="https://user-images.githubusercontent.com/7912302/236445596-8b6e770d-f50a-4508-8385-fe44b2053131.png">

## positive reviews and merges have a specific background color
<img width="1022" alt="Bildschirmfoto 2023-05-05 um 13 25 57" src="https://user-images.githubusercontent.com/7912302/236445777-d93ac98b-63da-4c59-94cf-8cbcaa450ed9.png">


This PR closes #667 #693