### PR TITLE
Fix codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-* @cloudhead
-* @rudolfs


### PR DESCRIPTION
By having a two matches for CODEOWNERS first @cloudhead and then @rudolfs, the pattern matches only the last mentioned code owner.

> If you want to match two or more code owners with the same pattern, all the code owners must be on the same line. If the code owners are not on the same line, the pattern matches only the last mentioned code owner.

source: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax

UPDATE: As talked with @cloudhead I removed the CODEOWNERS file since we match all files it isn't really useful.