### PR TITLE
Data pre-loading in router

### DIFF
--- a/httpd-client/index.ts
+++ b/httpd-client/index.ts
@@ -61,7 +61,7 @@ const nodeSchema = strictObject({
   id: string(),
 }) satisfies ZodSchema<Node>;
 
-export interface Root {
+export interface NodeInfo {
   message: string;
   service: string;
   version: string;
@@ -70,7 +70,7 @@ export interface Root {
   links: { href: string; rel: string; type: Method }[];
 }
 
-const rootSchema = strictObject({
+const nodeInfoSchema = strictObject({
   message: string(),
   service: string(),
   version: string(),
@@ -88,7 +88,7 @@ const rootSchema = strictObject({
       ]),
     }),
   ),
-}) satisfies ZodSchema<Root>;
+}) satisfies ZodSchema<NodeInfo>;
 
 export interface NodeStats {
   projects: { count: number };
@@ -115,14 +115,14 @@ export class HttpdClient {
     this.session = new session.Client(this.#fetcher);
   }
 
-  public async getRoot(options?: RequestOptions): Promise<Root> {
+  public async getNodeInfo(options?: RequestOptions): Promise<NodeInfo> {
     return this.#fetcher.fetchOk(
       {
         method: "GET",
         path: "",
         options,
       },
-      rootSchema,
+      nodeInfoSchema,
     );
   }
 

--- a/httpd-client/tests/client.test.ts
+++ b/httpd-client/tests/client.test.ts
@@ -8,8 +8,8 @@ const api = new HttpdClient({
 });
 
 describe("client", () => {
-  test("#getRoot()", async () => {
-    await api.getRoot();
+  test("#getNodeInfo()", async () => {
+    await api.getNodeInfo();
   });
 
   test("#getStats()", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radicle/gray-matter": "4.1.0",
         "@wooorm/starry-night": "^2.0.0",
+        "baconjs": "^3.0.17",
         "bs58": "^5.0.0",
         "buffer": "^6.0.3",
         "dompurify": "^3.0.2",
@@ -20,6 +21,7 @@
         "marked": "^5.0.1",
         "md5": "^2.3.0",
         "plausible-tracker": "^0.3.8",
+        "sinon": "^15.0.4",
         "svelte": "^3.58.0",
         "twemoji": "^14.0.2",
         "zod": "^3.21.2"
@@ -35,6 +37,7 @@
         "@types/marked": "^4.3.0",
         "@types/md5": "^2.3.2",
         "@types/node": "^18.16.2",
+        "@types/sinon": "^10.0.14",
         "@types/sinonjs__fake-timers": "^8.1.2",
         "@typescript-eslint/eslint-plugin": "^5.59.2",
         "chalk": "^5.2.0",
@@ -596,7 +599,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
       "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
-      "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -605,10 +607,24 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
       "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
-      "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
       }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ=="
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
       "version": "2.2.0",
@@ -721,6 +737,15 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
+    },
+    "node_modules/@types/sinon": {
+      "version": "10.0.14",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.14.tgz",
+      "integrity": "sha512-mn72up6cjaMyMuaPaa/AwKf6WtsSRysQC7wxFkCm1XcOKXPM1z+5Y4H5wjIVBz4gdAkjvZxVVfjA6ba1nHr5WQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.2",
@@ -1142,6 +1167,11 @@
         "node": "*"
       }
     },
+    "node_modules/baconjs": {
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/baconjs/-/baconjs-3.0.17.tgz",
+      "integrity": "sha512-XwhawE4gmO+NhMKZYmUSidk8ZjDhx5pfp9k/s5HM25S+k/YKajsakFOxbmUU1L9zbh1SarPbCobBuHhCMPFbCA=="
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1531,6 +1561,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dir-glob": {
@@ -2119,7 +2157,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2425,6 +2462,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2489,6 +2531,11 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
     },
     "node_modules/katex": {
       "version": "0.16.7",
@@ -2566,6 +2613,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -2760,6 +2812,18 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
+    "node_modules/nise": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2867,6 +2931,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dependencies": {
+        "isarray": "0.0.1"
       }
     },
     "node_modules/path-type": {
@@ -3243,6 +3315,31 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true
     },
+    "node_modules/sinon": {
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.4.tgz",
+      "integrity": "sha512-uzmfN6zx3GQaria1kwgWGeKiXSSbShBbue6Dcj0SI8fiCNFbiUDqKl57WFlY5lyhxZVUKmXvzgG2pilRQCBwWg==",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.1.0",
+        "nise": "^5.1.4",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3370,7 +3467,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3598,7 +3694,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/marked": "^4.3.0",
     "@types/md5": "^2.3.2",
     "@types/node": "^18.16.2",
+    "@types/sinon": "^10.0.14",
     "@types/sinonjs__fake-timers": "^8.1.2",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "chalk": "^5.2.0",
@@ -45,6 +46,7 @@
   "dependencies": {
     "@radicle/gray-matter": "4.1.0",
     "@wooorm/starry-night": "^2.0.0",
+    "baconjs": "^3.0.17",
     "bs58": "^5.0.0",
     "buffer": "^6.0.3",
     "dompurify": "^3.0.2",
@@ -55,6 +57,7 @@
     "marked": "^5.0.1",
     "md5": "^2.3.0",
     "plausible-tracker": "^0.3.8",
+    "sinon": "^15.0.4",
     "svelte": "^3.58.0",
     "twemoji": "^14.0.2",
     "zod": "^3.21.2"

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,18 +6,22 @@
   import { unreachable } from "@app/lib/utils";
 
   import Header from "./App/Header.svelte";
-  import ModalPortal from "./App/ModalPortal.svelte";
   import Hotkeys from "./App/Hotkeys.svelte";
+  import LoadingBar from "./App/LoadingBar.svelte";
+  import ModalPortal from "./App/ModalPortal.svelte";
 
-  import NotFound from "@app/components/NotFound.svelte";
   import Home from "@app/views/home/Index.svelte";
-  import Session from "@app/views/session/Index.svelte";
   import Projects from "@app/views/projects/View.svelte";
   import Seeds from "@app/views/seeds/View.svelte";
+  import Session from "@app/views/session/Index.svelte";
+
+  import LoadError from "@app/components/LoadError.svelte";
+  import Loading from "@app/components/Loading.svelte";
+  import NotFound from "@app/components/NotFound.svelte";
 
   const activeRouteStore = router.activeRouteStore;
 
-  router.initialize();
+  router.loadFromLocation();
   session.initialize();
 
   if (!window.VITEST && !window.PLAYWRIGHT && import.meta.env.PROD) {
@@ -51,6 +55,10 @@
   <title>Radicle</title>
 </svelte:head>
 
+{#if $activeRouteStore.resource !== "booting"}
+  <LoadingBar />
+{/if}
+
 <ModalPortal />
 <Hotkeys />
 
@@ -58,16 +66,22 @@
   <Header />
   <div class="wrapper">
     {#if $activeRouteStore.resource === "home"}
-      <Home />
+      <Home {...$activeRouteStore.params} />
     {:else if $activeRouteStore.resource === "seeds"}
-      <Seeds hostnamePort={$activeRouteStore.params.hostnamePort} />
+      <Seeds {...$activeRouteStore.params} />
     {:else if $activeRouteStore.resource === "session"}
       <Session activeRoute={$activeRouteStore} />
     {:else if $activeRouteStore.resource === "projects"}
       <Projects activeRoute={$activeRouteStore} />
-    {:else if $activeRouteStore.resource === "404"}
+    {:else if $activeRouteStore.resource === "booting"}
+      <Loading />
+    {:else if $activeRouteStore.resource === "loadError"}
+      <LoadError {...$activeRouteStore.params} />
+    {:else if $activeRouteStore.resource === "notFound"}
       <div class="layout-centered">
-        <NotFound title="404" subtitle="Nothing here" />
+        <NotFound
+          title="Page not found"
+          subtitle={`${$activeRouteStore.params.url.replace("/", "")}`} />
       </div>
     {:else}
       {unreachable($activeRouteStore)}

--- a/src/App/Header/Search.svelte
+++ b/src/App/Header/Search.svelte
@@ -23,7 +23,7 @@
   let expanded = false;
 
   // Clears search input on user navigation.
-  router.historyStore.subscribe(() => (input = ""));
+  router.activeRouteStore.subscribe(() => (input = ""));
 
   function shake() {
     shaking = true;

--- a/src/App/Header/SearchResultsModal.svelte
+++ b/src/App/Header/SearchResultsModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" strictEvents>
-  import type { ProjectAndSeed } from "@app/lib/search";
+  import type { ProjectBaseUrl } from "@app/lib/search";
 
   import * as modal from "@app/lib/modal";
   import { formatRepositoryId } from "@app/lib/utils";
@@ -8,7 +8,7 @@
   import Modal from "@app/components/Modal.svelte";
 
   export let query: string;
-  export let results: ProjectAndSeed[];
+  export let results: ProjectBaseUrl[];
 </script>
 
 <style>

--- a/src/App/LoadingBar.svelte
+++ b/src/App/LoadingBar.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { isLoading } from "@app/lib/router";
+</script>
+
+<style>
+  .loading-bar {
+    height: 0.125rem;
+    background-color: var(--color-secondary);
+    width: 0%;
+    opacity: 0;
+    position: fixed;
+    z-index: 10;
+    transition: width 2s ease;
+  }
+
+  .visible {
+    opacity: 1;
+    width: 100%;
+  }
+</style>
+
+<div
+  role="progressbar"
+  aria-label="Page loading"
+  class="loading-bar"
+  class:visible={$isLoading} />

--- a/src/components/LoadError.svelte
+++ b/src/components/LoadError.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { twemoji } from "@app/lib/utils";
+
+  import Button from "@app/components/Button.svelte";
+  import ErrorMessage from "@app/components/ErrorMessage.svelte";
+
+  export let title: string | undefined = undefined;
+  export let errorMessage: string;
+  export let stackTrace: string;
+</script>
+
+<style>
+  .wrapper {
+    gap: 1rem;
+  }
+
+  .emoji {
+    display: flex;
+    font-size: var(--font-size-xx-large);
+  }
+</style>
+
+<div class="wrapper layout-centered">
+  <div class="emoji" use:twemoji>🏜️</div>
+  {#if title}
+    <div class="title txt-medium txt-bold txt-highlight">
+      {title}
+    </div>
+  {/if}
+  <ErrorMessage message={errorMessage} {stackTrace} />
+  <div style:margin-top="1rem">
+    <Button variant="foreground" on:click={() => window.history.back()}>
+      Back
+    </Button>
+  </div>
+</div>

--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -6,13 +6,14 @@
   import { toDom } from "hast-util-to-dom";
 
   import * as utils from "@app/lib/utils";
-  import { base, updateProjectRoute, activeRouteStore } from "@app/lib/router";
-  import { isUrl, twemoji, scrollIntoView, canonicalize } from "@app/lib/utils";
+  import { base, activeRouteStore } from "@app/lib/router";
   import { highlight } from "@app/lib/syntax";
+  import { isUrl, twemoji, scrollIntoView, canonicalize } from "@app/lib/utils";
   import {
     markdownExtensions as extensions,
     renderer,
   } from "@app/lib/markdown";
+  import { updateProjectRoute } from "@app/views/projects/router";
 
   export let content: string;
   export let hash: string | null = null;

--- a/src/components/NotFound.svelte
+++ b/src/components/NotFound.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import * as router from "@app/lib/router";
   import { twemoji } from "@app/lib/utils";
 
   import Button from "@app/components/Button.svelte";
@@ -36,6 +35,8 @@
   <div>{subtitle}</div>
 
   <div class="actions">
-    <Button variant="foreground" on:click={router.pop}>Back</Button>
+    <Button variant="foreground" on:click={() => window.history.back()}>
+      Back
+    </Button>
   </div>
 </div>

--- a/src/components/ProjectLink.svelte
+++ b/src/components/ProjectLink.svelte
@@ -1,12 +1,12 @@
 <script lang="ts" strictEvents>
-  import type { ProjectsParams } from "@app/lib/router/definitions";
+  import type { ProjectsParams } from "@app/views/projects/router";
   import { createEventDispatcher } from "svelte";
 
+  import { useDefaultNavigation } from "@app/lib/router";
   import {
     projectLinkHref,
     updateProjectRoute,
-    useDefaultNavigation,
-  } from "@app/lib/router";
+  } from "@app/views/projects/router";
 
   export let projectParams: Partial<ProjectsParams>;
   export let title: string | undefined = undefined;

--- a/src/lib/mutexExecutor.ts
+++ b/src/lib/mutexExecutor.ts
@@ -1,0 +1,112 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import * as Bacon from "baconjs";
+
+// A task executor that runs only one task concurrently. If a new task
+// is run, any previously running task is aborted and the promise
+// returned from `run()` will return undefined.
+//
+//     import * as mutexExecutor from "ui/src/mutexExecutor"
+//     const executor = mutexExecutor.create()
+//     const first = await executor.run(async () => {
+//       await sleep(1000)
+//       return "first"
+//     })
+//     const second = await executor.run(async () => "second")
+//
+// In the example above the promise `first` will resolve to `undefined`
+// while the promise `second` will resolve to "second".
+//
+// If the first tasks throws after the second task has run the
+// behavior is the same.
+//
+//     const first = await executor.run(async () => {
+//       await sleep(1000)
+//       throw new Error()
+//     })
+//
+// The task call back receives an AbortSignal as a parameter. The abort
+// event is emitted when another task is run.
+export function create(): MutexExecutor {
+  return new MutexExecutor();
+}
+
+// A worker that asynchronously process one item at a time and provides
+// the result as an event stream.
+//
+//     import * as mutexExecutor from "ui/src/mutexExecutor"
+//     const worker = mutexExecutor.createWorker(async (value) => {
+//       await sleep(1000)
+//       return value
+//     })
+//
+//     const firstPromise = worker.output.firstToPromise()
+//     worker.push("first)
+//     assert.equal(await firstPromise, "first")
+//
+// When an item is submitted to the worker while the previous items is
+// still being processed, the result of the first item will not be
+// emitted to `worker.output`. Instead, only the last item will be
+// emitted.
+export function createWorker<In, Out>(
+  fn: (x: In, abortSignal: AbortSignal) => Promise<Out>,
+): MutexWorker<In, Out> {
+  return new MutexWorker(fn);
+}
+
+class MutexExecutor {
+  private runningTaskId = 0;
+  private abortController: AbortController | null = null;
+
+  public async run<T>(
+    f: (abortSignal: AbortSignal) => Promise<T>,
+  ): Promise<T | undefined> {
+    this.runningTaskId += 1;
+    const taskId = this.runningTaskId;
+
+    if (this.abortController) {
+      this.abortController.abort();
+    }
+    this.abortController = new AbortController();
+    return f(this.abortController.signal).then(
+      data => {
+        if (this.runningTaskId === taskId) {
+          return data;
+        } else {
+          return undefined;
+        }
+      },
+      err => {
+        if (this.runningTaskId === taskId) {
+          throw err;
+        } else {
+          return undefined;
+        }
+      },
+    );
+  }
+}
+
+class MutexWorker<In, Out> {
+  private outputBus = new Bacon.Bus<Out>();
+  private executor = new MutexExecutor();
+
+  public output: Bacon.EventStream<Out>;
+
+  public constructor(
+    private fn: (x: In, abortSignal: AbortSignal) => Promise<Out>,
+  ) {
+    this.output = this.outputBus.toEventStream();
+  }
+
+  public async submit(x: In): Promise<void> {
+    const output = await this.executor.run(abort => this.fn(x, abort));
+    if (output !== undefined) {
+      this.outputBus.push(output);
+    }
+  }
+}

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -1,20 +1,22 @@
-import type { ProjectsParams, Route, ProjectRoute } from "./router/definitions";
-import type { Readable } from "svelte/store";
+import type { LoadedRoute, Route } from "@app/lib/router/definitions";
 
-import { get, writable, derived } from "svelte/store";
+import { writable } from "svelte/store";
+
+import * as mutexExecutor from "@app/lib/mutexExecutor";
+import { loadRoute } from "@app/lib/router/definitions";
 import { unreachable } from "@app/lib/utils";
+import {
+  resolveProjectRoute,
+  updateProjectRoute,
+} from "@app/views/projects/router";
 
-// This is only respected by Safari.
-const documentTitle = "Radicle Interface";
+// Only used by Safari.
+const DOCUMENT_TITLE = "Radicle Interface";
 
-export const historyStore = writable<Route[]>([{ resource: "home" }]);
-
-export const activeRouteStore: Readable<Route> = derived(
-  historyStore,
-  store => {
-    return store.slice(-1)[0];
-  },
-);
+export const isLoading = writable<boolean>(true);
+export const activeRouteStore = writable<LoadedRoute>({
+  resource: "booting",
+});
 
 export function useDefaultNavigation(event: MouseEvent) {
   return (
@@ -28,122 +30,71 @@ export function useDefaultNavigation(event: MouseEvent) {
 
 export const base = import.meta.env.VITE_HASH_ROUTING ? "./" : "/";
 
-// Gets triggered when clicking on an anchor hash tag e.g. <a href="#header"/>
-// Allows the jump to a anchor hash
-window.addEventListener("hashchange", e => {
-  const route = pathToRoute(e.newURL);
-  if (route?.resource === "projects" && route.params.hash) {
-    if (route.params.hash.match(/^L\d+$/)) {
-      updateProjectRoute({ line: route.params.hash });
-    } else {
-      updateProjectRoute({ hash: route.params.hash });
-    }
-  }
-});
-
-// Replaces history on any user interaction with forward and backwards buttons
-// with the current window.history.state
-window.addEventListener("popstate", e => {
-  if (e.state) replace(e.state);
-});
-
-export function createProjectRoute(
-  activeRoute: ProjectRoute,
-  projectRouteParams: Partial<ProjectsParams>,
-): ProjectRoute {
-  return {
-    resource: "projects",
-    params: {
-      ...activeRoute.params,
-      line: undefined,
-      hash: undefined,
-      ...projectRouteParams,
-    },
-  };
-}
-
-export function projectLinkHref(
-  projectRouteParams: Partial<ProjectsParams>,
-): string | undefined {
-  const activeRoute = get(activeRouteStore);
-
-  if (activeRoute.resource === "projects") {
-    return routeToPath(createProjectRoute(activeRoute, projectRouteParams));
-  } else {
-    throw new Error(
-      "Don't use project specific navigation outside of project views",
-    );
-  }
-}
-
-function sanitizeQueryString(queryString: string): string {
-  return queryString.startsWith("?") ? queryString.substring(1) : queryString;
-}
-
-export function updateProjectRoute(
-  projectRouteParams: Partial<ProjectsParams>,
-  opts: { replace: boolean } = { replace: false },
-) {
-  const activeRoute = get(activeRouteStore);
-
-  if (activeRoute.resource === "projects") {
-    const updatedRoute = createProjectRoute(activeRoute, projectRouteParams);
-    if (opts.replace) {
-      replace(updatedRoute);
-    } else {
-      push(updatedRoute);
-    }
-  } else {
-    throw new Error(
-      "Don't use project specific navigation outside of project views",
-    );
-  }
-}
-
-export const push = (newRoute: Route): void => {
-  const history = get(historyStore);
-
-  // Limit history to a maximum of 10 steps. We shouldn't be doing more than
-  // one subsequent pop() anyway.
-  historyStore.set([...history, newRoute].slice(-10));
-
-  const path = import.meta.env.VITE_HASH_ROUTING
-    ? "#" + routeToPath(newRoute)
-    : routeToPath(newRoute);
-
-  window.history.pushState(newRoute, documentTitle, path);
-};
-
-export const pop = (): void => {
-  const history = get(historyStore);
-  const newRoute = history.pop();
-  if (newRoute) {
-    historyStore.set(history);
-    window.history.back();
-  }
-};
-
-export function replace(newRoute: Route): void {
-  historyStore.set([newRoute]);
-
-  const path = import.meta.env.VITE_HASH_ROUTING
-    ? "#" + routeToPath(newRoute)
-    : routeToPath(newRoute);
-
-  window.history.replaceState(newRoute, documentTitle, path);
-}
-
-export const initialize = () => {
+export async function loadFromLocation(): Promise<void> {
   const { pathname, search, hash } = window.location;
   const url = pathname + search + hash;
   const route = pathToRoute(url);
 
   if (route) {
-    replace(route);
+    await replace(route);
   } else {
-    replace({ resource: "404", params: { url } });
+    await replace({ resource: "notFound", params: { url } });
   }
-};
+}
+
+window.addEventListener("popstate", () => loadFromLocation());
+
+// Gets triggered when clicking on an anchor hash tag e.g. <a href="#header"/>
+// Allows the jump to a anchor hash.
+window.addEventListener("hashchange", async (event: HashChangeEvent) => {
+  const route = pathToRoute(event.newURL);
+  if (route?.resource === "projects" && route.params.hash) {
+    if (route.params.hash.match(/^L\d+$/)) {
+      await updateProjectRoute({ line: route.params.hash });
+    } else {
+      await updateProjectRoute({ hash: route.params.hash });
+    }
+  }
+});
+
+const loadExecutor = mutexExecutor.create();
+
+async function navigate(
+  action: "push" | "replace",
+  newRoute: Route,
+): Promise<void> {
+  isLoading.set(true);
+
+  const loadedRoute = await loadExecutor.run(async () => {
+    return loadRoute(newRoute);
+  });
+
+  // Only let the last request through.
+  if (loadedRoute === undefined) {
+    return;
+  }
+
+  activeRouteStore.set(loadedRoute);
+  isLoading.set(false);
+
+  const path = import.meta.env.VITE_HASH_ROUTING
+    ? "#" + routeToPath(newRoute)
+    : routeToPath(newRoute);
+
+  if (action === "push") {
+    window.history.pushState(newRoute, DOCUMENT_TITLE, path);
+  } else if (action === "replace") {
+    window.history.replaceState(newRoute, DOCUMENT_TITLE, path);
+  }
+}
+
+export async function push(newRoute: Route): Promise<void> {
+  await navigate("push", newRoute);
+}
+
+export async function replace(newRoute: Route): Promise<void> {
+  await navigate("replace", newRoute);
+}
 
 function pathToRoute(path: string): Route | null {
   // This matches e.g. an empty string
@@ -191,7 +142,10 @@ function pathToRoute(path: string): Route | null {
           }
           return null;
         }
-        return { resource: "seeds", params: { hostnamePort } };
+        return {
+          resource: "seeds",
+          params: { hostnamePort, projectPageIndex: 0 },
+        };
       }
       return null;
     }
@@ -225,6 +179,8 @@ export function routeToPath(route: Route) {
     return `/session?id=${route.params.id}&sig=${route.params.signature}&pk=${route.params.publicKey}`;
   } else if (route.resource === "seeds") {
     return `/seeds/${route.params.hostnamePort}`;
+  } else if (route.resource === "loadError") {
+    return "";
   } else if (route.resource === "projects") {
     const hostnamePortPrefix = `/seeds/${route.params.hostnamePort}`;
     const content = `/${route.params.view.resource}`;
@@ -288,123 +244,13 @@ export function routeToPath(route: Route) {
     } else {
       return `${hostnamePortPrefix}/${route.params.id}${peer}${content}`;
     }
-  } else if (route.resource === "404") {
+  } else if (route.resource === "booting") {
+    return "";
+  } else if (route.resource === "notFound") {
     return route.params.url;
   } else {
     unreachable(route);
   }
-}
-
-function resolveProjectRoute(
-  url: URL,
-  hostnamePort: string,
-  id: string,
-  segments: string[],
-): ProjectsParams | null {
-  let content = segments.shift();
-  let peer;
-  if (content === "remotes") {
-    peer = segments.shift();
-    content = segments.shift();
-  }
-
-  if (!content || content === "tree") {
-    const line = url.href.match(/#L\d+$/)?.pop();
-    const hash = url.href.match(/#{1}[^#.]+$/)?.pop();
-    return {
-      view: { resource: "tree" },
-      id,
-      hostnamePort,
-      peer,
-      path: undefined,
-      revision: undefined,
-      search: undefined,
-      line: line?.substring(1),
-      hash: hash?.substring(1),
-      route: segments.join("/"),
-    };
-  } else if (content === "history") {
-    return {
-      view: { resource: "history" },
-      id,
-      hostnamePort,
-      peer,
-      path: undefined,
-      revision: undefined,
-      search: undefined,
-      route: segments.join("/"),
-    };
-  } else if (content === "commits") {
-    return {
-      view: { resource: "commits" },
-      id,
-      hostnamePort,
-      peer,
-      path: undefined,
-      revision: undefined,
-      search: undefined,
-      route: segments.join("/"),
-    };
-  } else if (content === "issues") {
-    const issueOrAction = segments.shift();
-    if (issueOrAction === "new") {
-      return {
-        view: { resource: "issues", params: { view: { resource: "new" } } },
-        id,
-        hostnamePort,
-        peer,
-        search: sanitizeQueryString(url.search),
-        path: undefined,
-        revision: undefined,
-      };
-    } else if (issueOrAction) {
-      return {
-        view: { resource: "issue", params: { issue: issueOrAction } },
-        id,
-        hostnamePort,
-        peer,
-        path: undefined,
-        revision: undefined,
-        search: undefined,
-      };
-    } else {
-      return {
-        view: { resource: "issues" },
-        id,
-        hostnamePort,
-        peer,
-        search: sanitizeQueryString(url.search),
-        path: undefined,
-        revision: undefined,
-      };
-    }
-  } else if (content === "patches") {
-    const patch = segments.shift();
-    const revision = segments.shift();
-    if (patch) {
-      return {
-        view: { resource: "patch", params: { patch, revision } },
-        id,
-        hostnamePort,
-        peer,
-        path: undefined,
-        revision: undefined,
-        search: sanitizeQueryString(url.search),
-      };
-    } else {
-      return {
-        view: { resource: "patches" },
-        id,
-        hostnamePort,
-        peer,
-        search: sanitizeQueryString(url.search),
-        path: undefined,
-        revision: undefined,
-      };
-    }
-  }
-
-  return null;
 }
 
 export const testExports = { pathToRoute };

--- a/src/lib/router/definitions.ts
+++ b/src/lib/router/definitions.ts
@@ -1,41 +1,57 @@
-export type Route =
-  | ProjectRoute
-  | { resource: "home" }
-  | {
-      resource: "session";
-      params: { id: string; signature: string; publicKey: string };
-    }
-  | { resource: "404"; params: { url: string } }
-  | { resource: "seeds"; params: { hostnamePort: string } };
+import type { HomeRoute, HomeLoadedRoute } from "@app/views/home/router";
+import type { ProjectRoute } from "@app/views/projects/router";
+import type { SeedsLoadedRoute, SeedsRoute } from "@app/views/seeds/router";
 
-export interface ProjectsParams {
-  id: string;
-  view:
-    | { resource: "tree" }
-    | { resource: "commits" }
-    | { resource: "history" }
-    | { resource: "issue"; params: { issue: string } }
-    | {
-        resource: "issues";
-        params?: {
-          view: { resource: "new" };
-        };
-      }
-    | {
-        resource: "patches";
-        params?: {
-          view: { resource: "new" };
-        };
-      }
-    | { resource: "patch"; params: { patch: string; revision?: string } };
-  hostnamePort: string;
-  hash?: string;
-  line?: string;
-  path?: string;
-  peer?: string;
-  revision?: string;
-  route?: string;
-  search?: string;
+import { loadHomeRoute } from "@app/views/home/router";
+import { loadSeedRoute } from "@app/views/seeds/router";
+
+interface BootingRoute {
+  resource: "booting";
 }
 
-export type ProjectRoute = { resource: "projects"; params: ProjectsParams };
+interface NotFoundRoute {
+  resource: "notFound";
+  params: { url: string };
+}
+
+interface SessionRoute {
+  resource: "session";
+  params: { id: string; signature: string; publicKey: string };
+}
+
+export interface LoadError {
+  resource: "loadError";
+  params: {
+    title?: string;
+    errorMessage: string;
+    stackTrace: string;
+  };
+}
+
+export type Route =
+  | BootingRoute
+  | HomeRoute
+  | LoadError
+  | NotFoundRoute
+  | ProjectRoute
+  | SeedsRoute
+  | SessionRoute;
+
+export type LoadedRoute =
+  | BootingRoute
+  | HomeLoadedRoute
+  | LoadError
+  | NotFoundRoute
+  | ProjectRoute
+  | SeedsLoadedRoute
+  | SessionRoute;
+
+export async function loadRoute(route: Route): Promise<LoadedRoute> {
+  if (route.resource === "seeds") {
+    return await loadSeedRoute(route.params);
+  } else if (route.resource === "home") {
+    return await loadHomeRoute();
+  } else {
+    return route;
+  }
+}

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -5,7 +5,7 @@ import { HttpdClient } from "@httpd-client";
 import { config } from "@app/lib/config";
 import { isFulfilled } from "@app/lib/utils";
 
-export interface ProjectAndSeed {
+export interface ProjectBaseUrl {
   project: Project;
   baseUrl: BaseUrl;
 }
@@ -13,7 +13,7 @@ export interface ProjectAndSeed {
 type SearchResult =
   | { type: "nothing" }
   | { type: "error"; message: string }
-  | { type: "projects"; results: ProjectAndSeed[] };
+  | { type: "projects"; results: ProjectBaseUrl[] };
 
 export async function searchProjectsAndProfiles(
   query: string,
@@ -51,7 +51,7 @@ export async function searchProjectsAndProfiles(
 
 export async function getProjectsFromSeeds(
   params: { id: string; baseUrl: BaseUrl }[],
-): Promise<ProjectAndSeed[]> {
+): Promise<ProjectBaseUrl[]> {
   const projectPromises = params.map(async param => {
     const api = new HttpdClient(param.baseUrl);
     const project = await api.project.getById(param.id);

--- a/src/lib/sleep.ts
+++ b/src/lib/sleep.ts
@@ -1,0 +1,5 @@
+export function sleep(timeMs: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, timeMs);
+  });
+}

--- a/src/views/home/Index.svelte
+++ b/src/views/home/Index.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
-  import { config } from "@app/lib/config";
-  import { getProjectsFromSeeds } from "@app/lib/search";
-  import { loadProjectActivity } from "@app/lib/commit";
+  import type { ProjectBaseUrlActivity } from "./router";
+
   import { twemoji } from "@app/lib/utils";
 
   import Link from "@app/components/Link.svelte";
-  import Loading from "@app/components/Loading.svelte";
-  import ErrorMessage from "@app/components/ErrorMessage.svelte";
   import ProjectCard from "@app/components/ProjectCard.svelte";
+
+  export let projects: ProjectBaseUrlActivity[];
 </script>
 
 <style>
-  main {
+  .wrapper {
     padding: 3rem 3rem;
     width: 100%;
     max-width: 74rem;
@@ -41,9 +40,6 @@
     font-size: var(--font-size-medium);
     margin-bottom: 1rem;
   }
-  .loading {
-    padding-top: 2rem;
-  }
   @media (max-width: 720px) {
     .blurb {
       max-width: none;
@@ -59,7 +55,7 @@
   <title>Radicle &ndash; Home</title>
 </svelte:head>
 
-<main>
+<div class="wrapper">
   <div class="blurb">
     <p use:twemoji>
       Radicle 🌱 enables developers 🧙 to securely collaborate 🔐 on software
@@ -67,48 +63,36 @@
     </p>
   </div>
 
-  {#await getProjectsFromSeeds(config.projects.pinned)}
-    <div class="loading">
-      <Loading center />
+  {#if projects.length > 0}
+    <div class="heading">
+      Explore <span class="txt-bold">projects</span>
+      on the Radicle network.
     </div>
-  {:then results}
-    {#if results.length}
-      <div class="heading">
-        Explore <span class="txt-bold">projects</span>
-        on the Radicle network.
-      </div>
 
-      <div class="projects">
-        {#each results as result}
-          {#await loadProjectActivity(result.project.id, result.baseUrl) then activity}
-            <div class="project">
-              <Link
-                route={{
-                  resource: "projects",
-                  params: {
-                    view: { resource: "tree" },
-                    id: result.project.id,
-                    hostnamePort: result.baseUrl.hostname,
-                    peer: undefined,
-                    revision: undefined,
-                  },
-                }}>
-                <ProjectCard
-                  compact
-                  description={result.project.description}
-                  head={result.project.head}
-                  id={result.project.id}
-                  name={result.project.name}
-                  {activity} />
-              </Link>
-            </div>
-          {/await}
-        {/each}
-      </div>
-    {/if}
-  {:catch error}
-    <div class="padding">
-      <ErrorMessage message="Couldn't load projects." stackTrace={error} />
+    <div class="projects">
+      {#each projects as { project, baseUrl, activity }}
+        <div class="project">
+          <Link
+            route={{
+              resource: "projects",
+              params: {
+                view: { resource: "tree" },
+                id: project.id,
+                hostnamePort: baseUrl.hostname,
+                peer: undefined,
+                revision: undefined,
+              },
+            }}>
+            <ProjectCard
+              compact
+              description={project.description}
+              head={project.head}
+              id={project.id}
+              name={project.name}
+              {activity} />
+          </Link>
+        </div>
+      {/each}
     </div>
-  {/await}
-</main>
+  {/if}
+</div>

--- a/src/views/home/router.ts
+++ b/src/views/home/router.ts
@@ -1,0 +1,48 @@
+import type { LoadError } from "@app/lib/router/definitions";
+import type { ProjectBaseUrl } from "@app/lib/search";
+import type { WeeklyActivity } from "@app/lib/commit";
+
+import { config } from "@app/lib/config";
+import { getProjectsFromSeeds } from "@app/lib/search";
+import { loadProjectActivity } from "@app/lib/commit";
+
+export interface ProjectBaseUrlActivity extends ProjectBaseUrl {
+  activity: WeeklyActivity[];
+}
+
+export interface HomeRoute {
+  resource: "home";
+}
+
+export interface HomeLoadedRoute {
+  resource: "home";
+  params: { projects: ProjectBaseUrlActivity[] };
+}
+
+export async function loadHomeRoute(): Promise<HomeLoadedRoute | LoadError> {
+  try {
+    const projects = await getProjectsFromSeeds(config.projects.pinned);
+    const results = await Promise.all(
+      projects.map(async projectSeed => {
+        const activity = await loadProjectActivity(
+          projectSeed.project.id,
+          projectSeed.baseUrl,
+        );
+        return {
+          ...projectSeed,
+          activity,
+        };
+      }),
+    );
+
+    return { resource: "home", params: { projects: results } };
+  } catch (error: any) {
+    return {
+      resource: "loadError",
+      params: {
+        errorMessage: "Could not load pinned projects.",
+        stackTrace: error.stack,
+      },
+    };
+  }
+}

--- a/src/views/projects/Blob.svelte
+++ b/src/views/projects/Blob.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Blob } from "@httpd-client";
   import type { MaybeHighlighted } from "@app/lib/syntax";
-  import type { ProjectRoute } from "@app/lib/router/definitions";
+  import type { ProjectRoute } from "@app/views/projects/router";
 
   import { afterUpdate, beforeUpdate, onMount } from "svelte";
   import { toHtml } from "hast-util-to-html";
@@ -9,7 +9,7 @@
   import { highlight } from "@app/lib/syntax";
   import { isMarkdownPath, scrollIntoView, twemoji } from "@app/lib/utils";
   import { lineNumbersGutter } from "@app/lib/syntax";
-  import { updateProjectRoute } from "@app/lib/router";
+  import { updateProjectRoute } from "@app/views/projects/router";
 
   import Readme from "@app/views/projects/Readme.svelte";
   import SquareButton from "@app/components/SquareButton.svelte";

--- a/src/views/projects/Browser.svelte
+++ b/src/views/projects/Browser.svelte
@@ -8,7 +8,7 @@
 
 <script lang="ts">
   import type { BaseUrl, Blob, Project, Tree } from "@httpd-client";
-  import type { ProjectRoute } from "@app/lib/router/definitions";
+  import type { ProjectRoute } from "@app/views/projects/router";
 
   import { onMount } from "svelte";
 

--- a/src/views/projects/Header.svelte
+++ b/src/views/projects/Header.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { BaseUrl, Project, Remote, Tree } from "@httpd-client";
-  import type { ProjectRoute } from "@app/lib/router/definitions";
+  import type { ProjectRoute } from "@app/views/projects/router";
 
   import { closeFocused } from "@app/components/Floating.svelte";
   import { config } from "@app/lib/config";
@@ -71,6 +71,7 @@
           baseUrl.port === config.seeds.defaultHttpdPort
             ? baseUrl.hostname
             : `${baseUrl.hostname}:${baseUrl.port}`,
+        projectPageIndex: 0,
       },
     }}>
     <SquareButton>

--- a/src/views/projects/Patch.svelte
+++ b/src/views/projects/Patch.svelte
@@ -42,10 +42,10 @@
   import type { Variant } from "@app/components/Badge.svelte";
 
   import * as utils from "@app/lib/utils";
-  import * as router from "@app/lib/router";
   import { capitalize } from "lodash";
   import { HttpdClient } from "@httpd-client";
   import { sessionStore } from "@app/lib/session";
+  import { updateProjectRoute } from "@app/views/projects/router";
 
   import Authorship from "@app/components/Authorship.svelte";
   import Badge from "@app/components/Badge.svelte";
@@ -308,7 +308,7 @@
               })}
               selected={currentRevision.id}
               on:select={({ detail: item }) => {
-                router.updateProjectRoute({
+                updateProjectRoute({
                   view: {
                     resource: "patch",
                     params: { patch: patch.id, revision: item.value },

--- a/src/views/projects/Readme.svelte
+++ b/src/views/projects/Readme.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { ProjectRoute } from "@app/lib/router/definitions";
+  import type { ProjectRoute } from "@app/views/projects/router";
 
   import Markdown from "@app/components/Markdown.svelte";
 

--- a/src/views/projects/View.svelte
+++ b/src/views/projects/View.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { IssueStatus } from "./Issues.svelte";
   import type { PatchStatus } from "./Patches.svelte";
-  import type { ProjectRoute } from "@app/lib/router/definitions";
+  import type { ProjectRoute } from "@app/views/projects/router";
   import type { Tree } from "@httpd-client";
 
   import * as router from "@app/lib/router";
@@ -9,6 +9,7 @@
   import { HttpdClient } from "@httpd-client";
   import { formatNodeId, unreachable } from "@app/lib/utils";
   import { sessionStore } from "@app/lib/session";
+  import { updateProjectRoute } from "@app/views/projects/router";
 
   import Loading from "@app/components/Loading.svelte";
   import ErrorMessage from "@app/components/ErrorMessage.svelte";
@@ -84,7 +85,7 @@
 
     if (activeRoute.params.route) {
       const { revision, path } = parseRoute(activeRoute.params.route, branches);
-      router.updateProjectRoute(
+      updateProjectRoute(
         {
           revision,
           path,
@@ -298,6 +299,6 @@
   </main>
 {:catch}
   <div class="layout-centered">
-    <NotFound subtitle={id} title="This project was not found" />
+    <NotFound subtitle={id} title="Project not found" />
   </div>
 {/await}

--- a/src/views/projects/router.ts
+++ b/src/views/projects/router.ts
@@ -1,0 +1,203 @@
+import { get } from "svelte/store";
+
+import { activeRouteStore, push, replace, routeToPath } from "@app/lib/router";
+
+export interface ProjectRoute {
+  resource: "projects";
+  params: ProjectsParams;
+}
+
+export interface ProjectsParams {
+  id: string;
+  hash?: string;
+  hostnamePort: string;
+  line?: string;
+  path?: string;
+  peer?: string;
+  revision?: string;
+  route?: string;
+  search?: string;
+  view:
+    | { resource: "tree" }
+    | { resource: "commits" }
+    | { resource: "history" }
+    | { resource: "issue"; params: { issue: string } }
+    | {
+        resource: "issues";
+        params?: {
+          view: { resource: "new" };
+        };
+      }
+    | {
+        resource: "patches";
+        params?: {
+          view: { resource: "new" };
+        };
+      }
+    | { resource: "patch"; params: { patch: string; revision?: string } };
+}
+
+function sanitizeQueryString(queryString: string): string {
+  return queryString.startsWith("?") ? queryString.substring(1) : queryString;
+}
+
+export function createProjectRoute(
+  activeRoute: ProjectRoute,
+  projectRouteParams: Partial<ProjectsParams>,
+): ProjectRoute {
+  return {
+    resource: "projects",
+    params: {
+      ...activeRoute.params,
+      line: undefined,
+      hash: undefined,
+      ...projectRouteParams,
+    },
+  };
+}
+
+export function projectLinkHref(
+  projectRouteParams: Partial<ProjectsParams>,
+): string | undefined {
+  const activeRoute = get(activeRouteStore);
+
+  if (activeRoute.resource === "projects") {
+    return routeToPath(createProjectRoute(activeRoute, projectRouteParams));
+  } else {
+    throw new Error(
+      "Don't use project specific navigation outside of project views",
+    );
+  }
+}
+
+export async function updateProjectRoute(
+  projectRouteParams: Partial<ProjectsParams>,
+  opts: { replace: boolean } = { replace: false },
+): Promise<void> {
+  const activeRoute = get(activeRouteStore);
+
+  if (activeRoute.resource === "projects") {
+    const updatedRoute = createProjectRoute(activeRoute, projectRouteParams);
+    if (opts.replace) {
+      await replace(updatedRoute);
+    } else {
+      await push(updatedRoute);
+    }
+  } else {
+    throw new Error(
+      "Don't use project specific navigation outside of project views",
+    );
+  }
+}
+
+export function resolveProjectRoute(
+  url: URL,
+  hostnamePort: string,
+  id: string,
+  segments: string[],
+): ProjectsParams | null {
+  let content = segments.shift();
+  let peer;
+  if (content === "remotes") {
+    peer = segments.shift();
+    content = segments.shift();
+  }
+
+  if (!content || content === "tree") {
+    const line = url.href.match(/#L\d+$/)?.pop();
+    const hash = url.href.match(/#{1}[^#.]+$/)?.pop();
+    return {
+      view: { resource: "tree" },
+      id,
+      hostnamePort,
+      peer,
+      path: undefined,
+      revision: undefined,
+      search: undefined,
+      line: line?.substring(1),
+      hash: hash?.substring(1),
+      route: segments.join("/"),
+    };
+  } else if (content === "history") {
+    return {
+      view: { resource: "history" },
+      id,
+      hostnamePort,
+      peer,
+      path: undefined,
+      revision: undefined,
+      search: undefined,
+      route: segments.join("/"),
+    };
+  } else if (content === "commits") {
+    return {
+      view: { resource: "commits" },
+      id,
+      hostnamePort,
+      peer,
+      path: undefined,
+      revision: undefined,
+      search: undefined,
+      route: segments.join("/"),
+    };
+  } else if (content === "issues") {
+    const issueOrAction = segments.shift();
+    if (issueOrAction === "new") {
+      return {
+        view: { resource: "issues", params: { view: { resource: "new" } } },
+        id,
+        hostnamePort,
+        peer,
+        search: sanitizeQueryString(url.search),
+        path: undefined,
+        revision: undefined,
+      };
+    } else if (issueOrAction) {
+      return {
+        view: { resource: "issue", params: { issue: issueOrAction } },
+        id,
+        hostnamePort,
+        peer,
+        path: undefined,
+        revision: undefined,
+        search: undefined,
+      };
+    } else {
+      return {
+        view: { resource: "issues" },
+        id,
+        hostnamePort,
+        peer,
+        search: sanitizeQueryString(url.search),
+        path: undefined,
+        revision: undefined,
+      };
+    }
+  } else if (content === "patches") {
+    const patch = segments.shift();
+    const revision = segments.shift();
+    if (patch) {
+      return {
+        view: { resource: "patch", params: { patch, revision } },
+        id,
+        hostnamePort,
+        peer,
+        path: undefined,
+        revision: undefined,
+        search: sanitizeQueryString(url.search),
+      };
+    } else {
+      return {
+        view: { resource: "patches" },
+        id,
+        hostnamePort,
+        peer,
+        search: sanitizeQueryString(url.search),
+        path: undefined,
+        revision: undefined,
+      };
+    }
+  }
+
+  return null;
+}

--- a/src/views/seeds/router.ts
+++ b/src/views/seeds/router.ts
@@ -1,0 +1,100 @@
+import type { BaseUrl, Project } from "@httpd-client";
+import type { LoadError } from "@app/lib/router/definitions";
+import type { WeeklyActivity } from "@app/lib/commit";
+
+import { HttpdClient } from "@httpd-client";
+import { extractBaseUrl } from "@app/lib/utils";
+import { loadProjectActivity } from "@app/lib/commit";
+
+interface SeedsRouteParams {
+  hostnamePort: string;
+  projectPageIndex: number;
+}
+
+export interface ProjectActivity {
+  project: Project;
+  activity: WeeklyActivity[];
+}
+
+export interface SeedsRoute {
+  resource: "seeds";
+  params: SeedsRouteParams;
+}
+
+export interface SeedsLoadedRoute {
+  resource: "seeds";
+  params: {
+    baseUrl: BaseUrl;
+    projectPageIndex: number;
+    version: string;
+    nid: string;
+    projects: ProjectActivity[];
+    projectCount: number;
+  };
+}
+
+const PROJECTS_PER_PAGE = 10;
+
+export async function loadProjects(
+  page: number,
+  baseUrl: BaseUrl,
+): Promise<{
+  total: number;
+  projects: ProjectActivity[];
+}> {
+  const api = new HttpdClient(baseUrl);
+
+  const [nodeStats, projects] = await Promise.all([
+    api.getStats(),
+    api.project.getAll({ page, perPage: PROJECTS_PER_PAGE }),
+  ]);
+
+  const results = await Promise.all(
+    projects.map(async project => {
+      const activity = await loadProjectActivity(project.id, baseUrl);
+      return {
+        project,
+        activity,
+      };
+    }),
+  );
+
+  return {
+    total: nodeStats.projects.count,
+    projects: results,
+  };
+}
+
+export async function loadSeedRoute(
+  params: SeedsRouteParams,
+): Promise<SeedsLoadedRoute | LoadError> {
+  const baseUrl = extractBaseUrl(params.hostnamePort);
+  const api = new HttpdClient(baseUrl);
+  try {
+    const projectPageIndex = 0;
+    const [nodeInfo, { projects, total }] = await Promise.all([
+      api.getNodeInfo(),
+      loadProjects(projectPageIndex, baseUrl),
+    ]);
+    return {
+      resource: "seeds",
+      params: {
+        projectPageIndex: projectPageIndex + 1,
+        baseUrl,
+        nid: nodeInfo.node.id,
+        version: nodeInfo.version,
+        projects: projects,
+        projectCount: total,
+      },
+    };
+  } catch (error: any) {
+    return {
+      resource: "loadError",
+      params: {
+        title: params.hostnamePort,
+        errorMessage: "Not able to query this seed.",
+        stackTrace: error.stack,
+      },
+    };
+  }
+}

--- a/src/views/session/Index.svelte
+++ b/src/views/session/Index.svelte
@@ -20,7 +20,7 @@
       modal.show({ component: AuthenticatedModal, props: {} });
       router.push({
         resource: "seeds",
-        params: { hostnamePort: "radicle.local" },
+        params: { hostnamePort: "radicle.local", projectPageIndex: 0 },
       });
     } else {
       modal.show({

--- a/tests/support/router.ts
+++ b/tests/support/router.ts
@@ -14,8 +14,16 @@ export const expectBackAndForwardNavigationWorks = async (
   page: Page,
 ) => {
   const currentURL = page.url();
+
   await page.goBack();
+  await page
+    .locator("role=progressbar[name='Page loading']")
+    .waitFor({ state: "hidden" });
   await expect(page).toHaveURL(beforeURL);
   await page.goForward();
+
+  await page
+    .locator("role=progressbar[name='Page loading']")
+    .waitFor({ state: "hidden" });
   await expect(page).toHaveURL(currentURL);
 };

--- a/tests/unit/mutexExecutor.test.ts
+++ b/tests/unit/mutexExecutor.test.ts
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import * as sinon from "sinon";
+import { describe, expect, test } from "vitest";
+
+import * as mutexExecutor from "@app/lib/mutexExecutor";
+import { sleep } from "@app/lib/sleep";
+
+describe("executor", () => {
+  test("cancels running task", async () => {
+    const e = mutexExecutor.create();
+
+    const first = e.run(async () => {
+      await sleep(10);
+      return "first";
+    });
+    const second = e.run(async () => {
+      return "second";
+    });
+
+    expect(await first).toBe(undefined);
+    expect(await second).toBe("second");
+
+    const third = e.run(async () => {
+      await sleep(10);
+      return "third";
+    });
+    const fourth = e.run(async () => {
+      return "fourth";
+    });
+
+    expect(await third).toBe(undefined);
+    expect(await fourth).toBe("fourth");
+  });
+
+  test("cancels multiple tasks", async () => {
+    const e = mutexExecutor.create();
+
+    const canceled1 = e.run(async () => {
+      await sleep(10);
+      return true;
+    });
+    const canceled2 = e.run(async () => {
+      await sleep(10);
+      return true;
+    });
+    const canceled3 = e.run(async () => {
+      await sleep(10);
+      return true;
+    });
+    const last = e.run(async () => {
+      return true;
+    });
+
+    expect(await canceled1).toBe(undefined);
+    expect(await canceled2).toBe(undefined);
+    expect(await canceled3).toBe(undefined);
+    expect(await last).toBe(true);
+  });
+
+  test("triggers abort signal event", async () => {
+    const e = mutexExecutor.create();
+    const abortListener = sinon.spy();
+
+    e.run(async abort => {
+      abort.addEventListener("abort", abortListener);
+      await sleep(10);
+      return "first";
+    });
+    expect(abortListener.called).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    e.run(async () => {});
+    expect(abortListener.called).toBe(true);
+  });
+
+  test("don’t throw error on aborted task", async () => {
+    const e = mutexExecutor.create();
+
+    const first = e.run(async () => {
+      await sleep(10);
+      throw new Error();
+    });
+    const second = e.run(async () => {
+      return "second";
+    });
+
+    expect(await first).toBe(undefined);
+    expect(await second).toBe("second");
+  });
+});
+
+describe("worker", () => {
+  test("sequential work", async () => {
+    const w = mutexExecutor.createWorker(async (value: number) => {
+      await sleep(10);
+      return value;
+    });
+
+    const outputs: number[] = [];
+    w.output.onValue(value => outputs.push(value));
+
+    await w.submit(1);
+    await w.submit(2);
+    await w.submit(3);
+
+    expect(outputs).toEqual([1, 2, 3]);
+  });
+
+  test("overlapping work cancels", async () => {
+    const w = mutexExecutor.createWorker(async (value: number) => {
+      await sleep(10);
+      return value;
+    });
+
+    const nextOutput = w.output.firstToPromise();
+
+    w.submit(1);
+    w.submit(2);
+    w.submit(3);
+
+    expect(await nextOutput).toEqual(3);
+  });
+});

--- a/tests/unit/router.test.ts
+++ b/tests/unit/router.test.ts
@@ -35,18 +35,18 @@ describe("routeToPath", () => {
 
 describe("pathToRoute", () => {
   test.each([
-    { input: "", output: null, description: "Empty 404 Route" },
+    { input: "", output: null, description: "Empty not found Route" },
     {
       input: "/foo/baz/bar",
       output: null,
-      description: "Non existant 404 Route",
+      description: "Non existant not found route",
     },
     { input: "/", output: { resource: "home" }, description: "Home Route" },
     {
       input: "/seeds/willow.radicle.garden",
       output: {
         resource: "seeds",
-        params: { hostnamePort: "willow.radicle.garden" },
+        params: { hostnamePort: "willow.radicle.garden", projectPageIndex: 0 },
       },
       description: "Seed View Route",
     },


### PR DESCRIPTION
Implements data pre-loading in the router. This PR only converts the `Home` and `Seed` views to the new architecture. The `Project` view will be converted in a follow-up, since it's a bigger chunk of work.

There are three types of loading behaviour now:
  - when navigating within the app we show a loading bar at the top
  - when the app is hard-refreshed or when the user lands in the app by clicking an URL there is a "three dot" loader in the center of the whole page
  - when views fetch additional data after the initial loading we show a small "three dot" loader

https://user-images.githubusercontent.com/158411/236129134-3e7e6f88-d3dc-4102-bf81-5db057e01283.mov


Refs: https://github.com/radicle-dev/radicle-interface/issues/668.