### PR TITLE
Increase height of `Command` component, change margins

### DIFF
--- a/src/App/Header/Connect.svelte
+++ b/src/App/Header/Connect.svelte
@@ -152,7 +152,7 @@
         <div class="info">
           To access your local Radicle node on this site, run:
         </div>
-        <div style:margin="0 1rem 1rem 1rem">
+        <div style:margin="0.5rem 1rem 1rem 1rem">
           <Command command="radicle-httpd" />
         </div>
       </div>

--- a/src/components/Command.svelte
+++ b/src/components/Command.svelte
@@ -10,14 +10,15 @@
     display: flex;
   }
   .cmd {
+    height: 2rem;
+    line-height: 2rem;
     background-color: var(--color-foreground-3);
     border-radius: var(--border-radius-small);
     display: inline-block;
     font-family: var(--font-family-monospace);
-    font-size: var(--font-size-small);
-    margin-top: 0.5rem;
+    font-size: var(--font-size-tiny);
     overflow: hidden;
-    padding: 2px 0.5rem;
+    padding: 0 0.5rem;
     position: relative;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
- Increases height of `Command` component to 2rem and vertical aligns text
- Reduces margin in Clone modal, which seemed odd.

**Current**
<img width="353" alt="Bildschirmfoto 2023-06-07 um 12 46 56" src="https://github.com/radicle-dev/radicle-interface/assets/7912302/62c703ee-a97f-4250-9688-ddc954ba9672">
<img width="426" alt="Bildschirmfoto 2023-06-07 um 12 46 50" src="https://github.com/radicle-dev/radicle-interface/assets/7912302/e25d575b-1a13-4761-8e9c-13a4716b5d89">

**New**
<img width="357" alt="Bildschirmfoto 2023-06-07 um 12 44 58" src="https://github.com/radicle-dev/radicle-interface/assets/7912302/09f00ac4-10f0-4a90-9c39-289fe54b33f5">
<img width="422" alt="Bildschirmfoto 2023-06-07 um 12 43 53" src="https://github.com/radicle-dev/radicle-interface/assets/7912302/c0d9ecc5-4a93-4ac9-b8c1-8c0008609901">

Closes #817 