### PR TITLE
Make commit list and commit view visually consistent

### DIFF
--- a/src/views/projects/Commit.svelte
+++ b/src/views/projects/Commit.svelte
@@ -19,9 +19,9 @@
   }
   .header {
     padding: 1rem;
-    background: var(--color-background-1);
-    border-radius: var(--border-radius);
     margin-bottom: 1.5rem;
+    border-radius: var(--border-radius);
+    border: 1px solid var(--color-foreground-3);
   }
   .summary {
     display: flex;

--- a/src/views/projects/Commit/CommitTeaser.svelte
+++ b/src/views/projects/Commit/CommitTeaser.svelte
@@ -13,7 +13,7 @@
 
 <style>
   .teaser {
-    background-color: var(--color-background-1);
+    background-color: var(--color-foreground-1);
     padding: 0.75rem 0rem;
     display: flex;
     align-items: center;

--- a/src/views/projects/SourceBrowser/FileDiff.svelte
+++ b/src/views/projects/SourceBrowser/FileDiff.svelte
@@ -76,7 +76,7 @@
   main {
     font-size: var(--font-size-small);
     border-top: 1px dashed var(--color-foreground-4);
-    background: var(--color-background-1);
+    background-color: var(--color-foreground-1);
     border-radius: 0 0 var(--border-radius-small) var(--border-radius-small);
     overflow-x: auto;
   }
@@ -90,7 +90,6 @@
     padding: 1rem;
     color: var(--color-foreground-5);
     text-align: center;
-    background-color: var(--color-foreground-2);
   }
   .browse {
     margin-left: auto;


### PR DESCRIPTION
We style the commit teaser and commit header visually to fit in better with patches and issues. This means:
  - commit header gets a border instead of a background color
  - commit list teaser gets a background color in light mode
  - file diff also gets a background color in light mode

Closes https://github.com/radicle-dev/radicle-interface/issues/721.

<img width="1840" alt="Screenshot 2023-05-12 at 06 39 06" src="https://github.com/radicle-dev/radicle-interface/assets/158411/e0dfdfab-8b46-4ce1-9da3-902a0adbf618">
<img width="1840" alt="Screenshot 2023-05-12 at 06 39 09" src="https://github.com/radicle-dev/radicle-interface/assets/158411/2533268a-46a3-4695-a661-723fc9a44b55">
<img width="1840" alt="Screenshot 2023-05-12 at 06 39 20" src="https://github.com/radicle-dev/radicle-interface/assets/158411/a0c19949-55e0-42e6-bbcb-c9c77c10ac22">
<img width="1840" alt="Screenshot 2023-05-12 at 06 39 31" src="https://github.com/radicle-dev/radicle-interface/assets/158411/431b85a9-e6cb-4d1e-b320-1df542176461">
<img width="1840" alt="Screenshot 2023-05-12 at 06 39 43" src="https://github.com/radicle-dev/radicle-interface/assets/158411/4c688b45-79f8-4f06-bdbf-9153ea85d993">
<img width="1840" alt="Screenshot 2023-05-12 at 06 39 47" src="https://github.com/radicle-dev/radicle-interface/assets/158411/56128778-5523-49e0-b04e-7fe447fd71ba">
<img width="1840" alt="Screenshot 2023-05-12 at 06 39 56" src="https://github.com/radicle-dev/radicle-interface/assets/158411/f1ff9dc1-ad70-4602-b665-ef436ad5c261">
<img width="1840" alt="Screenshot 2023-05-12 at 06 39 58" src="https://github.com/radicle-dev/radicle-interface/assets/158411/788ab320-854f-4ee4-bcf1-e36ec8657126">
