### PR TITLE
Tests automatically use heartwood binaries from local test folder

### DIFF
--- a/.github/workflows/check-e2e.yml
+++ b/.github/workflows/check-e2e.yml
@@ -40,7 +40,6 @@ jobs:
         run: |
           mkdir -p tests/artifacts;
           ./scripts/install-binaries;
-          ./scripts/install-binaries --show-path >> $GITHUB_PATH;
 
       - name: Run Playwright tests
         run: |

--- a/scripts/install-binaries
+++ b/scripts/install-binaries
@@ -69,24 +69,4 @@ do
   fi
 done
 
-RADICLE_HOME=${RAD_HOME:-"${HOME}/.radicle/bin"}
-
-# Add a separator between binaries download and PATH instructions.
 echo
-
-if [[ ":$PATH:" != *":$BINARY_PATH:"* ]]; then
-  if [[ ":$PATH:" == *":$RADICLE_HOME:"* ]]; then
-    echo "⚠️  You already have a radicle bin folder in your PATH variable."
-    echo
-    echo "To ensure you are using the correct test binaries, run the following command:"
-  else
-    echo "Before running the tests, make sure your PATH variable is set up correctly by running:"
-  fi
-
-  echo " 👉 export PATH=$BINARY_PATH:\$PATH"
-
-else
-  echo "✅ $BINARY_PATH is already in your PATH variable."
-fi
-
-

--- a/tests/support/fixtures.ts
+++ b/tests/support/fixtures.ts
@@ -5,24 +5,19 @@ import type { PeerManager, RadiclePeer } from "./peerManager.js";
 import * as Fs from "node:fs/promises";
 import * as FsSync from "node:fs";
 import * as Path from "node:path";
-import { dirname } from "node:path";
-import { fileURLToPath } from "node:url";
 import { test as base, expect, type ViewportSize } from "@playwright/test";
 
 import * as Process from "./process.js";
 import * as issue from "@tests/support/cobs/issue.js";
 import * as logLabel from "@tests/support/logLabel.js";
 import * as patch from "@tests/support/cobs/patch.js";
-import { createOptions } from "@tests/support/support.js";
+import { createOptions, supportDir, tmpDir } from "@tests/support/support.js";
 import { createPeerManager } from "@tests/support/peerManager.js";
 import { createProject } from "@tests/support/project.js";
 
 export { expect };
 
-const filename = fileURLToPath(import.meta.url);
-export const supportDir = dirname(filename);
-export const tmpDir = Path.resolve(supportDir, "..", "./tmp");
-export const fixturesDir = Path.resolve(supportDir, "..", "./fixtures");
+const fixturesDir = Path.resolve(supportDir, "..", "./fixtures");
 
 type ViewportTypes = "iPhoneXR" | "Desktop";
 

--- a/tests/support/globalSetup.ts
+++ b/tests/support/globalSetup.ts
@@ -12,10 +12,9 @@ import {
   createSourceBrowsingFixture,
   gitOptions,
   startPalmHttpd,
-  supportDir,
-  tmpDir,
 } from "@tests/support/fixtures.js";
 import { createPeerManager } from "@tests/support/peerManager.js";
+import { heartwoodShortSha, tmpDir } from "./support";
 
 const workspacePaths = [Path.join(tmpDir, "peers"), Path.join(tmpDir, "repos")];
 
@@ -69,13 +68,10 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
 
 // Assert that the `rad` CLI is installed and has the correct version.
 async function assertRadInstalled(): Promise<void> {
-  const versionConstraint = (
-    await Fs.readFile(`${supportDir}/heartwood-version`, "utf8")
-  ).substring(0, 7);
   const { stdout: version } = await execa("rad", ["--version"]);
-  if (!version.includes(versionConstraint)) {
+  if (!version.includes(heartwoodShortSha)) {
     throw new Error(
-      `rad version ${version} does not satisfy ${versionConstraint}`,
+      `rad version ${version} does not satisfy ${heartwoodShortSha}`,
     );
   }
 }

--- a/tests/support/support.ts
+++ b/tests/support/support.ts
@@ -1,5 +1,8 @@
 import type { Options } from "execa";
 import * as Crypto from "node:crypto";
+import { fileURLToPath } from "node:url";
+import * as Path from "node:path";
+import * as Fs from "node:fs/promises";
 
 // Generate string of 12 random characters with 8 bits of entropy.
 export function randomTag(): string {
@@ -13,3 +16,17 @@ export function createOptions(projectFolder: string, days: number): Options {
     env: { RAD_COMMIT_TIME: (1671211684 + days * 86400).toString() },
   };
 }
+
+const filename = fileURLToPath(import.meta.url);
+export const supportDir = Path.dirname(filename);
+export const tmpDir = Path.resolve(supportDir, "..", "./tmp");
+export const fixturesDir = Path.resolve(supportDir, "..", "./fixtures");
+
+export const heartwoodShortSha = (
+  await Fs.readFile(`${supportDir}/heartwood-version`, "utf8")
+).substring(0, 7);
+
+process.env.PATH = [
+  Path.join(tmpDir, "bin", heartwoodShortSha),
+  process.env.PATH,
+].join(Path.delimiter);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
   "exclude": ["node_modules/*"],
   "compilerOptions": {
     "target": "es2020",
-    "module": "es2020",
+    "module": "es2022",
     "types": ["vite/client"],
     "sourceMap": true,
     "baseUrl": "./",


### PR DESCRIPTION
It’s not necessary anymore to add the folder with the heartwood test binaries to `PATH` before running the end-to-end tests.