### PR TITLE
Test that route building and parsing leave routes invariant

### DIFF
--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -12,6 +12,8 @@ import {
 } from "@app/views/projects/router";
 import { loadRoute } from "@app/lib/router/definitions";
 
+export { type Route };
+
 // Only used by Safari.
 const DOCUMENT_TITLE = "Radicle Interface";
 
@@ -227,7 +229,7 @@ function seedPath(baseUrl: BaseUrl) {
   }
 }
 
-export function routeToPath(route: Route) {
+export function routeToPath(route: Route): string {
   if (route.resource === "home") {
     return "/";
   } else if (route.resource === "session") {
@@ -302,7 +304,7 @@ export function routeToPath(route: Route) {
   } else if (route.resource === "notFound") {
     return route.params.url;
   } else {
-    utils.unreachable(route);
+    return utils.unreachable(route);
   }
 }
 


### PR DESCRIPTION
We replace the tests for `routeToPath` with a test that calls `pathToRoute(routeToPath(route))`. These test do not only cover the assertions of the previous tests but also check an important invariant for route parsing and building.

I’m not using `test.each` here because this makes the tests less readable.