### PR TITLE
Relax radicle-httpd API schema checking

### DIFF
--- a/httpd-client/index.ts
+++ b/httpd-client/index.ts
@@ -25,7 +25,7 @@ import type {
 import type { RequestOptions, Method } from "./lib/fetcher.js";
 import type { ZodSchema } from "zod";
 
-import { array, literal, number, strictObject, string, union } from "zod";
+import { array, literal, number, object, string, union } from "zod";
 
 import * as project from "./lib/project.js";
 import * as session from "./lib/session.js";
@@ -57,7 +57,7 @@ export interface Node {
   id: string;
 }
 
-const nodeSchema = strictObject({
+const nodeSchema = object({
   id: string(),
 }) satisfies ZodSchema<Node>;
 
@@ -70,14 +70,14 @@ export interface NodeInfo {
   links: { href: string; rel: string; type: Method }[];
 }
 
-const nodeInfoSchema = strictObject({
+const nodeInfoSchema = object({
   message: string(),
   service: string(),
   version: string(),
   node: nodeSchema,
   path: string(),
   links: array(
-    strictObject({
+    object({
       href: string(),
       rel: string(),
       type: union([
@@ -95,9 +95,9 @@ export interface NodeStats {
   users: { count: number };
 }
 
-const nodeStatsSchema = strictObject({
-  projects: strictObject({ count: number() }),
-  users: strictObject({ count: number() }),
+const nodeStatsSchema = object({
+  projects: object({ count: number() }),
+  users: object({ count: number() }),
 }) satisfies ZodSchema<NodeStats>;
 
 export class HttpdClient {

--- a/httpd-client/lib/project.ts
+++ b/httpd-client/lib/project.ts
@@ -17,7 +17,7 @@ import {
   number,
   optional,
   record,
-  strictObject,
+  object,
   string,
   union,
 } from "zod";
@@ -57,20 +57,20 @@ export interface Project {
   trackings: number;
 }
 
-const projectSchema = strictObject({
+const projectSchema = object({
   id: string(),
   name: string(),
   description: string(),
   defaultBranch: string(),
   delegates: array(string()),
   head: string(),
-  patches: strictObject({
+  patches: object({
     open: number(),
     draft: number(),
     archived: number(),
     merged: number(),
   }),
-  issues: strictObject({
+  issues: object({
     open: number(),
     closed: number(),
   }),
@@ -83,7 +83,7 @@ export interface Activity {
   activity: number[];
 }
 
-const activitySchema = strictObject({
+const activitySchema = object({
   activity: array(number()),
 }) satisfies ZodSchema<Activity>;
 
@@ -95,7 +95,7 @@ export interface Blob {
   lastCommit: CommitHeader;
 }
 
-const blobSchema = strictObject({
+const blobSchema = object({
   binary: boolean(),
   content: optional(string()),
   name: string(),
@@ -109,7 +109,7 @@ interface TreeEntry {
   kind: "tree" | "blob";
 }
 
-const treeEntrySchema = strictObject({
+const treeEntrySchema = object({
   path: string(),
   name: string(),
   kind: union([literal("blob"), literal("tree")]),
@@ -129,12 +129,12 @@ export interface Tree {
   stats: TreeStats;
 }
 
-const treeSchema = strictObject({
+const treeSchema = object({
   entries: array(treeEntrySchema),
   lastCommit: commitHeaderSchema,
   name: string(),
   path: string(),
-  stats: strictObject({
+  stats: object({
     commits: number(),
     branches: number(),
     contributors: number(),
@@ -148,7 +148,7 @@ export interface Remote {
   delegate: boolean;
 }
 
-const remoteSchema = strictObject({
+const remoteSchema = object({
   id: string(),
   alias: string().optional(),
   heads: record(string(), string()),
@@ -162,7 +162,7 @@ export interface DiffResponse {
   diff: Diff;
 }
 
-const diffResponseSchema = strictObject({
+const diffResponseSchema = object({
   commits: array(commitHeaderSchema),
   diff: diffSchema,
 }) satisfies ZodSchema<DiffResponse>;

--- a/httpd-client/lib/project/comment.ts
+++ b/httpd-client/lib/project/comment.ts
@@ -1,5 +1,5 @@
 import type { ZodSchema } from "zod";
-import { array, number, record, strictObject, string } from "zod";
+import { array, number, record, object, string } from "zod";
 
 export type ThreadUpdateAction =
   | { type: "comment"; body: string; replyTo?: string }
@@ -21,9 +21,9 @@ export interface Comment {
   replyTo: string | null;
 }
 
-export const commentSchema = strictObject({
+export const commentSchema = object({
   id: string(),
-  author: strictObject({ id: string(), alias: string().optional() }),
+  author: object({ id: string(), alias: string().optional() }),
   body: string(),
   reactions: array(record(string(), number())),
   timestamp: number(),

--- a/httpd-client/lib/project/commit.ts
+++ b/httpd-client/lib/project/commit.ts
@@ -1,12 +1,12 @@
 import type { ZodSchema } from "zod";
-import { array, literal, number, strictObject, string, union } from "zod";
+import { array, literal, number, object, string, union } from "zod";
 
 interface GitPerson {
   name: string;
   email: string;
 }
 
-const gitPersonSchema = strictObject({
+const gitPersonSchema = object({
   name: string(),
   email: string(),
 }) satisfies ZodSchema<GitPerson>;
@@ -19,12 +19,12 @@ export interface CommitHeader {
   committer: GitPerson & { time: number };
 }
 
-export const commitHeaderSchema = strictObject({
+export const commitHeaderSchema = object({
   id: string(),
   author: gitPersonSchema,
   summary: string(),
   description: string(),
-  committer: gitPersonSchema.merge(strictObject({ time: number() })),
+  committer: gitPersonSchema.merge(object({ time: number() })),
 }) satisfies ZodSchema<CommitHeader>;
 
 interface AdditionHunkLine {
@@ -33,7 +33,7 @@ interface AdditionHunkLine {
   type: "addition";
 }
 
-const additionHunkLineSchema = strictObject({
+const additionHunkLineSchema = object({
   line: string(),
   lineNo: number(),
   type: literal("addition"),
@@ -45,7 +45,7 @@ interface DeletionHunkLine {
   type: "deletion";
 }
 
-const deletionHunkLineSchema = strictObject({
+const deletionHunkLineSchema = object({
   line: string(),
   lineNo: number(),
   type: literal("deletion"),
@@ -58,7 +58,7 @@ interface ContextHunkLine {
   type: "context";
 }
 
-const contextHunkLineSchema = strictObject({
+const contextHunkLineSchema = object({
   line: string(),
   lineNoNew: number(),
   lineNoOld: number(),
@@ -78,7 +78,7 @@ interface ChangesetHunk {
   lines: HunkLine[];
 }
 
-const changesetHunkSchema = strictObject({
+const changesetHunkSchema = object({
   header: string(),
   lines: array(hunkLineSchema),
 }) satisfies ZodSchema<ChangesetHunk>;
@@ -92,9 +92,9 @@ export interface DiffAddedDeletedModifiedChangeset {
   };
 }
 
-const diffAddedDeletedModifiedChangesetSchema = strictObject({
+const diffAddedDeletedModifiedChangesetSchema = object({
   path: string(),
-  diff: strictObject({
+  diff: object({
     type: union([literal("plain"), literal("binary"), literal("empty")]),
     hunks: array(changesetHunkSchema),
     eof: union([
@@ -111,7 +111,7 @@ interface DiffCopiedMovedChangeset {
   oldPath: string;
 }
 
-const diffCopiedMovedChangesetSchema = strictObject({
+const diffCopiedMovedChangesetSchema = object({
   newPath: string(),
   oldPath: string(),
 }) satisfies ZodSchema<DiffCopiedMovedChangeset>;
@@ -129,13 +129,13 @@ export interface Diff {
   };
 }
 
-export const diffSchema = strictObject({
+export const diffSchema = object({
   added: array(diffAddedDeletedModifiedChangesetSchema),
   deleted: array(diffAddedDeletedModifiedChangesetSchema),
   moved: array(diffCopiedMovedChangesetSchema),
   copied: array(diffCopiedMovedChangesetSchema),
   modified: array(diffAddedDeletedModifiedChangesetSchema),
-  stats: strictObject({
+  stats: object({
     filesChanged: number(),
     insertions: number(),
     deletions: number(),
@@ -148,7 +148,7 @@ export interface Commit {
   branches: string[];
 }
 
-export const commitSchema = strictObject({
+export const commitSchema = object({
   commit: commitHeaderSchema,
   diff: diffSchema,
   branches: array(string()),
@@ -159,9 +159,9 @@ export interface Commits {
   stats: { commits: number; branches: number; contributors: number };
 }
 
-export const commitsSchema = strictObject({
+export const commitsSchema = object({
   commits: array(commitSchema),
-  stats: strictObject({
+  stats: object({
     commits: number(),
     branches: number(),
     contributors: number(),

--- a/httpd-client/lib/project/issue.ts
+++ b/httpd-client/lib/project/issue.ts
@@ -1,6 +1,6 @@
 import type { Comment, ThreadUpdateAction } from "./comment.js";
 import type { ZodSchema } from "zod";
-import { array, boolean, literal, strictObject, string, union } from "zod";
+import { array, boolean, literal, object, string, union } from "zod";
 
 import { commentSchema } from "./comment.js";
 
@@ -9,8 +9,8 @@ export type IssueState =
   | { status: "closed"; reason: "other" | "solved" };
 
 const issueStateSchema = union([
-  strictObject({ status: literal("open") }),
-  strictObject({
+  object({ status: literal("open") }),
+  object({
     status: literal("closed"),
     reason: union([literal("other"), literal("solved")]),
   }),
@@ -26,9 +26,9 @@ export interface Issue {
   assignees: string[];
 }
 
-export const issueSchema = strictObject({
+export const issueSchema = object({
   id: string(),
-  author: strictObject({ id: string(), alias: string().optional() }),
+  author: object({ id: string(), alias: string().optional() }),
   title: string(),
   state: issueStateSchema,
   discussion: array(commentSchema),
@@ -41,7 +41,7 @@ export interface IssueCreated {
   id: string;
 }
 
-export const issueCreatedSchema = strictObject({
+export const issueCreatedSchema = object({
   success: boolean(),
   id: string(),
 }) satisfies ZodSchema<IssueCreated>;

--- a/httpd-client/lib/project/patch.ts
+++ b/httpd-client/lib/project/patch.ts
@@ -8,7 +8,7 @@ import {
   literal,
   number,
   optional,
-  strictObject,
+  object,
   string,
   tuple,
   union,
@@ -21,17 +21,17 @@ export type PatchState =
   | { status: "merged"; revision: string; commit: string };
 
 const patchStateSchema = union([
-  strictObject({
+  object({
     status: literal("draft"),
   }),
-  strictObject({
+  object({
     status: literal("open"),
     conflicts: array(tuple([string(), string()])).optional(),
   }),
-  strictObject({
+  object({
     status: literal("archived"),
   }),
-  strictObject({
+  object({
     status: literal("merged"),
     revision: string(),
     commit: string(),
@@ -45,8 +45,8 @@ export interface Merge {
   timestamp: number;
 }
 
-const mergeSchema = strictObject({
-  author: strictObject({ id: string(), alias: string().optional() }),
+const mergeSchema = object({
+  author: object({ id: string(), alias: string().optional() }),
   revision: string(),
   commit: string(),
   timestamp: number(),
@@ -61,10 +61,10 @@ interface CodeLocation {
   };
 }
 
-const codeLocationSchema = strictObject({
+const codeLocationSchema = object({
   path: string(),
   commit: string(),
-  lines: strictObject({
+  lines: object({
     start: number(),
     end: number(),
   }),
@@ -76,7 +76,7 @@ interface CodeComment {
   timestamp: number;
 }
 
-const codeCommentSchema = strictObject({
+const codeCommentSchema = object({
   location: codeLocationSchema,
   comment: string(),
   timestamp: number(),
@@ -92,8 +92,8 @@ export interface Review {
   timestamp: number;
 }
 
-const reviewSchema = strictObject({
-  author: strictObject({ id: string(), alias: string().optional() }),
+const reviewSchema = object({
+  author: object({ id: string(), alias: string().optional() }),
   verdict: optional(union([literal("accept"), literal("reject")]).nullable()),
   comment: optional(string().nullable()),
   inline: array(codeCommentSchema),
@@ -112,9 +112,9 @@ export interface Revision {
   timestamp: number;
 }
 
-const revisionSchema = strictObject({
+const revisionSchema = object({
   id: string(),
-  author: strictObject({ id: string(), alias: string().optional() }),
+  author: object({ id: string(), alias: string().optional() }),
   description: string(),
   base: string(),
   oid: string(),
@@ -136,9 +136,9 @@ export interface Patch {
   revisions: Revision[];
 }
 
-export const patchSchema = strictObject({
+export const patchSchema = object({
   id: string(),
-  author: strictObject({ id: string(), alias: string().optional() }),
+  author: object({ id: string(), alias: string().optional() }),
   title: string(),
   state: patchStateSchema,
   target: string(),

--- a/httpd-client/lib/session.ts
+++ b/httpd-client/lib/session.ts
@@ -2,7 +2,7 @@ import type { Fetcher, RequestOptions } from "./fetcher.js";
 import type { SuccessResponse } from "./shared.js";
 import type { ZodSchema } from "zod";
 
-import { number, strictObject, string } from "zod";
+import { number, object, string } from "zod";
 
 import { successResponseSchema } from "./shared.js";
 
@@ -14,7 +14,7 @@ interface Session {
   expiresAt: number;
 }
 
-const sessionSchema = strictObject({
+const sessionSchema = object({
   sessionId: string(),
   status: string(),
   publicKey: string(),

--- a/httpd-client/lib/shared.ts
+++ b/httpd-client/lib/shared.ts
@@ -1,11 +1,11 @@
 import type { ZodSchema } from "zod";
 
-import { literal, strictObject } from "zod";
+import { literal, object } from "zod";
 
 export interface SuccessResponse {
   success: true;
 }
 
-export const successResponseSchema = strictObject({
+export const successResponseSchema = object({
   success: literal(true),
 }) satisfies ZodSchema<SuccessResponse>;


### PR DESCRIPTION
This way we can deploy back-end API changes that are backwards compatible without breaking the UI.

The downside is that we might miss new fields that are added to `radicle-httpd`.