### PR TITLE
Use author from `Revision` as it might differ from original one

### DIFF
--- a/httpd-client/lib/project/patch.ts
+++ b/httpd-client/lib/project/patch.ts
@@ -87,6 +87,7 @@ const reviewSchema = strictObject({
 
 export interface Revision {
   id: string;
+  author: { id: string; alias?: string };
   description: string;
   base: string;
   oid: string;
@@ -99,6 +100,7 @@ export interface Revision {
 
 const revisionSchema = strictObject({
   id: string(),
+  author: strictObject({ id: string(), alias: string().optional() }),
   description: string(),
   base: string(),
   oid: string(),

--- a/src/views/projects/Cob/Revision.svelte
+++ b/src/views/projects/Cob/Revision.svelte
@@ -167,7 +167,8 @@
           {#if element.inner.description}
             <CommentComponent
               {caption}
-              {authorId}
+              authorId={element.inner.author.id}
+              authorAlias={element.inner.author.alias}
               timestamp={element.timestamp}
               rawPath={utils.getRawBasePath(projectId, baseUrl, projectHead)}
               body={element.inner.description} />


### PR DESCRIPTION
Revision can possibly have different authors, so we pass the `author` field too. Closes https://github.com/radicle-dev/radicle-interface/issues/781.


Please wait for merge of this [patch](https://app.radicle.xyz/seeds/seed.radicle.xyz/rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5/patches/407c161e41455943a3939e885a9c8cab4a0387b1?tab=activity) to API first.

![revision-author](https://github.com/radicle-dev/radicle-interface/assets/14107758/a78ccbf7-4008-4ede-9747-4e9c7aff9929)
