### PR TITLE
Adjust action wording to show only latest action in patch list

### DIFF
--- a/src/views/projects/Patch/PatchTeaser.svelte
+++ b/src/views/projects/Patch/PatchTeaser.svelte
@@ -147,9 +147,9 @@
     </div>
     <div class="summary">
       <span class="meta id">
-        {formatObjectId(patch.id)} opened {formatTimestamp(
-          latestRevision.timestamp,
-        )} by
+        {formatObjectId(patch.id)}
+        {patch.revisions.length > 1 ? "updated" : "opened"}
+        {formatTimestamp(latestRevision.timestamp)} by
         <Authorship authorId={patch.author.id} />
       </span>
     </div>


### PR DESCRIPTION
It will show either "Opened x days ago" or "Updated x days ago" depending whether there is one or multiple revisions.

Closes https://github.com/radicle-dev/radicle-interface/issues/752.

<img width="1840" alt="Screenshot 2023-05-12 at 06 52 55" src="https://github.com/radicle-dev/radicle-interface/assets/158411/f77f9a9d-0882-49df-b218-0f12f34aa9cb">
