### PR TITLE
tests: Bring FakeTimers into the present

### DIFF
--- a/tests/e2e/project/commit.spec.ts
+++ b/tests/e2e/project/commit.spec.ts
@@ -25,7 +25,7 @@ test("relative timestamps", async ({ page }) => {
   await page.addInitScript(() => {
     window.initializeTestStubs = () => {
       window.e2eTestStubs.FakeTimers.install({
-        now: new Date("December 21 2022 12:00:00").valueOf(),
+        now: new Date("January 21 2023 12:00:00").valueOf(),
         shouldClearNativeTimers: true,
         shouldAdvanceTime: false,
       });
@@ -33,7 +33,9 @@ test("relative timestamps", async ({ page }) => {
   });
   await page.goto(modifiedFileFixture);
   await expect(
-    page.locator(`.commit .header >> text=${"Bob Belcher committed now"}`),
+    page.locator(
+      `.commit .header >> text=${"Bob Belcher committed last month"}`,
+    ),
   ).toBeVisible();
 });
 

--- a/tests/e2e/project/commits.spec.ts
+++ b/tests/e2e/project/commits.spec.ts
@@ -91,7 +91,7 @@ test("relative timestamps", async ({ page }) => {
   await page.addInitScript(() => {
     window.initializeTestStubs = () => {
       window.e2eTestStubs.FakeTimers.install({
-        now: new Date("December 21 2022 12:00:00").valueOf(),
+        now: new Date("January 21 2023 12:00:00").valueOf(),
         shouldClearNativeTimers: true,
         shouldAdvanceTime: false,
       });
@@ -107,11 +107,11 @@ test("relative timestamps", async ({ page }) => {
     `did:key:${bobRemote.substring(8).substring(0, 6)}…${bobRemote.slice(-6)}`,
   );
   const latestCommit = page.locator(".teaser").first();
-  await expect(latestCommit).toContainText("Bob Belcher committed now");
+  await expect(latestCommit).toContainText("Bob Belcher committed last month");
   await expect(latestCommit).toContainText("28f3710");
   const earliestCommit = page.locator(".teaser").last();
   await expect(earliestCommit).toContainText(
-    "Alice Liddell committed last month",
+    "Alice Liddell committed 2 months ago",
   );
 });
 

--- a/tests/visual/cob.spec.ts
+++ b/tests/visual/cob.spec.ts
@@ -4,7 +4,7 @@ test.beforeEach(async ({ page }) => {
   await page.addInitScript(() => {
     window.initializeTestStubs = () => {
       window.e2eTestStubs.FakeTimers.install({
-        now: new Date("November 24 2022 12:00:00").valueOf(),
+        now: new Date("January 21 2023 12:00:00").valueOf(),
         shouldClearNativeTimers: true,
         shouldAdvanceTime: false,
       });

--- a/tests/visual/landingPage.spec.ts
+++ b/tests/visual/landingPage.spec.ts
@@ -8,7 +8,7 @@ test("landing page", async ({ page }) => {
   await page.addInitScript(() => {
     window.initializeTestStubs = () => {
       window.e2eTestStubs.FakeTimers.install({
-        now: new Date("November 24 2022 12:00:00").valueOf(),
+        now: new Date("January 21 2023 12:00:00").valueOf(),
         shouldClearNativeTimers: true,
         shouldAdvanceTime: false,
       });

--- a/tests/visual/project.spec.ts
+++ b/tests/visual/project.spec.ts
@@ -14,7 +14,7 @@ test("commits page", async ({ page }) => {
   await page.addInitScript(() => {
     window.initializeTestStubs = () => {
       window.e2eTestStubs.FakeTimers.install({
-        now: new Date("November 24 2022 12:00:00").valueOf(),
+        now: new Date("January 21 2023 12:00:00").valueOf(),
         shouldClearNativeTimers: true,
         shouldAdvanceTime: false,
       });
@@ -35,7 +35,7 @@ test("commit page", async ({ page }) => {
   await page.addInitScript(() => {
     window.initializeTestStubs = () => {
       window.e2eTestStubs.FakeTimers.install({
-        now: new Date("November 24 2022 12:00:00").valueOf(),
+        now: new Date("January 21 2023 12:00:00").valueOf(),
         shouldClearNativeTimers: true,
         shouldAdvanceTime: false,
       });

--- a/tests/visual/seed.spec.ts
+++ b/tests/visual/seed.spec.ts
@@ -4,7 +4,7 @@ test("seed page", async ({ page }) => {
   await page.addInitScript(() => {
     window.initializeTestStubs = () => {
       window.e2eTestStubs.FakeTimers.install({
-        now: new Date("November 24 2022 12:00:00").valueOf(),
+        now: new Date("January 21 2023 12:00:00").valueOf(),
         shouldClearNativeTimers: true,
         shouldAdvanceTime: false,
       });


### PR DESCRIPTION
Okay I'm not sure if this fixes it, but this PR is still needed, we were faking a time that was before any commits, patches or issues would have been created..
So let's go back to the future 😅 

- Forwards the fakeTimer to January 21 2023 12:00:00

Refs #851 