### PR TITLE
Fix wrapping of PatchTeaser

### DIFF
--- a/src/views/projects/Patch/PatchTeaser.svelte
+++ b/src/views/projects/Patch/PatchTeaser.svelte
@@ -60,17 +60,13 @@
   .patch-title:hover {
     text-decoration: underline;
   }
-  .comment-count {
-    align-items: center;
-    padding-right: 1rem;
-    gap: 0.5rem;
-    color: var(--color-foreground-5);
-  }
   .right {
-    align-self: center;
-    justify-self: center;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
     padding-right: 1rem;
     margin-left: auto;
+    color: var(--color-foreground-5);
   }
   .state {
     justify-self: center;
@@ -152,16 +148,14 @@
     </div>
   </div>
   <div class="right">
-    <div class="comment-count">
-      {#await diffPromise then { diff }}
-        <DiffStatBadge
-          insertions={diff.stats.insertions}
-          deletions={diff.stats.deletions} />
-      {/await}
-      {#if latestRevision.discussions.length > 0}
-        <Icon name="chat" />
-        <span>{latestRevision.discussions.length}</span>
-      {/if}
-    </div>
+    {#await diffPromise then { diff }}
+      <DiffStatBadge
+        insertions={diff.stats.insertions}
+        deletions={diff.stats.deletions} />
+    {/await}
+    {#if latestRevision.discussions.length > 0}
+      <Icon name="chat" />
+      <span>{latestRevision.discussions.length}</span>
+    {/if}
   </div>
 </div>


### PR DESCRIPTION
We haven't specified the direction of the flexbox here, so it goes with column.
Also cleans up some css and divs.

**Current**
![image](https://github.com/radicle-dev/radicle-interface/assets/7912302/1c91b1c0-c627-4d29-bbc8-e67067442655)

**Fixed**
<img width="927" alt="Bildschirmfoto 2023-05-31 um 15 12 31" src="https://github.com/radicle-dev/radicle-interface/assets/7912302/c9d8defc-f661-4414-a681-866f98c63f9e">

Closes #796 