### PR TITLE
Fix alias color in review

### DIFF
--- a/src/components/Authorship.svelte
+++ b/src/components/Authorship.svelte
@@ -1,15 +1,19 @@
+<script lang="ts" context="module">
+  export type AuthorAliasColor =
+    | "--color-primary-5"
+    | "--color-foreground-5"
+    | "--color-positive-5"
+    | "--color-negative-5"
+    | undefined;
+</script>
+
 <script lang="ts">
   import Avatar from "@app/components/Avatar.svelte";
   import { formatNodeId, formatTimestamp } from "@app/lib/utils";
 
   export let authorId: string;
   export let authorAlias: string | undefined = undefined;
-  export let authorAliasColor:
-    | "--color-primary-5"
-    | "--color-foreground-5"
-    | "--color-positive-5"
-    | "--color-negative-5"
-    | undefined = "--color-foreground-5";
+  export let authorAliasColor: AuthorAliasColor = "--color-foreground-5";
   export let caption: string | undefined = undefined;
   export let noAvatar: boolean = false;
   export let timestamp: number | undefined = undefined;

--- a/src/components/Comment.svelte
+++ b/src/components/Comment.svelte
@@ -1,4 +1,6 @@
 <script lang="ts" strictEvents>
+  import type { AuthorAliasColor } from "@app/components/Authorship.svelte";
+
   import Authorship from "@app/components/Authorship.svelte";
   import Button from "@app/components/Button.svelte";
   import Icon from "@app/components/Icon.svelte";
@@ -9,6 +11,7 @@
   export let id: string | undefined = undefined;
   export let authorId: string;
   export let authorAlias: string | undefined = undefined;
+  export let authorAliasColor: AuthorAliasColor = "--color-foreground-5";
   export let timestamp: number;
   export let body: string;
   export let showReplyIcon: boolean = false;
@@ -49,7 +52,12 @@
 
 <div class="card" {id}>
   <div class="card-header">
-    <Authorship {caption} {authorId} {authorAlias} {timestamp} />
+    <Authorship
+      {caption}
+      {authorId}
+      {authorAlias}
+      {authorAliasColor}
+      {timestamp} />
     <div class="actions">
       {#if showReplyIcon}
         <Button

--- a/src/views/projects/Cob/Revision.svelte
+++ b/src/views/projects/Cob/Revision.svelte
@@ -351,6 +351,7 @@
                 caption={formatVerdict(revisionId, review.verdict)}
                 authorId={author}
                 authorAlias={review.author.alias}
+                authorAliasColor={aliasColorForVerdict(review.verdict)}
                 timestamp={review.timestamp}
                 rawPath={utils.getRawBasePath(projectId, baseUrl, projectHead)}
                 body={review.comment} />


### PR DESCRIPTION
If a patch review has a comment we didn't pass the color down to the alias.

**Current**
<img width="558" alt="Bildschirmfoto 2023-06-08 um 12 18 22" src="https://github.com/radicle-dev/radicle-interface/assets/7912302/8a9f86fc-cc1b-4a54-922d-b701e34d71af">

**New**
<img width="604" alt="Bildschirmfoto 2023-06-08 um 12 18 13" src="https://github.com/radicle-dev/radicle-interface/assets/7912302/c0b4985e-1a19-4a92-bdf7-5e39599e4b11">
