### PR TITLE
Fix flaky seed listing

### DIFF
--- a/tests/visual/seed.spec.ts
+++ b/tests/visual/seed.spec.ts
@@ -1,3 +1,4 @@
+import type { Project } from "@httpd-client";
 import { test, expect } from "@tests/support/fixtures.js";
 
 test("seed page", async ({ page }) => {
@@ -9,6 +10,22 @@ test("seed page", async ({ page }) => {
         shouldAdvanceTime: false,
       });
     };
+  });
+
+  // Repos in heartwood are read from storage with `fs::read_dir`
+  // which has no deterministic ordering, it depends on
+  // the filesystem and the operating system.
+  //
+  // > The order in which this iterator returns entries is platform and filesystem dependent.
+  // source: https://doc.rust-lang.org/std/fs/fn.read_dir.html
+  //
+  // So we sort the request here, to get a visually persistent listing.
+  // TODO: If at some point project sorting is introduced we can probably remove this.
+  await page.route("**/api/v1/projects?page=0&perPage=10", async route => {
+    const response = await route.fetch();
+    const json: Project[] = await response.json();
+    json.sort((a, b) => a.name.localeCompare(b.name));
+    await route.fulfill({ response, json });
   });
 
   await page.goto("/seeds/radicle.local", { waitUntil: "networkidle" });


### PR DESCRIPTION
Mocking seed project listing route, and sorting projects by `localeCompare`.
This should return projects always in the same order.

Since in production we aren't sorting projects yet, and don't show much information that requires us to sort them, I think this is more a test issue, that doesn't allow us to have a deterministic ordering of projects.
If at some point project sorting is introduced we can probably revert this PR