### PR TITLE
Separate commit listing from revision timeline

### DIFF
--- a/src/components/Comment.svelte
+++ b/src/components/Comment.svelte
@@ -26,7 +26,7 @@
   .card {
     display: flex;
     flex-direction: column;
-    border-radius: var(--border-radius);
+    border-radius: inherit;
     background-color: inherit;
   }
   .card-header {
@@ -38,7 +38,7 @@
   }
   .card-body {
     font-size: var(--font-size-small);
-    padding: 0 1rem 0.5rem 1rem;
+    padding: 0 1rem 0.7rem 1rem;
   }
   .actions {
     display: flex;

--- a/src/components/Link.svelte
+++ b/src/components/Link.svelte
@@ -5,6 +5,7 @@
   import { push, routeToPath, useDefaultNavigation } from "@app/lib/router";
 
   export let route: Route;
+  export let title: string | undefined = undefined;
 
   const dispatch = createEventDispatcher<{
     afterNavigate: never;
@@ -21,6 +22,6 @@
   }
 </script>
 
-<a on:click={navigateToRoute} href={routeToPath(route)}>
+<a on:click={navigateToRoute} href={routeToPath(route)} {title}>
   <slot />
 </a>

--- a/src/components/Thread.svelte
+++ b/src/components/Thread.svelte
@@ -57,10 +57,10 @@
   }
   .comment {
     background-color: var(--color-foreground-1);
-    border-radius: var(--border-radius);
+    border-radius: var(--border-radius-small);
   }
   .reply {
-    margin-left: 3rem;
+    margin-left: 1.5rem;
   }
   .actions {
     display: flex;
@@ -89,6 +89,7 @@
         id={reply.id}
         authorId={reply.author.id}
         authorAlias={reply.author.alias}
+        caption="replied"
         timestamp={reply.timestamp}
         body={reply.body} />
     </div>

--- a/src/views/projects/Cob/Revision.svelte
+++ b/src/views/projects/Cob/Revision.svelte
@@ -19,7 +19,7 @@
   import Icon from "@app/components/Icon.svelte";
   import InlineMarkdown from "@app/components/InlineMarkdown.svelte";
   import Markdown from "@app/components/Markdown.svelte";
-  import ProjectLink from "@app/components/ProjectLink.svelte";
+  import Link from "@app/components/Link.svelte";
   import Thread from "@app/components/Thread.svelte";
 
   export let baseUrl: BaseUrl;
@@ -194,15 +194,26 @@
           <DiffStatBadge {insertions} {deletions} />
         {/if}
         {#if previousRevOid}
-          <ProjectLink
+          <Link
             title="Compare {utils.formatObjectId(
               previousRevOid,
             )}..{utils.formatObjectId(revisionOid)}"
-            projectParams={{
-              search: `diff=${previousRevOid}..${revisionOid}`,
+            route={{
+              resource: "projects",
+              params: {
+                id: projectId,
+                baseUrl,
+                view: {
+                  resource: "patch",
+                  params: {
+                    patch: patchId,
+                    search: `diff=${previousRevOid}..${revisionOid}`,
+                  },
+                },
+              },
             }}>
             <Icon name="diff" />
-          </ProjectLink>
+          </Link>
         {/if}
         <Floating>
           <svelte:fragment slot="toggle">
@@ -214,10 +225,21 @@
                 ? [projectHead, previousRevOid]
                 : [projectHead]}>
               <svelte:fragment slot="item" let:item>
-                <ProjectLink
+                <Link
                   title="{item}..{revisionOid}"
-                  projectParams={{
-                    search: `diff=${item}..${revisionOid}`,
+                  route={{
+                    resource: "projects",
+                    params: {
+                      id: projectId,
+                      baseUrl,
+                      view: {
+                        resource: "patch",
+                        params: {
+                          patch: patchId,
+                          search: `diff=${item}..${revisionOid}`,
+                        },
+                      },
+                    },
                   }}>
                   {#if item === projectHead}
                     <DropdownItem selected={false} size="small">
@@ -232,7 +254,7 @@
                       )})
                     </DropdownItem>
                   {/if}
-                </ProjectLink>
+                </Link>
               </svelte:fragment>
             </Dropdown>
           </svelte:fragment>
@@ -253,7 +275,10 @@
           </div>
         {/if}
         <div class="txt-tiny">
-          <Authorship {authorId} {authorAlias} timestamp={revisionTimestamp}>
+          <Authorship
+            authorId={revisionAuthor.id}
+            authorAlias={revisionAuthor.alias}
+            timestamp={revisionTimestamp}>
             {caption}
           </Authorship>
           {#if response?.commits}
@@ -265,19 +290,22 @@
                     <span class="commit-separator">
                       {i === 0 ? "╎" : "│"}
                     </span>
-                    <Avatar inline nodeId={authorId} />
-                    <ProjectLink
-                      projectParams={{
-                        view: { resource: "commits" },
-                        revision: commit.id,
-                        search: undefined,
+                    <Avatar inline nodeId={revisionAuthor.id} />
+                    <Link
+                      route={{
+                        resource: "projects",
+                        params: {
+                          id: projectId,
+                          baseUrl,
+                          view: { resource: "commits", commitId: commit.id },
+                        },
                       }}>
                       <div class="commit-summary" use:twemoji>
                         <InlineMarkdown
                           content={commit.summary}
                           fontSize="tiny" />
                       </div>
-                    </ProjectLink>
+                    </Link>
                   </span>
                   <span>
                     {utils.formatCommit(commit.id)}

--- a/src/views/projects/Patch.svelte
+++ b/src/views/projects/Patch.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" context="module">
-  import type { Comment, Review, Revision, Merge } from "@httpd-client";
+  import type { Comment, Review, Merge } from "@httpd-client";
 
   interface Thread {
     root: Comment;
@@ -9,12 +9,6 @@
   interface TimelineReview {
     inner: [string, Review];
     type: "review";
-    timestamp: number;
-  }
-
-  interface TimelineRevision {
-    inner: Revision;
-    type: "revision";
     timestamp: number;
   }
 
@@ -30,11 +24,7 @@
     timestamp: number;
   }
 
-  export type Timeline =
-    | TimelineMerge
-    | TimelineReview
-    | TimelineRevision
-    | TimelineThread;
+  export type Timeline = TimelineMerge | TimelineReview | TimelineThread;
 </script>
 
 <script lang="ts">
@@ -165,6 +155,7 @@
         revisionBase: string;
         revisionOid: string;
         revisionAuthor: { id: string; alias?: string | undefined };
+        revisionDescription: string;
       },
       Timeline[],
     ]
@@ -175,6 +166,7 @@
       revisionBase: rev.base,
       revisionOid: rev.oid,
       revisionAuthor: rev.author,
+      revisionDescription: rev.description,
     },
     [
       ...rev.reviews.map<TimelineReview>(review => ({
@@ -201,11 +193,6 @@
               .sort((a, b) => a.timestamp - b.timestamp),
           },
         })),
-      {
-        type: "revision",
-        timestamp: rev.timestamp,
-        inner: rev,
-      } as TimelineRevision,
     ].sort((a, b) => a.timestamp - b.timestamp),
   ]);
 </script>

