### PR TITLE
Display a seed URL that matches `isLocal` as `radicle.local`

### DIFF
--- a/src/views/projects/Header.svelte
+++ b/src/views/projects/Header.svelte
@@ -9,6 +9,7 @@
   import Link from "@app/components/Link.svelte";
   import ProjectLink from "@app/components/ProjectLink.svelte";
   import SquareButton from "@app/components/SquareButton.svelte";
+  import { isLocal } from "@app/lib/utils";
 
   export let activeRoute: ProjectRoute;
   export let baseUrl: BaseUrl;
@@ -113,7 +114,7 @@
       },
     }}>
     <SquareButton>
-      {baseUrl.hostname}
+      {isLocal(baseUrl.hostname) ? "radicle.local" : baseUrl.hostname}
     </SquareButton>
   </Link>
 </div>

--- a/tests/e2e/hashRouter.spec.ts
+++ b/tests/e2e/hashRouter.spec.ts
@@ -34,7 +34,7 @@ test("navigation between seed and project pages", async ({ page }) => {
   await expectBackAndForwardNavigationWorks("/#/seeds/radicle.local", page);
   await expectUrlPersistsReload(page);
 
-  await page.locator('role=link[name="127.0.0.1"]').click();
+  await page.locator('role=link[name="radicle.local"]').click();
   await expect(page).toHaveURL("/#/seeds/127.0.0.1");
 });
 

--- a/tests/e2e/historyRouter.spec.ts
+++ b/tests/e2e/historyRouter.spec.ts
@@ -34,7 +34,7 @@ test("navigation between seed and project pages", async ({ page }) => {
   await expectBackAndForwardNavigationWorks("/seeds/radicle.local", page);
   await expectUrlPersistsReload(page);
 
-  await page.locator('role=link[name="127.0.0.1"]').click();
+  await page.locator('role=link[name="radicle.local"]').click();
   await expect(page).toHaveURL("/seeds/127.0.0.1");
 });
 


### PR DESCRIPTION
<img width="487" alt="Bildschirmfoto 2023-06-02 um 10 19 23" src="https://github.com/radicle-dev/radicle-interface/assets/7912302/98476834-ba66-4518-a43f-484f65657fc0">
