### PR TITLE
Navigate to raw file

### DIFF
--- a/src/views/projects/Blob.svelte
+++ b/src/views/projects/Blob.svelte
@@ -118,7 +118,7 @@
     margin-right: 0.25rem;
   }
 
-  .markdown-toggle {
+  .toggle {
     margin-right: 0.5rem;
   }
 
@@ -228,15 +228,15 @@
       </span>
       <div class="right">
         {#if isMarkdown}
-          <div class="markdown-toggle">
-            <SquareButton
-              active={!showMarkdown}
-              clickable
-              on:click={toggleMarkdown}>
-              Raw
+          <div class="toggle">
+            <SquareButton clickable on:click={toggleMarkdown}>
+              {showMarkdown ? "Plain" : "Markdown"}
             </SquareButton>
           </div>
         {/if}
+        <a href="{rawPath}/{blob.path}" class="toggle">
+          <SquareButton clickable>Raw</SquareButton>
+        </a>
         <div class="last-commit" title={lastCommit.author.name} use:twemoji>
           <span class="hash">
             {lastCommit.id.slice(0, 7)}

--- a/tests/e2e/project.spec.ts
+++ b/tests/e2e/project.spec.ts
@@ -96,7 +96,7 @@ test("source file highlighting", async ({ page }) => {
 
 test("navigate line numbers", async ({ page }) => {
   await page.goto(`${projectFixtureUrl}/tree/main/markdown/cheatsheet.md`);
-  await page.locator(".markdown-toggle").click();
+  await page.locator('text="Plain"').click();
 
   await page.locator('[href="#L5"]').click();
   await expect(page.locator("#L5")).toHaveClass("line highlight");
@@ -231,14 +231,12 @@ test("markdown files", async ({ page }) => {
 
   // Switch between raw and rendered modes.
   {
-    const rawButton = page.locator(".markdown-toggle .square-button");
-
-    await rawButton.click();
-    await expect(rawButton).toHaveClass(/active/);
+    const plainButton = page.locator('text="Plain"');
+    await plainButton.click();
     await expect(page.locator("text=##### Table of Contents")).toBeVisible();
 
-    await rawButton.click();
-    await expect(rawButton).not.toHaveClass("active");
+    const markdownButton = page.locator('text="Markdown"');
+    await markdownButton.click();
   }
 
   // Internal links go to anchor.


### PR DESCRIPTION
Changes the functionality of the `Raw` button to navigate to the file.
Adding a button that toggles between the markdown and plain text and shows this by either displaying `Markdown` or `Plain`

<img width="1060" alt="Bildschirmfoto 2023-05-17 um 11 28 44" src="https://github.com/radicle-dev/radicle-interface/assets/7912302/65a05a8a-8d1d-43fc-a2a9-ddebdaf22d20">
<img width="1083" alt="Bildschirmfoto 2023-05-17 um 11 28 37" src="https://github.com/radicle-dev/radicle-interface/assets/7912302/595cd1ea-ca79-411f-bfec-dffa60affdae">

Closes #714 