--- a/tests/e2e/project/patches.spec.ts
+++ b/tests/e2e/project/patches.spec.ts
@@ -8,7 +8,7 @@ test("navigate listing", async ({ page }) => {
   await page.locator('role=link[name="1 merged"]').click();
   await expect(page).toHaveURL(`${cobUrl}/patches?state=merged`);
   await expect(
-    page.locator(".comments").filter({ hasText: "2" }),
+    page.locator(".comments").filter({ hasText: "5" }),
   ).toBeVisible();
 });
 
@@ -52,7 +52,7 @@ test("use revision selector", async ({ page }) => {
   ).toHaveText("Add more text");
 
   // Switching to the initial revision
-  await page.getByText("Revision 5140fb2").click();
+  await page.getByText("Revision 2592b1e").click();
   await expect(page.locator(".dropdown")).toBeVisible();
   await page.getByRole("link", { name: "Revision 0f3697f" }).click();
   await expect(page.locator(".dropdown")).toBeHidden();

--- a/tests/support/fixtures.ts
+++ b/tests/support/fixtures.ts
@@ -430,14 +430,40 @@ export async function createCobsFixture(peer: RadiclePeer) {
     createOptions(projectFolder, 2),
   );
   await peer.rad(
-    ["review", patchOne, "-m", "LGTM", "--accept"],
+    [
+      "comment",
+      patchOne,
+      "--message",
+      "Yeah no problem!",
+      "--reply-to",
+      commentPatchOne,
+    ],
     createOptions(projectFolder, 3),
+  );
+  const { stdout: commentTwo } = await peer.rad(
+    ["comment", patchOne, "--message", "Looking good so far"],
+    createOptions(projectFolder, 4),
+  );
+  await peer.rad(
+    [
+      "comment",
+      patchOne,
+      "--message",
+      "Thanks again!",
+      "--reply-to",
+      commentTwo,
+    ],
+    createOptions(projectFolder, 5),
+  );
+  await peer.rad(
+    ["review", patchOne, "-m", "LGTM", "--accept"],
+    createOptions(projectFolder, 6),
   );
   await patch.merge(
     peer,
     defaultBranch,
     "feature/add-readme",
-    createOptions(projectFolder, 4),
+    createOptions(projectFolder, 7),
   );
 
   const patchTwo = await patch.create(
@@ -482,8 +508,20 @@ export async function createCobsFixture(peer: RadiclePeer) {
   await peer.git(["add", "."], { cwd: projectFolder });
   await peer.git(["commit", "-m", "Add more text"], { cwd: projectFolder });
   await peer.git(
-    ["push", "rad", "feature/better-subtitle"],
+    [
+      "push",
+      "-o",
+      "patch.message=Most of the missing README text was caused by the git-daemon not having a writers block. It seems like using an RNG was not a good enough solution.",
+      "-o",
+      "patch.message=After this change, the README seem to be written correctly",
+      "rad",
+      "feature/better-subtitle",
+    ],
     createOptions(projectFolder, 3),
+  );
+  await peer.rad(
+    ["review", patchThree, "-m", "No this doesn't look better", "--reject"],
+    createOptions(projectFolder, 2),
   );
 
   const patchFour = await patch.create(


### PR DESCRIPTION
Moving the commit listing out of the revision timeline, improves the code somewhat, since the revision object isn't really a revision event like merge, review, etc.

![image](https://github.com/radicle-dev/radicle-interface/assets/7912302/453bfc9e-2726-48e8-aa4a-f73c673ffc04)
