### PR TITLE
Add hr before first footnote in footer

### DIFF
--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -85,7 +85,9 @@ const footnoteMarkedExtension = {
     }
   },
   renderer: (token: marked.Tokens.Generic) => {
-    return `<p class="txt-small" id="${footnotePrefix}:${token.reference}">${
+    return `${
+      token.reference === "0" ? "<hr />" : ""
+    }<p class="txt-small" id="${footnotePrefix}:${token.reference}">${
       token.reference
     }. ${marked.parseInline(
       token.text,
@@ -116,11 +118,11 @@ const anchorMarkedExtension = {
   },
 };
 
-// Overwrites the rendering of heading tokens.
-// Since there are possible non ASCII characters in headings,
-// we escape them by replacing them with dashes and,
-// trim eventual dashes on each side of the string.
 export const renderer = {
+  // Overwrites the rendering of heading tokens.
+  // Since there are possible non ASCII characters in headings,
+  // we escape them by replacing them with dashes and,
+  // trim eventual dashes on each side of the string.
   heading(text: string, level: 1 | 2 | 3 | 4 | 5 | 6) {
     const escapedText = text
       .toLowerCase()


### PR DESCRIPTION
This PR closes #734 

This PR adds a `<hr>` element before the first footnote in the footer if there is one.
And the styling of a `<hr>` element has currently a margin of 1rem on each side.

<img width="979" alt="Bildschirmfoto 2023-05-08 um 10 12 05" src="https://user-images.githubusercontent.com/7912302/236771722-f63d1cae-d054-40ee-a972-f0fe6b1956ae.png">
