### PR TITLE
Fix padding and linebreaks in markdown

### DIFF
--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -187,7 +187,7 @@
     margin-bottom: 0.625rem;
   }
 
-  .markdown :global(p:last-child) {
+  .markdown :global(p:only-child) {
     margin-bottom: 0;
   }
 
@@ -282,7 +282,7 @@
     margin: 1rem 0;
   }
   /* Allows the parent to specify its own bottom margin */
-  .markdown :global(:last-child) {
+  .markdown :global(> :last-child) {
     margin-bottom: 0;
   }
   .markdown :global(li > ul) {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -132,17 +132,6 @@ export const renderer = {
 
     return `<h${level} id="${escapedText}">${text}</h${level}>`;
   },
-  listitem(text: string) {
-    const hasLineBreaks = text.trim().indexOf("\n");
-    if (hasLineBreaks === -1) {
-      return `<li>${text}</li>`;
-    }
-    const [first, ...remaining] = text.trim().split("\n");
-    const liContent = `${first}<div class="list-content">${remaining.join(
-      "\n",
-    )}</div>`;
-    return `<li>${liContent}</li>`;
-  },
   link(href: string, _title: string, text: string) {
     // Adding the file-link class to relative file names,
     // so we're able to navigate to the file in the editor.


### PR DESCRIPTION
Ok it seems I introduced a regression with #643 that now impacts in list items with soft line breaks.
So I changed the implementation removing that renderer and keep the padding as it was and just removing margin when there is only a paragraph without other elements.

![image](https://user-images.githubusercontent.com/7912302/237036542-47b82d5a-9b82-44b9-b716-62100a3f9a84.png)
![image](https://user-images.githubusercontent.com/7912302/237036209-aa542a83-9bde-44f6-9761-6b7db024ae72.png)
