### PR TITLE
Remove radicle-git project from pinned projects

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -44,15 +44,6 @@
         }
       },
       {
-        "name": "radicle-git",
-        "id": "rad:zMKWcgFLjUSVBBVmxbcMzzokRxub",
-        "baseUrl": {
-          "hostname": "seed.radicle.xyz",
-          "port": 443,
-          "scheme": "https"
-        }
-      },
-      {
         "name": "radicle-team",
         "id": "rad:z2Jk1mNqyX7AjT4K83jJW9vQoHn4f",
         "baseUrl": {


### PR DESCRIPTION
It's not on the seed anymore. To avoid this console error:
<img width="689" alt="Screenshot 2023-06-01 at 16 21 27" src="https://github.com/radicle-dev/radicle-interface/assets/158411/858ba2c1-ec7f-4f4f-97dd-e2a44c694ab2">
