### PR TITLE
Escape html in markdown before passing it to the sanitizer

### DIFF
--- a/src/components/InlineMarkdown.svelte
+++ b/src/components/InlineMarkdown.svelte
@@ -17,6 +17,7 @@
 
   const render = (content: string): string =>
     dompurify.sanitize(marked.parseInline(escapeHtml(content)), {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       SANITIZE_DOM: false,
     });
 </script>

--- a/src/components/InlineMarkdown.svelte
+++ b/src/components/InlineMarkdown.svelte
@@ -3,7 +3,7 @@
   import { marked } from "marked";
 
   import { renderer } from "@app/lib/markdown";
-  import { twemoji } from "@app/lib/utils";
+  import { escapeHtml, twemoji } from "@app/lib/utils";
 
   export let content: string;
   export let fontSize: "tiny" | "small" | "medium" = "small";
@@ -16,8 +16,9 @@
   });
 
   const render = (content: string): string =>
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    dompurify.sanitize(marked.parseInline(content), { SANITIZE_DOM: false });
+    dompurify.sanitize(marked.parseInline(escapeHtml(content)), {
+      SANITIZE_DOM: false,
+    });
 </script>
 
 <style>

--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -35,8 +35,9 @@
   let container: HTMLElement;
 
   const render = (content: string): string =>
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    dompurify.sanitize(marked.parse(content), { SANITIZE_DOM: false });
+    dompurify.sanitize(marked.parse(utils.escapeHtml(content)), {
+      SANITIZE_DOM: false,
+    });
 
   function navigateToMarkdownLink(event: any) {
     if (event.target.matches(".file-link")) {

--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -36,6 +36,7 @@
 
   const render = (content: string): string =>
     dompurify.sanitize(marked.parse(utils.escapeHtml(content)), {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       SANITIZE_DOM: false,
     });
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -294,3 +294,7 @@ export function formatObjectId(id: string): string {
 export function stripDidPrefix(array: string[]): string[] {
   return array.map(id => id.replace("did:key:", ""));
 }
+
+export function escapeHtml(input: string): string {
+  return input.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/tests/support/fixtures.ts
+++ b/tests/support/fixtures.ts
@@ -365,7 +365,10 @@ export async function createCobsFixture(peer: RadiclePeer) {
     "Add README\n\nThis commit adds more information to the README",
     "feature/add-readme",
     () => Fs.writeFile(Path.join(projectFolder, "README.md"), "# Cobs Repo"),
-    ["Let's add a README", "This repo needed a README"],
+    [
+      "Let's add a README",
+      "This repo needed a README, let's check that <RID> and <OID> get rendered",
+    ],
     { cwd: projectFolder },
   );
   await peer.rad(


### PR DESCRIPTION
Ok this PR escapes `<` and `>` before passing it through the sanitizer, this way we allow values like `<RID>` and `<OID>` to show up in the rendered output

Closes #831 