### PR TITLE
Remove hack for `happy-dom`

### DIFF
--- a/tests/support/setupVitest.ts
+++ b/tests/support/setupVitest.ts
@@ -1,9 +1,0 @@
-// Found in https://github.com/belgattitude/nextjs-monorepo-example/pull/2913
-// Hack for vitest 0.25.2 / happy-dom. Keep till those issues are fixed
-// - https://github.com/vitest-dev/vitest/issues/2305#issuecomment-1311420462
-// - https://github.com/capricorn86/happy-dom/issues/569
-
-import { URL } from "node:url";
-//@ts-expect-error The two types don't match, but for this hack we have to
-//overwrite the given URL by happy-dom with the URL class passed by Node
-globalThis.URL = URL;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,6 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 
 export default defineConfig({
   test: {
-    setupFiles: "./tests/support/setupVitest",
     environment: "happy-dom",
     include: ["tests/unit/**/*.test.ts"],
     reporters: "verbose",


### PR DESCRIPTION
The update to happy-dom 8.0 did remove the need to do the assignment hack in `setupVitest`

source: https://github.com/vitest-dev/vitest/issues/2305#issuecomment-1396387954