### PR TITLE
Handle custom httpd port

### DIFF
--- a/httpd-client/index.ts
+++ b/httpd-client/index.ts
@@ -125,7 +125,7 @@ export class HttpdClient {
     }`;
   }
 
-  public get hostnamePort(): string {
+  public get hostAndPort(): string {
     return `${this.#baseUrl.hostname}:${this.#baseUrl.port}`;
   }
 

--- a/httpd-client/index.ts
+++ b/httpd-client/index.ts
@@ -115,6 +115,28 @@ export class HttpdClient {
     this.session = new session.Client(this.#fetcher);
   }
 
+  public changePort(port: number): void {
+    this.#baseUrl.port = port;
+  }
+
+  public get url(): string {
+    return `${this.#baseUrl.scheme}://${this.#baseUrl.hostname}:${
+      this.#baseUrl.port
+    }`;
+  }
+
+  public get hostnamePort(): string {
+    return `${this.#baseUrl.hostname}:${this.#baseUrl.port}`;
+  }
+
+  public get hostname(): string {
+    return this.#baseUrl.hostname;
+  }
+
+  public get port(): string {
+    return this.#baseUrl.port.toString();
+  }
+
   public async getNodeInfo(options?: RequestOptions): Promise<NodeInfo> {
     return this.#fetcher.fetchOk(
       {

--- a/src/App/Header/Connect.svelte
+++ b/src/App/Header/Connect.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import type { HttpdState } from "@app/lib/httpd";
 
+  import * as httpd from "@app/lib/httpd";
   import { closeFocused } from "@app/components/Floating.svelte";
-  import { httpdStore, disconnect } from "@app/lib/httpd";
+  import { httpdStore } from "@app/lib/httpd";
 
   import Authorship from "@app/components/Authorship.svelte";
   import Button from "@app/components/Button.svelte";
@@ -11,11 +12,15 @@
   import Floating from "@app/components/Floating.svelte";
   import Icon from "@app/components/Icon.svelte";
   import Link from "@app/components/Link.svelte";
+  import PortInput from "@app/App/Header/Connect/PortInput.svelte";
 
   $: command = import.meta.env.PROD
-    ? "rad web"
-    : `rad web --frontend ${new URL(import.meta.url).origin}`;
+    ? `rad web --backend ${httpd.api.url}`
+    : `rad web --frontend ${new URL(import.meta.url).origin} --backend ${
+        httpd.api.url
+      }`;
 
+  let customPort = httpd.api.port;
   const buttonTitle: Record<HttpdState["state"], string> = {
     stopped: "radicle-httpd is stopped",
     running: "radicle-httpd is running",
@@ -56,7 +61,7 @@
     height: 2.5rem;
     justify-content: space-between;
     line-height: 2.5rem;
-    padding: 0 0.8rem;
+    padding: 0 1rem;
     user-select: none;
     width: 100%;
   }
@@ -64,7 +69,7 @@
     background-color: var(--color-foreground-3);
     color: var(--color-foreground-6);
   }
-  .rounded {
+  .rounded:last-of-type:hover {
     border-bottom-left-radius: var(--border-radius);
     border-bottom-right-radius: var(--border-radius);
   }
@@ -114,7 +119,10 @@
           on:afterNavigate={closeFocused}
           route={{
             resource: "seeds",
-            params: { hostnamePort: "radicle.local", projectPageIndex: 0 },
+            params: {
+              hostnamePort: httpd.api.hostnamePort,
+              projectPageIndex: 0,
+            },
           }}>
           <div class="dropdown-button">Browse</div>
         </Link>
@@ -123,7 +131,7 @@
         <div
           class="dropdown-button rounded"
           on:click={() => {
-            void disconnect();
+            void httpd.disconnect();
             closeFocused();
           }}>
           Disconnect
@@ -135,14 +143,18 @@
           To connect to your local Radicle node, run this command in your
           terminal:
         </div>
-        <div style:margin="0 1rem 1rem 1rem">
+        <div style:margin="0 1rem 0.5rem 1rem">
           <Command {command} />
         </div>
+        <PortInput bind:port={customPort} />
         <Link
           on:afterNavigate={closeFocused}
           route={{
             resource: "seeds",
-            params: { hostnamePort: "radicle.local", projectPageIndex: 0 },
+            params: {
+              hostnamePort: httpd.api.hostnamePort,
+              projectPageIndex: 0,
+            },
           }}>
           <div class="dropdown-button rounded">Browse</div>
         </Link>
@@ -155,6 +167,7 @@
         <div style:margin="0.5rem 1rem 1rem 1rem">
           <Command command="radicle-httpd" />
         </div>
+        <PortInput bind:port={customPort} />
       </div>
     {/if}
   </div>

--- a/src/App/Header/Connect.svelte
+++ b/src/App/Header/Connect.svelte
@@ -120,7 +120,7 @@
           route={{
             resource: "seeds",
             params: {
-              hostnamePort: httpd.api.hostnamePort,
+              hostAndPort: httpd.api.hostAndPort,
               projectPageIndex: 0,
             },
           }}>
@@ -152,7 +152,7 @@
           route={{
             resource: "seeds",
             params: {
-              hostnamePort: httpd.api.hostnamePort,
+              hostAndPort: httpd.api.hostAndPort,
               projectPageIndex: 0,
             },
           }}>

--- a/src/App/Header/Connect/PortInput.svelte
+++ b/src/App/Header/Connect/PortInput.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import * as httpd from "@app/lib/httpd";
+
+  import TextInput from "@app/components/TextInput.svelte";
+
+  export let port: string;
+
+  $: validPortNumber = Number(port) > 0 && Number(port) <= 65535;
+</script>
+
+<style>
+  .item {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    padding: 0.5rem 1rem 0.5rem 1rem;
+    justify-content: space-between;
+    border-top: 1px solid var(--color-foreground-3);
+    height: 2.5rem;
+  }
+</style>
+
+<div class="item">
+  <span>Port</span>
+  <div style:width="6.5rem">
+    <TextInput
+      name="port"
+      size="small"
+      variant="modal"
+      bind:value={port}
+      valid={validPortNumber}
+      on:submit={() => httpd.changeHttpdPort(Number(port))} />
+  </div>
+</div>

--- a/src/App/Header/Search.svelte
+++ b/src/App/Header/Search.svelte
@@ -123,13 +123,9 @@
       {loading}
       disabled={loading}
       bind:value={input}
-      on:focus={() => {
-        expanded = true;
-      }}
+      on:focus={() => (expanded = true)}
       on:blur={() => {
-        if (input === "") {
-          expanded = false;
-        }
+        if (input === "") expanded = false;
       }}
       on:submit={search}
       placeholder={searchPlaceholder}>

--- a/src/App/Header/Search.svelte
+++ b/src/App/Header/Search.svelte
@@ -6,7 +6,7 @@
   import * as modal from "@app/lib/modal";
   import * as router from "@app/lib/router";
   import { searchPlaceholder } from "@app/lib/shared";
-  import { unreachable } from "@app/lib/utils";
+  import { getHostAndPort, unreachable } from "@app/lib/utils";
 
   import Icon from "@app/components/Icon.svelte";
   import SearchResultsModal from "@app/App/Header/SearchResultsModal.svelte";
@@ -47,13 +47,14 @@
     } else if (searchResult.type === "projects") {
       input = "";
       if (searchResult.results.length === 1) {
+        const { project, baseUrl } = searchResult.results[0];
         void router.push({
           resource: "projects",
           params: {
             view: { resource: "tree" },
-            id: searchResult.results[0].project.id,
+            id: project.id,
             peer: undefined,
-            hostnamePort: searchResult.results[0].baseUrl.hostname,
+            hostAndPort: getHostAndPort(baseUrl),
             hash: undefined,
             search: undefined,
           },

--- a/src/App/Header/SearchResultsModal.svelte
+++ b/src/App/Header/SearchResultsModal.svelte
@@ -2,7 +2,7 @@
   import type { ProjectBaseUrl } from "@app/lib/search";
 
   import * as modal from "@app/lib/modal";
-  import { formatRepositoryId } from "@app/lib/utils";
+  import { formatRepositoryId, getHostAndPort } from "@app/lib/utils";
 
   import Link from "@app/components/Link.svelte";
   import Modal from "@app/components/Modal.svelte";
@@ -40,7 +40,7 @@
                 resource: "projects",
                 params: {
                   view: { resource: "tree" },
-                  hostnamePort: result.baseUrl.hostname,
+                  hostAndPort: getHostAndPort(result.baseUrl),
                   id: result.project.id,
                 },
               }}>

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -124,8 +124,8 @@ function pathToRoute(url: URL): Route | null {
   const resource = segments.shift();
   switch (resource) {
     case "seeds": {
-      const hostnamePort = segments.shift();
-      if (hostnamePort) {
+      const hostAndPort = segments.shift();
+      if (hostAndPort) {
         const id = segments.shift();
         if (id) {
           // Allows project paths with or without trailing slash
@@ -139,17 +139,17 @@ function pathToRoute(url: URL): Route | null {
                 view: { resource: "tree" },
                 id,
                 peer: undefined,
-                hostnamePort,
+                hostAndPort,
               },
             };
           }
-          const params = resolveProjectRoute(url, hostnamePort, id, segments);
+          const params = resolveProjectRoute(url, hostAndPort, id, segments);
           if (params) {
             return {
               resource: "projects",
               params: {
                 ...params,
-                hostnamePort,
+                hostAndPort,
                 id,
               },
             };
@@ -158,7 +158,7 @@ function pathToRoute(url: URL): Route | null {
         }
         return {
           resource: "seeds",
-          params: { hostnamePort, projectPageIndex: 0 },
+          params: { hostAndPort, projectPageIndex: 0 },
         };
       }
       return null;
@@ -192,11 +192,11 @@ export function routeToPath(route: Route) {
   } else if (route.resource === "session") {
     return `/session?id=${route.params.id}&sig=${route.params.signature}&pk=${route.params.publicKey}`;
   } else if (route.resource === "seeds") {
-    return `/seeds/${route.params.hostnamePort}`;
+    return `/seeds/${route.params.hostAndPort}`;
   } else if (route.resource === "loadError") {
     return "";
   } else if (route.resource === "projects") {
-    const hostnamePortPrefix = `/seeds/${route.params.hostnamePort}`;
+    const hostAndPortPrefix = `/seeds/${route.params.hostAndPort}`;
     const content = `/${route.params.view.resource}`;
 
     let peer = "";
@@ -230,31 +230,31 @@ export function routeToPath(route: Route) {
 
     if (route.params.view.resource === "tree") {
       if (suffix) {
-        return `${hostnamePortPrefix}/${route.params.id}${peer}/tree${suffix}`;
+        return `${hostAndPortPrefix}/${route.params.id}${peer}/tree${suffix}`;
       }
-      return `${hostnamePortPrefix}/${route.params.id}${peer}`;
+      return `${hostAndPortPrefix}/${route.params.id}${peer}`;
     } else if (route.params.view.resource === "commits") {
-      return `${hostnamePortPrefix}/${route.params.id}${peer}/commits${suffix}`;
+      return `${hostAndPortPrefix}/${route.params.id}${peer}/commits${suffix}`;
     } else if (route.params.view.resource === "history") {
-      return `${hostnamePortPrefix}/${route.params.id}${peer}/history${suffix}`;
+      return `${hostAndPortPrefix}/${route.params.id}${peer}/history${suffix}`;
     } else if (
       route.params.view.resource === "issues" &&
       route.params.view.params?.view.resource === "new"
     ) {
-      return `${hostnamePortPrefix}/${route.params.id}${peer}/issues/new${suffix}`;
+      return `${hostAndPortPrefix}/${route.params.id}${peer}/issues/new${suffix}`;
     } else if (route.params.view.resource === "issues") {
-      return `${hostnamePortPrefix}/${route.params.id}${peer}/issues${suffix}`;
+      return `${hostAndPortPrefix}/${route.params.id}${peer}/issues${suffix}`;
     } else if (route.params.view.resource === "issue") {
-      return `${hostnamePortPrefix}/${route.params.id}${peer}/issues/${route.params.view.params.issue}`;
+      return `${hostAndPortPrefix}/${route.params.id}${peer}/issues/${route.params.view.params.issue}`;
     } else if (route.params.view.resource === "patches") {
-      return `${hostnamePortPrefix}/${route.params.id}${peer}/patches${suffix}`;
+      return `${hostAndPortPrefix}/${route.params.id}${peer}/patches${suffix}`;
     } else if (route.params.view.resource === "patch") {
       if (route.params.view.params.revision) {
-        return `${hostnamePortPrefix}/${route.params.id}${peer}/patches/${route.params.view.params.patch}/${route.params.view.params.revision}${suffix}`;
+        return `${hostAndPortPrefix}/${route.params.id}${peer}/patches/${route.params.view.params.patch}/${route.params.view.params.revision}${suffix}`;
       }
-      return `${hostnamePortPrefix}/${route.params.id}${peer}/patches/${route.params.view.params.patch}${suffix}`;
+      return `${hostAndPortPrefix}/${route.params.id}${peer}/patches/${route.params.view.params.patch}${suffix}`;
     } else {
-      return `${hostnamePortPrefix}/${route.params.id}${peer}${content}`;
+      return `${hostAndPortPrefix}/${route.params.id}${peer}${content}`;
     }
   } else if (route.resource === "booting") {
     return "";

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -255,10 +255,11 @@ export function extractBaseUrl(hostnamePort: string): BaseUrl {
   ) {
     return { hostname: "127.0.0.1", port: 8080, scheme: "http" };
   } else if (hostnamePort.includes(":")) {
+    const [hostname, port] = hostnamePort.split(":");
     return {
-      hostname: hostnamePort.split(":")[0],
-      port: Number(hostnamePort.split(":")[1]),
-      scheme: config.seeds.defaultHttpdScheme,
+      hostname,
+      port: Number(port),
+      scheme: isLocal(hostname) ? "http" : config.seeds.defaultHttpdScheme,
     };
   } else {
     return {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -244,18 +244,18 @@ export function twemoji(
   });
 }
 
-export function extractBaseUrl(hostnamePort: string): BaseUrl {
+export function extractBaseUrl(hostAndPort: string): BaseUrl {
   if (
-    hostnamePort === "radicle.local" ||
-    hostnamePort === "radicle.local:8080" ||
-    hostnamePort === "0.0.0.0" ||
-    hostnamePort === "0.0.0.0:8080" ||
-    hostnamePort === "127.0.0.1" ||
-    hostnamePort === "127.0.0.1:8080"
+    hostAndPort === "radicle.local" ||
+    hostAndPort === "radicle.local:8080" ||
+    hostAndPort === "0.0.0.0" ||
+    hostAndPort === "0.0.0.0:8080" ||
+    hostAndPort === "127.0.0.1" ||
+    hostAndPort === "127.0.0.1:8080"
   ) {
     return { hostname: "127.0.0.1", port: 8080, scheme: "http" };
-  } else if (hostnamePort.includes(":")) {
-    const [hostname, port] = hostnamePort.split(":");
+  } else if (hostAndPort.includes(":")) {
+    const [hostname, port] = hostAndPort.split(":");
     return {
       hostname,
       port: Number(port),
@@ -263,11 +263,17 @@ export function extractBaseUrl(hostnamePort: string): BaseUrl {
     };
   } else {
     return {
-      hostname: hostnamePort,
+      hostname: hostAndPort,
       port: config.seeds.defaultHttpdPort,
       scheme: config.seeds.defaultHttpdScheme,
     };
   }
+}
+
+export function getHostAndPort(baseUrl: BaseUrl): string {
+  return baseUrl.port === config.seeds.defaultHttpdPort
+    ? baseUrl.hostname
+    : `${baseUrl.hostname}:${baseUrl.port}`;
 }
 
 export function createAddRemoveArrays(

--- a/src/views/home/Index.svelte
+++ b/src/views/home/Index.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { ProjectBaseUrlActivity } from "./router";
 
-  import { twemoji } from "@app/lib/utils";
+  import { getHostAndPort, twemoji } from "@app/lib/utils";
 
   import Link from "@app/components/Link.svelte";
   import ProjectCard from "@app/components/ProjectCard.svelte";
@@ -78,7 +78,7 @@
               params: {
                 view: { resource: "tree" },
                 id: project.id,
-                hostnamePort: baseUrl.hostname,
+                hostAndPort: getHostAndPort(baseUrl),
                 peer: undefined,
                 revision: undefined,
               },

--- a/src/views/projects/Header.svelte
+++ b/src/views/projects/Header.svelte
@@ -2,8 +2,7 @@
   import type { BaseUrl } from "@httpd-client";
   import type { ProjectLoadedView } from "@app/views/projects/router";
 
-  import { config } from "@app/lib/config";
-  import { isLocal } from "@app/lib/utils";
+  import { getHostAndPort, isLocal } from "@app/lib/utils";
   import { pluralize } from "@app/lib/pluralize";
 
   import CloneButton from "@app/views/projects/CloneButton.svelte";
@@ -108,10 +107,7 @@
     route={{
       resource: "seeds",
       params: {
-        hostnamePort:
-          baseUrl.port === config.seeds.defaultHttpdPort
-            ? baseUrl.hostname
-            : `${baseUrl.hostname}:${baseUrl.port}`,
+        hostAndPort: getHostAndPort(baseUrl),
         projectPageIndex: 0,
       },
     }}>

--- a/src/views/projects/Issue.svelte
+++ b/src/views/projects/Issue.svelte
@@ -141,7 +141,7 @@
         resource: "projects",
         params: {
           id: projectId,
-          hostnamePort: baseUrl.hostname,
+          hostAndPort: utils.getHostAndPort(baseUrl),
           view: {
             resource: "issue",
             params: { issue: issue.id },

--- a/src/views/projects/View.svelte
+++ b/src/views/projects/View.svelte
@@ -26,7 +26,7 @@
   import Patches from "./Patches.svelte";
   import ProjectMeta from "./ProjectMeta.svelte";
 
-  export let hostnamePort: string;
+  export let hostAndPort: string;
   export let id: string;
   export let project: Project;
   export let view: ProjectLoadedView;
@@ -43,7 +43,7 @@
     (searchParams.get("tab") as "activity" | "commits" | "files") || "activity";
   $: patchFilter = (searchParams.get("state") as PatchStatus) || "open";
   $: patchDiffFilter = searchParams.get("diff") || undefined;
-  $: baseUrl = utils.extractBaseUrl(hostnamePort);
+  $: baseUrl = utils.extractBaseUrl(hostAndPort);
   $: api = new HttpdClient(baseUrl);
 
   function handleIssueCreation({ detail: issueId }: CustomEvent<string>) {
@@ -51,7 +51,7 @@
       resource: "projects",
       params: {
         id,
-        hostnamePort: httpd.api.hostnamePort,
+        hostAndPort: httpd.api.hostAndPort,
         view: {
           resource: "issue",
           params: { issue: issueId },

--- a/src/views/projects/View.svelte
+++ b/src/views/projects/View.svelte
@@ -4,6 +4,7 @@
   import type { Project } from "@httpd-client";
   import type { ProjectLoadedView } from "@app/views/projects/router";
 
+  import * as httpd from "@app/lib/httpd";
   import * as router from "@app/lib/router";
   import * as utils from "@app/lib/utils";
   import { HttpdClient } from "@httpd-client";
@@ -49,8 +50,8 @@
     void router.push({
       resource: "projects",
       params: {
-        id: id,
-        hostnamePort: baseUrl.hostname,
+        id,
+        hostnamePort: httpd.api.hostnamePort,
         view: {
           resource: "issue",
           params: { issue: issueId },

--- a/src/views/projects/router.ts
+++ b/src/views/projects/router.ts
@@ -29,7 +29,7 @@ export interface ProjectLoadedRoute {
 export interface ProjectsParams {
   id: string;
   hash?: string;
-  hostnamePort: string;
+  hostAndPort: string;
   path?: string;
   peer?: string;
   revision?: string;
@@ -56,7 +56,7 @@ export interface ProjectsParams {
 }
 
 export interface ProjectLoadedParams {
-  hostnamePort: string;
+  hostAndPort: string;
   id: string;
   project: Project;
   view: ProjectLoadedView;
@@ -146,7 +146,7 @@ export function parseRevisionToOid(
 export async function loadProjectRoute(
   params: ProjectsParams,
 ): Promise<ProjectLoadedRoute | LoadError> {
-  const baseUrl = extractBaseUrl(params.hostnamePort);
+  const baseUrl = extractBaseUrl(params.hostAndPort);
   const api = new HttpdClient(baseUrl);
   try {
     if (
@@ -408,7 +408,7 @@ export async function updateProjectRoute(
 
 export function resolveProjectRoute(
   url: URL,
-  hostnamePort: string,
+  hostAndPort: string,
   id: string,
   segments: string[],
 ): ProjectsParams | null {
@@ -424,7 +424,7 @@ export function resolveProjectRoute(
     return {
       view: { resource: "tree" },
       id,
-      hostnamePort,
+      hostAndPort,
       peer,
       path: undefined,
       revision: undefined,
@@ -436,7 +436,7 @@ export function resolveProjectRoute(
     return {
       view: { resource: "history" },
       id,
-      hostnamePort,
+      hostAndPort,
       peer,
       path: undefined,
       revision: undefined,
@@ -447,7 +447,7 @@ export function resolveProjectRoute(
     return {
       view: { resource: "commits" },
       id,
-      hostnamePort,
+      hostAndPort,
       peer,
       path: undefined,
       revision: undefined,
@@ -460,7 +460,7 @@ export function resolveProjectRoute(
       return {
         view: { resource: "issues", params: { view: { resource: "new" } } },
         id,
-        hostnamePort,
+        hostAndPort,
         peer,
         search: sanitizeQueryString(url.search),
         path: undefined,
@@ -470,7 +470,7 @@ export function resolveProjectRoute(
       return {
         view: { resource: "issue", params: { issue: issueOrAction } },
         id,
-        hostnamePort,
+        hostAndPort,
         peer,
         path: undefined,
         revision: undefined,
@@ -480,7 +480,7 @@ export function resolveProjectRoute(
       return {
         view: { resource: "issues" },
         id,
-        hostnamePort,
+        hostAndPort,
         peer,
         search: sanitizeQueryString(url.search),
         path: undefined,
@@ -494,7 +494,7 @@ export function resolveProjectRoute(
       return {
         view: { resource: "patch", params: { patch, revision } },
         id,
-        hostnamePort,
+        hostAndPort,
         peer,
         path: undefined,
         revision: undefined,
@@ -504,7 +504,7 @@ export function resolveProjectRoute(
       return {
         view: { resource: "patches" },
         id,
-        hostnamePort,
+        hostAndPort,
         peer,
         search: sanitizeQueryString(url.search),
         path: undefined,

--- a/src/views/seeds/View.svelte
+++ b/src/views/seeds/View.svelte
@@ -3,7 +3,7 @@
   import type { ProjectActivity } from "@app/views/seeds/router";
 
   import { config } from "@app/lib/config";
-  import { isLocal, truncateId } from "@app/lib/utils";
+  import { getHostAndPort, isLocal, truncateId } from "@app/lib/utils";
   import { loadProjects } from "@app/views/seeds/router";
 
   import Button from "@app/components/Button.svelte";
@@ -131,10 +131,7 @@
               params: {
                 view: { resource: "tree" },
                 id: project.id,
-                hostnamePort:
-                  baseUrl.port === config.seeds.defaultHttpdPort
-                    ? baseUrl.hostname
-                    : `${baseUrl.hostname}:${baseUrl.port}`,
+                hostAndPort: getHostAndPort(baseUrl),
                 revision: undefined,
                 hash: undefined,
                 search: undefined,

--- a/src/views/seeds/router.ts
+++ b/src/views/seeds/router.ts
@@ -7,7 +7,7 @@ import { extractBaseUrl } from "@app/lib/utils";
 import { loadProjectActivity } from "@app/lib/commit";
 
 interface SeedsRouteParams {
-  hostnamePort: string;
+  hostAndPort: string;
   projectPageIndex: number;
 }
 
@@ -68,7 +68,7 @@ export async function loadProjects(
 export async function loadSeedRoute(
   params: SeedsRouteParams,
 ): Promise<SeedsLoadedRoute | LoadError> {
-  const baseUrl = extractBaseUrl(params.hostnamePort);
+  const baseUrl = extractBaseUrl(params.hostAndPort);
   const api = new HttpdClient(baseUrl);
   try {
     const projectPageIndex = 0;
@@ -91,7 +91,7 @@ export async function loadSeedRoute(
     return {
       resource: "loadError",
       params: {
-        title: params.hostnamePort,
+        title: params.hostAndPort,
         errorMessage: "Not able to query this seed.",
         stackTrace: error.stack,
       },

--- a/src/views/session/Index.svelte
+++ b/src/views/session/Index.svelte
@@ -20,7 +20,7 @@
       modal.show({ component: AuthenticatedModal, props: {} });
       void router.push({
         resource: "seeds",
-        params: { hostnamePort: "radicle.local", projectPageIndex: 0 },
+        params: { hostnamePort: httpd.api.hostnamePort, projectPageIndex: 0 },
       });
     } else {
       modal.show({

--- a/src/views/session/Index.svelte
+++ b/src/views/session/Index.svelte
@@ -20,7 +20,10 @@
       modal.show({ component: AuthenticatedModal, props: {} });
       void router.push({
         resource: "seeds",
-        params: { hostnamePort: httpd.api.hostnamePort, projectPageIndex: 0 },
+        params: {
+          hostAndPort: httpd.api.hostAndPort,
+          projectPageIndex: 0,
+        },
       });
     } else {
       modal.show({

--- a/tests/e2e/hotkeys.spec.ts
+++ b/tests/e2e/hotkeys.spec.ts
@@ -29,7 +29,7 @@ test("global hotkeys", async ({ page }) => {
     await expect(page.getByPlaceholder(searchPlaceholder)).toHaveValue(
       "searchquery?",
     );
-    await expect(page.getByText("⏎")).toBeVisible();
+    await expect(page.getByText("⏎")).toBeHidden();
     await expect(page.getByPlaceholder(searchPlaceholder)).not.toBeFocused();
   }
 });

--- a/tests/e2e/httpd.spec.ts
+++ b/tests/e2e/httpd.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@tests/support/fixtures.js";
+
+test("change httpd port", async ({ page, peerManager }) => {
+  const peer = await peerManager.startPeer({ name: "httpd" });
+
+  await peer.startHttpd(8070);
+  await peer.startNode();
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "radicle.local" }).click();
+
+  await page.locator('input[name="port"]').fill("8070");
+  await page.locator('input[name="port"]').press("Enter");
+
+  const { stdout } = await peer.rad([
+    "web",
+    "--frontend",
+    "http://localhost:3000",
+    "--backend",
+    "http://127.0.0.1:8070",
+  ]);
+  const match = stdout.trim().match(/(http:\/\/localhost:3000\/.*)$/);
+  if (!match) {
+    throw Error("Not able to parse auth url");
+  }
+  await page.goto(match[0]);
+  await expect(page.getByText("Authenticated")).toBeVisible();
+  await expect(page).toHaveURL("/seeds/127.0.0.1:8070");
+});

--- a/tests/unit/router.test.ts
+++ b/tests/unit/router.test.ts
@@ -10,7 +10,7 @@ describe("routeToPath", () => {
     {
       input: {
         resource: "seeds",
-        params: { hostnamePort: "willow.radicle.garden" },
+        params: { hostAndPort: "willow.radicle.garden" },
       },
       output: "/seeds/willow.radicle.garden",
       description: "Seed View Route",
@@ -20,7 +20,7 @@ describe("routeToPath", () => {
         resource: "projects",
         params: {
           view: { resource: "tree" },
-          hostnamePort: "willow.radicle.garden",
+          hostAndPort: "willow.radicle.garden",
           id: "rad:zKtT7DmF9H34KkvcKj9PHW19WzjT",
         },
       },
@@ -54,7 +54,7 @@ describe("pathToRoute", () => {
       input: new URL("/seeds/willow.radicle.garden", dummyUrl),
       output: {
         resource: "seeds",
-        params: { hostnamePort: "willow.radicle.garden", projectPageIndex: 0 },
+        params: { hostAndPort: "willow.radicle.garden", projectPageIndex: 0 },
       },
       description: "Seed View Route",
     },
@@ -67,7 +67,7 @@ describe("pathToRoute", () => {
         resource: "projects",
         params: {
           view: { resource: "tree" },
-          hostnamePort: "willow.radicle.garden",
+          hostAndPort: "willow.radicle.garden",
           profile: undefined,
           peer: undefined,
           id: "rad:zKtT7DmF9H34KkvcKj9PHW19WzjT",
@@ -92,7 +92,7 @@ describe("pathToRoute", () => {
         resource: "projects",
         params: {
           view: { resource: "tree" },
-          hostnamePort: "willow.radicle.garden",
+          hostAndPort: "willow.radicle.garden",
           profile: undefined,
           peer: undefined,
           id: "rad:zKtT7DmF9H34KkvcKj9PHW19WzjT",


### PR DESCRIPTION
We only support fetching the default httpd port (8080). This PR removes navigation to `radicle.local` which represents `0.0.0.0:8080`, and prepares the app for defining a custom port.

Adds a e2e test also to test that authenticating with a custom port works and navigates to the correct seed.