### PR TITLE
Clean up project view props

### DIFF
--- a/src/App/Header/Search.svelte
+++ b/src/App/Header/Search.svelte
@@ -56,7 +56,6 @@
             peer: undefined,
             baseUrl,
             hash: undefined,
-            search: undefined,
           },
         });
       } else {

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -264,9 +264,6 @@ export function routeToPath(route: Route): string {
       }
     }
 
-    if (route.params.search) {
-      suffix += `?${route.params.search}`;
-    }
     if (route.params.hash) {
       suffix += `#${route.params.hash}`;
     }
@@ -286,12 +283,21 @@ export function routeToPath(route: Route): string {
     ) {
       return `${seed}/${route.params.id}${peer}/issues/new${suffix}`;
     } else if (route.params.view.resource === "issues") {
+      if (route.params.view.params.search) {
+        suffix += `?${route.params.view.params.search}`;
+      }
       return `${seed}/${route.params.id}${peer}/issues${suffix}`;
     } else if (route.params.view.resource === "issue") {
       return `${seed}/${route.params.id}${peer}/issues/${route.params.view.params.issue}`;
     } else if (route.params.view.resource === "patches") {
+      if (route.params.view.params.search) {
+        suffix += `?${route.params.view.params.search}`;
+      }
       return `${seed}/${route.params.id}${peer}/patches${suffix}`;
     } else if (route.params.view.resource === "patch") {
+      if (route.params.view.params.search) {
+        suffix += `?${route.params.view.params.search}`;
+      }
       if (route.params.view.params.revision) {
         return `${seed}/${route.params.id}${peer}/patches/${route.params.view.params.patch}/${route.params.view.params.revision}${suffix}`;
       }

--- a/src/views/projects/Cob/Revision.svelte
+++ b/src/views/projects/Cob/Revision.svelte
@@ -212,7 +212,13 @@
             previousRevOid,
           )}..{utils.formatObjectId(revisionOid)}"
           projectParams={{
-            search: `diff=${previousRevOid}..${revisionOid}`,
+            view: {
+              resource: "patch",
+              params: {
+                patch: patchId,
+                search: `diff=${previousRevOid}..${revisionOid}`,
+              },
+            },
           }}>
           <Icon name="diff" />
         </ProjectLink>
@@ -230,7 +236,13 @@
               <ProjectLink
                 title="{item}..{revisionOid}"
                 projectParams={{
-                  search: `diff=${item}..${revisionOid}`,
+                  view: {
+                    resource: "patch",
+                    params: {
+                      patch: patchId,
+                      search: `diff=${item}..${revisionOid}`,
+                    },
+                  },
                 }}>
                 {#if item === projectHead}
                   <DropdownItem selected={false} size="small">
@@ -292,7 +304,6 @@
                         projectParams={{
                           view: { resource: "commits" },
                           revision: commit.id,
-                          search: undefined,
                         }}>
                         <div class="commit-summary" use:twemoji>
                           <InlineMarkdown

--- a/src/views/projects/Commit/CommitTeaser.svelte
+++ b/src/views/projects/Commit/CommitTeaser.svelte
@@ -98,7 +98,6 @@
         projectParams={{
           view: { resource: "commits" },
           revision: commit.id,
-          search: undefined,
         }}>
         <div class="summary" use:twemoji>
           <InlineMarkdown content={commit.summary} />

--- a/src/views/projects/Header.svelte
+++ b/src/views/projects/Header.svelte
@@ -65,6 +65,7 @@
       id: projectId,
       view: {
         resource: "issues",
+        params: { view: { resource: "list" } },
       },
       peer: undefined,
       search: undefined,
@@ -86,6 +87,7 @@
       id: projectId,
       view: {
         resource: "patches",
+        params: { view: { resource: "list" } },
       },
       peer: undefined,
       search: undefined,

--- a/src/views/projects/Header.svelte
+++ b/src/views/projects/Header.svelte
@@ -68,7 +68,6 @@
         params: { view: { resource: "list" } },
       },
       peer: undefined,
-      search: undefined,
       revision: undefined,
       path: undefined,
     }}>
