### PR TITLE
Add error handling for issue creation and commenting

### DIFF
--- a/src/views/projects/Cob/ErrorModal.svelte
+++ b/src/views/projects/Cob/ErrorModal.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import ErrorMessage from "@app/components/ErrorMessage.svelte";
+  import Modal from "@app/components/Modal.svelte";
+
+  export let title: string;
+  export let subtitle: string[];
+  export let error: Error;
+</script>
+
+<Modal {title} emoji="🚨">
+  <div slot="subtitle">
+    {@html subtitle.join("<br />")}
+  </div>
+  <div slot="body">
+    <ErrorMessage message={error.message} stackTrace={error.stack} />
+  </div>
+</Modal>

--- a/src/views/projects/Issue.svelte
+++ b/src/views/projects/Issue.svelte
@@ -32,7 +32,8 @@
   const rawPath = utils.getRawBasePath(projectId, baseUrl, projectHead);
   const api = new HttpdClient(baseUrl);
 
-  const action: "create" | "edit" | "view" =
+  let action: "edit" | "view";
+  $: action =
     $httpdStore.state === "authenticated" && utils.isLocal(baseUrl.hostname)
       ? "edit"
       : "view";

--- a/tests/e2e/project/issues.spec.ts
+++ b/tests/e2e/project/issues.spec.ts
@@ -1,4 +1,5 @@
 import { test, cobUrl, expect } from "@tests/support/fixtures.js";
+import { createProject } from "@tests/support/project";
 
 test("navigate issue listing", async ({ page }) => {
   await page.goto(cobUrl);
@@ -16,4 +17,41 @@ test("navigate single issue", async ({ page }) => {
   await expect(page).toHaveURL(
     `${cobUrl}/issues/4fc727e722d3979fd2073d9b56b2751658a4ae79`,
   );
+});
+
+test("test issue editing failing", async ({ page, authenticatedPeer }) => {
+  const { rid, projectFolder } = await createProject(
+    authenticatedPeer,
+    "issue-editing",
+  );
+  await authenticatedPeer.rad(
+    [
+      "issue",
+      "open",
+      "--title",
+      "This issue is going to fail",
+      "--description",
+      "Let's see",
+    ],
+    { cwd: projectFolder },
+  );
+
+  await page.route(
+    `**/v1/projects/${rid}/issues/d316f7a90a40dacbfb8728044bad50c9f71d44ba`,
+    route => {
+      if (route.request().method() !== "PATCH") {
+        void route.fallback();
+        return;
+      }
+      void route.fulfill({ status: 500 });
+    },
+  );
+
+  await page.goto(
+    `/seeds/127.0.0.1:8070/${rid}/issues/d316f7a90a40dacbfb8728044bad50c9f71d44ba`,
+  );
+
+  await page.getByPlaceholder("Leave your comment").fill("This is a comment");
+  await page.getByRole("button", { name: "Comment" }).click();
+  await expect(page.getByText("Issue editing failed")).toBeVisible();
 });

--- a/tests/support/fixtures.ts
+++ b/tests/support/fixtures.ts
@@ -32,6 +32,7 @@ export const test = base.extend<{
   customAppConfig: boolean;
   stateDir: string;
   peerManager: PeerManager;
+  authenticatedPeer: RadiclePeer;
   outputLog: Stream.Writable;
 }>({
   customAppConfig: [false, { option: true }],
@@ -143,6 +144,35 @@ export const test = base.extend<{
       outputLog,
     });
     await use(peerManager);
+  },
+
+  authenticatedPeer: async ({ page, peerManager }, use) => {
+    const peer = await peerManager.startPeer({
+      name: "httpd",
+      gitOptions: gitOptions["bob"],
+    });
+
+    await peer.startHttpd(8070);
+    await peer.startNode();
+    await page.goto("/");
+    await page.getByRole("button", { name: "radicle.local" }).click();
+    await page.locator('input[name="port"]').fill("8070");
+    await page.locator('input[name="port"]').press("Enter");
+    const { stdout } = await peer.rad([
+      "web",
+      "--frontend",
+      "http://localhost:3000",
+      "--backend",
+      "http://127.0.0.1:8070",
+    ]);
+    const match = stdout.trim().match(/(http:\/\/localhost:3000\/.*)$/);
+    if (!match) {
+      throw Error("Not able to parse auth url");
+    }
+    await page.goto(match[0]);
+    await page.getByRole("button", { name: "Close" }).click();
+
+    await use(peer);
   },
 
   // eslint-disable-next-line no-empty-pattern


### PR DESCRIPTION
Catches errors that can occur during issue editing, commenting and replying.
Also adds a `authenticatedPeer` fixture, which authenticates a `RadiclePeer` with `radicle-httpd`

Shows a display that tells the user something went wrong, and a `ErrorMessage` component to copy the message and stackTrace
<img width="501" alt="Bildschirmfoto 2023-06-15 um 13 29 36" src="https://github.com/radicle-dev/radicle-interface/assets/7912302/df52c732-ebef-4e79-8b33-607958db6827">

Also when there is an issue while refreshing the issue with a GET request after the PATCH update action, we show a different error

<img width="517" alt="Bildschirmfoto 2023-06-15 um 13 32 51" src="https://github.com/radicle-dev/radicle-interface/assets/7912302/db83fb1d-959a-4b42-95e7-4f278285b7e1">

Closes #793 