### PR TITLE
Update marked to v5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "hast-util-to-html": "^8.0.4",
         "katex": "^0.16.7",
         "lodash": "^4.17.21",
-        "marked": "^4.3.0",
+        "marked": "^5.0.1",
         "md5": "^2.3.0",
         "plausible-tracker": "^0.3.8",
         "svelte": "^3.58.0",
@@ -2607,14 +2607,14 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.0.1.tgz",
+      "integrity": "sha512-Nn9peC4lvIZdcfp8Uze6xk4ZYowkcj/K6+e/6rLHadhtjqeip/bYRxMgt3124IGGJ3RPs2uX5YVmAGbUutY18g==",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 18"
       }
     },
     "node_modules/md5": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "hast-util-to-html": "^8.0.4",
     "katex": "^0.16.7",
     "lodash": "^4.17.21",
-    "marked": "^4.3.0",
+    "marked": "^5.0.1",
     "md5": "^2.3.0",
     "plausible-tracker": "^0.3.8",
     "svelte": "^3.58.0",

--- a/src/components/InlineMarkdown.svelte
+++ b/src/components/InlineMarkdown.svelte
@@ -8,7 +8,12 @@
   export let content: string;
   export let fontSize: "small" | "medium" = "small";
 
-  marked.use({ renderer });
+  marked.use({
+    renderer,
+    // TODO: Disables deprecated options, remove once removed from marked
+    mangle: false,
+    headerIds: false,
+  });
 
   const render = (content: string): string =>
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -23,7 +23,13 @@
   $: frontMatter = Object.entries(doc.data).filter(
     ([, val]) => typeof val === "string" || typeof val === "number",
   );
-  marked.use({ extensions, renderer });
+  marked.use({
+    extensions,
+    renderer,
+    // TODO: Disables deprecated options, remove once removed from marked
+    mangle: false,
+    headerIds: false,
+  });
 
   let container: HTMLElement;
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -3,6 +3,9 @@ import katex from "katex";
 import { marked } from "marked";
 import { isUrl } from "./utils";
 
+// TODO: Disables deprecated options, remove once removed from marked
+marked.use({ mangle: false, headerIds: false });
+
 const emojisMarkedExtension = {
   name: "emoji",
   level: "inline",


### PR DESCRIPTION
Disables some of the deprecated options to avoid the console warnings.
Removes obfuscation of plain-text emails.

Closes #731