### PR TITLE
Make sure filter tabs are displayed properly on mobile

### DIFF
--- a/src/components/SquareButton.svelte
+++ b/src/components/SquareButton.svelte
@@ -18,6 +18,7 @@
     color: var(--color-foreground);
     font-family: var(--font-family-monospace);
     font-size: var(--font-size-tiny);
+    white-space: nowrap;
   }
 
   .small {

--- a/src/views/projects/Patches.svelte
+++ b/src/views/projects/Patches.svelte
@@ -107,7 +107,7 @@
 
 <div class="patches">
   <div style="margin-bottom: 1rem;">
-    <div style="display: flex; gap: 0.5rem;">
+    <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
       {#each options as option}
         {#if option.disabled}
           <SquareButton


### PR DESCRIPTION
We make sure that the space between the counter and wording doesn't wrap and then wrap the tabs themselves if they take more space than the viewport.

Closes: https://github.com/radicle-dev/radicle-interface/issues/665, https://github.com/radicle-dev/radicle-interface/issues/720

<img width="412" alt="Screenshot 2023-05-15 at 11 28 51" src="https://github.com/radicle-dev/radicle-interface/assets/158411/7888409c-4857-4b59-8d72-c781055a84c0">
