### PR TITLE
Expand browser tree when navigation through relative file links

### DIFF
--- a/src/views/projects/Tree/Folder.svelte
+++ b/src/views/projects/Tree/Folder.svelte
@@ -15,8 +15,8 @@
   export let loadingPath: string | null = null;
   export let revision: string;
 
-  let expanded = currentPath.indexOf(prefix) === 0;
-  let tree: Promise<Tree | undefined> = expanded
+  $: expanded = currentPath.indexOf(prefix) === 0;
+  $: tree = expanded
     ? fetchTree(prefix).then(tree => {
         return tree;
       })


### PR DESCRIPTION
The `expanded` and the `tree` variable should react to changes to the `currentPath`

Closes #862 