### PR TITLE
Show comments that are thread replies to the issue body

### DIFF
--- a/src/views/projects/Issue.svelte
+++ b/src/views/projects/Issue.svelte
@@ -146,10 +146,15 @@
     }
   }
 
+  const issueDescription = issue.discussion[0];
+
   $: selectedItem = issue.state.status === "closed" ? items[0] : items[1];
   $: threads = issue.discussion
-    .slice(1) // Skip the first comment, which is the issue description
-    .filter(comment => !comment.replyTo)
+    .filter(
+      comment =>
+        (comment.id !== issueDescription.id && !comment.replyTo) ||
+        comment.replyTo === issueDescription.id,
+    )
     .map(thread => {
       return {
         root: thread,


### PR DESCRIPTION
Previously treated the issue body as a comment and people could post a thread reply to that first comment. Now we treat the first comment as the issue body and disallow replying to it via a thread. There are still some old replies, we show them as regular comments.

Closes https://github.com/radicle-dev/radicle-interface/issues/749.

http://localhost:3000/seeds/seed.radicle.xyz/rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5/issues/923cce20c2a7e6629f5c3ace6127d8a77578901d

<img width="1840" alt="Screenshot 2023-05-12 at 07 44 15" src="https://github.com/radicle-dev/radicle-interface/assets/158411/93bdae1f-2d85-413f-be7e-547e3e4de2cd">

