### PR TITLE
Don't select the + and - signs when selecting a diff

### DIFF
--- a/src/views/projects/SourceBrowser/FileDiff.svelte
+++ b/src/views/projects/SourceBrowser/FileDiff.svelte
@@ -139,6 +139,7 @@
     text-align: center;
     padding-left: 0.75rem;
     padding-right: 0.75rem;
+    user-select: none;
   }
   .diff-expand-header {
     padding-left: 0.5rem;


### PR DESCRIPTION
Before:
![broken](https://github.com/radicle-dev/radicle-interface/assets/158411/871e25b1-4e0e-45c2-80ea-b4340cab9361)

After:
<img width="978" alt="Screenshot 2023-05-15 at 14 01 57" src="https://github.com/radicle-dev/radicle-interface/assets/158411/15173f69-4cda-4c90-ba8f-275a4631d9df">

Github for reference:
![gh](https://github.com/radicle-dev/radicle-interface/assets/158411/09d69117-12d4-476a-898d-d2cdb9fc8b57)