@@ -90,7 +89,6 @@
         params: { view: { resource: "list" } },
       },
       peer: undefined,
-      search: undefined,
       revision: undefined,
       path: undefined,
     }}>

--- a/src/views/projects/Issues.svelte
+++ b/src/views/projects/Issues.svelte
@@ -120,7 +120,13 @@
           {#if !option.disabled}
             <ProjectLink
               projectParams={{
-                search: `state=${option.value}`,
+                view: {
+                  resource: "issues",
+                  params: {
+                    view: { resource: "list" },
+                    search: `state=${option.value}`,
+                  },
+                },
               }}>
               <SquareButton
                 clickable={option.disabled}

--- a/src/views/projects/Patch.svelte
+++ b/src/views/projects/Patch.svelte
@@ -338,7 +338,14 @@
           {#if !option.disabled}
             <ProjectLink
               projectParams={{
-                search: `tab=${option.value}`,
+                view: {
+                  resource: "patch",
+                  params: {
+                    patch: patch.id,
+                    revision,
+                    search: `tab=${option.value}`,
+                  },
+                },
               }}>
               <SquareButton
                 size="small"
@@ -361,7 +368,13 @@
         {#if diff}
           <ProjectLink
             projectParams={{
-              search: `diff=${diff}`,
+              view: {
+                resource: "patch",
+                params: {
+                  patch: patch.id,
+                  search: `diff=${diff}`,
+                },
+              },
             }}>
             <SquareButton size="small" active={true}>
               Diff {diff.substr(0, 6)}..{diff.split("..")[1].substr(0, 6)}
@@ -388,9 +401,12 @@
                   projectParams={{
                     view: {
                       resource: "patch",
-                      params: { patch: patch.id, revision: item.id },
+                      params: {
+                        patch: patch.id,
+                        revision: item.id,
+                        search: `tab=${currentTab}`,
+                      },
                     },
-                    search: `tab=${currentTab}`,
                   }}>
                   <DropdownItem
                     selected={item.id === currentRevision.id}

--- a/src/views/projects/Patches.svelte
+++ b/src/views/projects/Patches.svelte
@@ -122,7 +122,13 @@
         {:else}
           <ProjectLink
             projectParams={{
-              search: `state=${option.value}`,
+              view: {
+                resource: "patches",
+                params: {
+                  view: { resource: "list" },
+                  search: `state=${option.value}`,
+                },
+              },
             }}>
             <SquareButton
               clickable={option.disabled}

--- a/src/views/projects/SourceBrowser/FileDiff.svelte
+++ b/src/views/projects/SourceBrowser/FileDiff.svelte
@@ -175,7 +175,6 @@
           view: { resource: "tree" },
           path: file.path,
           revision,
-          search: undefined,
         }}>
         <Icon name="browse" />
       </ProjectLink>

--- a/src/views/projects/SourceBrowser/FileLocationChange.svelte
+++ b/src/views/projects/SourceBrowser/FileLocationChange.svelte
@@ -54,7 +54,6 @@
           view: { resource: "tree" },
           path: file.newPath,
           revision,
-          search: undefined,
         }}>
         <Icon name="browse" />
       </ProjectLink>

--- a/src/views/projects/SourceBrowsingHeader.svelte
+++ b/src/views/projects/SourceBrowsingHeader.svelte
@@ -61,7 +61,6 @@
         resource: "history",
       },
       revision,
-      search: undefined,
     }}>
     <SquareButton
       active={view.resource === "history" || view.resource === "commits"}>

--- a/src/views/projects/View.svelte
+++ b/src/views/projects/View.svelte
@@ -90,10 +90,18 @@
     {:else if view.resource === "commits"}
       <Commit commit={view.commit} />
     {/if}
-  {:else if view.resource === "issues" && view.params?.view.resource === "new"}
-    <NewIssue projectId={id} projectHead={project.head} {baseUrl} />
   {:else if view.resource === "issues"}
