### PR TITLE
Add `noUnusedLocals` and `noUnusedParameters` to `tsconfig`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,8 @@
     "moduleResolution": "node",
     "strict": true,
     "resolveJsonModule": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "useDefineForClassFields": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
This PR fixes #732, with adding the `noUnusedLocals` and `noUnusedParameters` option to `tsconfig`

It seems that once we added the `--tsconfig` param to `svelte-check` in f215f9f4fd54587fa0e5ba21f1289314e6e2a954 we overrode some defaults which included the checking for unused local variables.

So I added some checks to tsconfig