### PR TITLE
Reverse commit ordering in patch revisions

### DIFF
--- a/src/views/projects/Cob/Revision.svelte
+++ b/src/views/projects/Cob/Revision.svelte
@@ -280,7 +280,7 @@
             </Authorship>
             {#if response?.commits}
               <div class="commits txt-tiny">
-                {#each response.commits as commit, i}
+                {#each response.commits.reverse() as commit, i}
                   <div class="commit-event">
                     <span>
                       <span class="commit-pointer">╰─</span>


### PR DESCRIPTION
Current (ordering in reverse list "HEAD on top"):
<img width="683" src="https://github.com/radicle-dev/radicle-interface/assets/7912302/6a80e2f1-6150-452b-a65b-5fd548d3ad72">

New (ordering from merge base on the top to HEAD bottom):
<img width="683" alt="Bildschirmfoto 2023-06-22 um 15 42 31" src="https://github.com/radicle-dev/radicle-interface/assets/7912302/15e88c99-cac4-4bb7-baa6-e0bbea1cd1aa">