-    <Issues {baseUrl} projectId={id} issueCounters={project.issues} {search} />
+    {#if view.params.view.resource === "new"}
+      <NewIssue projectId={id} projectHead={project.head} {baseUrl} />
+    {:else if view.params.view.resource === "list"}
+      <Issues
+        {baseUrl}
+        projectId={id}
+        issueCounters={project.issues}
+        {search} />
+    {:else}
+      {unreachable(view.params.view.resource)}
+    {/if}
   {:else if view.resource === "issue"}
     <Issue
       projectId={id}

--- a/src/views/projects/View.svelte
+++ b/src/views/projects/View.svelte
@@ -25,7 +25,6 @@
   export let hash: string | undefined = undefined;
   export let peer: string | undefined = undefined;
   export let revision: string | undefined = undefined;
-  export let search: string | undefined = undefined;
 </script>
 
 <style>
@@ -98,7 +97,7 @@
         {baseUrl}
         projectId={id}
         issueCounters={project.issues}
-        {search} />
+        search={view.params.search} />
     {:else}
       {unreachable(view.params.view.resource)}
     {/if}
@@ -113,7 +112,7 @@
       {baseUrl}
       projectId={id}
       patchCounters={project.patches}
-      {search} />
+      search={view.params.search} />
   {:else if view.resource === "patch"}
     <Patch
       patch={view.params.loadedPatch}
@@ -122,7 +121,7 @@
       projectDefaultBranch={project.defaultBranch}
       projectHead={project.head}
       revision={view.params.revision}
-      {search} />
+      search={view.params.search} />
   {:else}
     {unreachable(view)}
   {/if}

--- a/src/views/projects/router.ts
+++ b/src/views/projects/router.ts
@@ -62,7 +62,6 @@ export interface ProjectsParams {
   peer?: string;
   revision?: string;
   route?: string;
-  search?: string;
 }
 
 export interface ProjectLoadedParams {
@@ -471,7 +470,6 @@ export function createProjectRoute(
     params: {
       ...activeRoute.params,
       hash: undefined,
-      search: undefined,
       ...projectRouteParams,
     },
   };
@@ -533,7 +531,6 @@ export function resolveProjectRoute(
       peer,
       path: undefined,
       revision: undefined,
-      search: undefined,
       hash: hash?.substring(1),
       route: segments.join("/"),
     };
@@ -545,7 +542,6 @@ export function resolveProjectRoute(
       peer,
       path: undefined,
       revision: undefined,
-      search: undefined,
       route: segments.join("/"),
     };
   } else if (content === "commits") {
@@ -556,7 +552,6 @@ export function resolveProjectRoute(
       peer,
       path: undefined,
       revision: undefined,
-      search: undefined,
       route: segments.join("/"),
     };
   } else if (content === "issues") {
@@ -573,7 +568,6 @@ export function resolveProjectRoute(
         baseUrl,
         id,
         peer,
-        search: sanitizeQueryString(url.search),
         path: undefined,
         revision: undefined,
       };
@@ -585,7 +579,6 @@ export function resolveProjectRoute(
         peer,
         path: undefined,
         revision: undefined,
-        search: undefined,
       };
     } else {
       return {
@@ -599,7 +592,6 @@ export function resolveProjectRoute(
         baseUrl,
         id,
         peer,
-        search: sanitizeQueryString(url.search),
         path: undefined,
         revision: undefined,
       };
@@ -618,7 +610,6 @@ export function resolveProjectRoute(
         peer,
         path: undefined,
         revision: undefined,
-        search: sanitizeQueryString(url.search),
       };
     } else {
       return {
@@ -632,7 +623,6 @@ export function resolveProjectRoute(
         baseUrl,
         id,
         peer,
-        search: sanitizeQueryString(url.search),
         path: undefined,
         revision: undefined,
       };

--- a/src/views/seeds/View.svelte
+++ b/src/views/seeds/View.svelte
@@ -132,9 +132,6 @@
                 view: { resource: "tree" },
                 id: project.id,
                 baseUrl,
-                revision: undefined,
-                hash: undefined,
-                search: undefined,
               },
             }}>
             <ProjectCard


### PR DESCRIPTION
We pass down props only where it's needed.

TBD remove the following props from the top-level `ProjectsParams` and `ProjectLoadedParams` types:

```
  hash?: string;
  path?: string;
  peer?: string;
  revision?: string;
  route?: string;
  search?: string;
```