### PR TITLE
Add `<details>` and `<summary>` and comments to trusted tags

### DIFF
--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -190,6 +190,10 @@
     margin-bottom: 0;
   }
 
+  .markdown :global(details) {
+    margin-bottom: 0.625rem;
+  }
+
   .markdown :global(blockquote) {
     color: var(--color-foreground-6);
     border-left: 0.3rem solid var(--color-foreground-4);


### PR DESCRIPTION
This PR fixes #883 also handles codespans and code blocks inside of trusted html tags.