### PR TITLE
Add `alias` to `Patch`

### DIFF
--- a/httpd-client/lib/project/patch.ts
+++ b/httpd-client/lib/project/patch.ts
@@ -128,7 +128,6 @@ export interface Patch {
   id: string;
   author: { id: string; alias?: string };
   title: string;
-  description: string;
   state: PatchState;
   target: string;
   tags: string[];
@@ -141,7 +140,6 @@ export const patchSchema = strictObject({
   id: string(),
   author: strictObject({ id: string(), alias: string().optional() }),
   title: string(),
-  description: string(),
   state: patchStateSchema,
   target: string(),
   tags: array(string()),

--- a/httpd-client/lib/project/patch.ts
+++ b/httpd-client/lib/project/patch.ts
@@ -102,6 +102,7 @@ const reviewSchema = strictObject({
 
 export interface Revision {
   id: string;
+  author: { id: string; alias?: string };
   description: string;
   base: string;
   oid: string;
@@ -113,6 +114,7 @@ export interface Revision {
 
 const revisionSchema = strictObject({
   id: string(),
+  author: strictObject({ id: string(), alias: string().optional() }),
   description: string(),
   base: string(),
   oid: string(),

--- a/httpd-client/lib/project/patch.ts
+++ b/httpd-client/lib/project/patch.ts
@@ -131,6 +131,7 @@ export interface Patch {
   target: string;
   tags: string[];
   merges: Merge[];
+  reviewers: string[];
   revisions: Revision[];
 }
 
@@ -143,6 +144,7 @@ export const patchSchema = strictObject({
   target: string(),
   tags: array(string()),
   merges: array(mergeSchema),
+  reviewers: array(string()),
   revisions: array(revisionSchema),
 }) satisfies ZodSchema<Patch>;
 

--- a/src/components/Authorship.svelte
+++ b/src/components/Authorship.svelte
@@ -4,6 +4,12 @@
 
   export let authorId: string;
   export let authorAlias: string | undefined = undefined;
+  export let authorAliasColor:
+    | "--color-primary-5"
+    | "--color-foreground-5"
+    | "--color-positive-5"
+    | "--color-negative-5"
+    | undefined = "--color-foreground-5";
   export let caption: string | undefined = undefined;
   export let noAvatar: boolean = false;
   export let timestamp: number | undefined = undefined;
@@ -28,9 +34,6 @@
   .body {
     white-space: nowrap;
   }
-  .alias {
-    color: var(--color-foreground-5);
-  }
 </style>
 
 <span class="authorship txt-tiny">
@@ -40,13 +43,13 @@
   <span class="id layout-desktop">
     {formatNodeId(authorId)}
     {#if authorAlias}
-      <span class="alias">({authorAlias})</span>
+      <span style:color="var({authorAliasColor})">({authorAlias})</span>
     {/if}
   </span>
   <span class="id layout-mobile">
     {formatNodeId(authorId).replace("did:key:", "")}
     {#if authorAlias}
-      <span class="alias">({authorAlias})</span>
+      <span style:color="var({authorAliasColor})">({authorAlias})</span>
     {/if}
   </span>
   {#if !caption}

--- a/src/views/projects/Cob/Revision.svelte
+++ b/src/views/projects/Cob/Revision.svelte
@@ -21,6 +21,7 @@
   import ThreadComponent from "@app/components/Thread.svelte";
 
   export let authorId: string;
+  export let authorAlias: string | undefined = undefined;
   export let baseUrl: BaseUrl;
   export let expanded: boolean = true;
   export let patchId: string;
@@ -45,6 +46,17 @@
         return `rejected revision ${utils.formatObjectId(revision)}`;
       default:
         return `left a comment on revision ${utils.formatObjectId(revision)}`;
+    }
+  }
+
+  function aliasColorForVerdict(verdict?: string | null) {
+    switch (verdict) {
+      case "accept":
+        return "--color-positive-5";
+      case "reject":
+        return "--color-negative-5";
+      default:
+        return "--color-foreground-5";
     }
   }
 
@@ -228,13 +240,17 @@
               <CommentComponent
                 {caption}
                 {authorId}
+                {authorAlias}
                 timestamp={element.timestamp}
                 rawPath={utils.getRawBasePath(projectId, baseUrl, projectHead)}
                 body={element.inner.description} />
             </div>
           {:else}
             <div class="action-padding action-background txt-tiny">
-              <Authorship {authorId} timestamp={element.timestamp}>
+              <Authorship
+                {authorId}
+                {authorAlias}
+                timestamp={element.timestamp}>
                 {caption}
               </Authorship>
             </div>
@@ -275,8 +291,10 @@
             class="action-padding action-background merge layout-desktop txt-tiny">
             <div class="action-content">
               <Authorship
-                authorId={element.inner.node}
-                timestamp={element.timestamp}>
+                authorId={element.inner.author.id}
+                authorAlias={element.inner.author.alias}
+                timestamp={element.timestamp}
+                authorAliasColor="--color-primary-5">
                 merged
                 {utils.formatCommit(element.inner.commit)}
               </Authorship>
@@ -285,7 +303,10 @@
           <div
             class="action-padding action-background merge layout-mobile txt-tiny">
             <div class="action-content">
-              <Authorship authorId={element.inner.node}>
+              <Authorship
+                authorId={element.inner.author.id}
+                authorAlias={element.inner.author.alias}
+                authorAliasColor="--color-primary-5">
                 merged
                 {utils.formatCommit(element.inner.commit)}
               </Authorship>
@@ -301,6 +322,7 @@
               <CommentComponent
                 caption={formatVerdict(revisionId, review.verdict)}
                 authorId={author}
+                authorAlias={review.author.alias}
                 timestamp={review.timestamp}
                 rawPath={utils.getRawBasePath(projectId, baseUrl, projectHead)}
                 body={review.comment} />
@@ -311,7 +333,11 @@
               class:positive-review={element.inner[2].verdict === "accept"}
               class:negative-review={element.inner[2].verdict === "reject"}>
               <div class="action-content">
-                <Authorship authorId={author} timestamp={element.timestamp}>
+                <Authorship
+                  authorId={author}
+                  authorAlias={review.author.alias}
+                  authorAliasColor={aliasColorForVerdict(review.verdict)}
+                  timestamp={element.timestamp}>
                   {formatVerdict(revisionId, review.verdict)}
                 </Authorship>
               </div>
@@ -321,7 +347,10 @@
               class:positive-review={element.inner[2].verdict === "accept"}
               class:negative-review={element.inner[2].verdict === "reject"}>
               <div class="action-content">
-                <Authorship authorId={author}>
+                <Authorship
+                  authorId={author}
+                  authorAlias={review.author.alias}
+                  authorAliasColor={aliasColorForVerdict(review.verdict)}>
                   {formatVerdict(revisionId, review.verdict)}
                 </Authorship>
               </div>

--- a/src/views/projects/Cob/Revision.svelte
+++ b/src/views/projects/Cob/Revision.svelte
@@ -239,8 +239,8 @@
             <div class="action-background">
               <CommentComponent
                 {caption}
-                {authorId}
-                {authorAlias}
+                authorId={element.inner.author.id}
+                authorAlias={element.inner.author.alias}
                 timestamp={element.timestamp}
                 rawPath={utils.getRawBasePath(projectId, baseUrl, projectHead)}
                 body={element.inner.description} />

--- a/src/views/projects/Patch.svelte
+++ b/src/views/projects/Patch.svelte
@@ -153,10 +153,10 @@
       revisionOid: rev.oid,
     },
     [
-      ...rev.reviews.map<TimelineReview>(([author, review]) => ({
+      ...rev.reviews.map<TimelineReview>(review => ({
         timestamp: review.timestamp,
         type: "review",
-        inner: [rev.id, author, review],
+        inner: [rev.id, review.author.id, review],
       })),
       ...rev.merges.map<TimelineMerge>(inner => ({
         timestamp: inner.timestamp,
@@ -279,7 +279,9 @@
         {/if}
       </svelte:fragment>
       <div class="author" slot="author">
-        opened by <Authorship authorId={patch.author.id} />
+        opened by <Authorship
+          authorId={patch.author.id}
+          authorAlias={patch.author.alias} />
         {utils.formatTimestamp(patch.revisions[0].timestamp)}
       </div>
     </CobHeader>
@@ -379,6 +381,7 @@
             on:reply={createReply}
             patchId={patch.id}
             authorId={patch.author.id}
+            authorAlias={patch.author.alias}
             expanded={index === patch.revisions.length - 1}
             previousRevId={previousRevision?.id}
             previousRevOid={previousRevision?.oid} />

--- a/src/views/projects/Patch.svelte
+++ b/src/views/projects/Patch.svelte
@@ -158,11 +158,13 @@
         type: "review",
         inner: [rev.id, review.author.id, review],
       })),
-      ...rev.merges.map<TimelineMerge>(inner => ({
-        timestamp: inner.timestamp,
-        type: "merge",
-        inner,
-      })),
+      ...patch.merges
+        .filter(merge => merge.revision === rev.id)
+        .map<TimelineMerge>(inner => ({
+          timestamp: inner.timestamp,
+          type: "merge",
+          inner,
+        })),
       ...rev.discussions
         .filter(comment => !comment.replyTo)
         .map<TimelineThread>(thread => ({

--- a/src/views/projects/Patch.svelte
+++ b/src/views/projects/Patch.svelte
@@ -268,9 +268,9 @@
         </Badge>
       </svelte:fragment>
       <svelte:fragment slot="description">
-        {#if patch.description}
+        {#if patch.revisions[0].description}
           <Markdown
-            content={patch.description}
+            content={patch.revisions[0].description}
             rawPath={utils.getRawBasePath(
               projectId,
               baseUrl,


### PR DESCRIPTION
This PR adds alias to Patch view. You should see 5 instances of alias in this image:

![Screenshot from 2023-05-19 18-17-06](https://github.com/radicle-dev/radicle-interface/assets/14107758/714b1b67-94b3-4c46-a5df-f988bf7f2ba6)
