### PR TITLE
Use dedicated `commitId` parameter for commits route

### DIFF
--- a/src/components/ProjectLink.svelte
+++ b/src/components/ProjectLink.svelte
@@ -8,7 +8,9 @@
     updateProjectRoute,
   } from "@app/views/projects/router";
 
-  export let projectParams: Partial<ProjectsParams>;
+  export let projectParams: Partial<
+    Omit<ProjectsParams, "id" | "route" | "hash">
+  >;
   export let title: string | undefined = undefined;
 
   const dispatch = createEventDispatcher<{ click: never }>();

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -253,7 +253,6 @@ export function routeToPath(route: Route): string {
     } else {
       if (
         (route.params.view.resource === "tree" ||
-          route.params.view.resource === "commits" ||
           route.params.view.resource === "history") &&
         route.params.revision
       ) {
@@ -274,7 +273,7 @@ export function routeToPath(route: Route): string {
       }
       return `${seed}/${route.params.id}${peer}`;
     } else if (route.params.view.resource === "commits") {
-      return `${seed}/${route.params.id}${peer}/commits${suffix}`;
+      return `${seed}/${route.params.id}${peer}/commits/${route.params.view.commitId}`;
     } else if (route.params.view.resource === "history") {
       return `${seed}/${route.params.id}${peer}/history${suffix}`;
     } else if (

--- a/src/views/projects/Cob/Revision.svelte
+++ b/src/views/projects/Cob/Revision.svelte
@@ -302,8 +302,7 @@
                       <Avatar inline nodeId={authorId} />
                       <ProjectLink
                         projectParams={{
-                          view: { resource: "commits" },
-                          revision: commit.id,
+                          view: { resource: "commits", commitId: commit.id },
                         }}>
                         <div class="commit-summary" use:twemoji>
                           <InlineMarkdown

--- a/src/views/projects/Commit/CommitTeaser.svelte
+++ b/src/views/projects/Commit/CommitTeaser.svelte
@@ -96,8 +96,7 @@
     <div class="message">
       <ProjectLink
         projectParams={{
-          view: { resource: "commits" },
-          revision: commit.id,
+          view: { resource: "commits", commitId: commit.id },
         }}>
         <div class="summary" use:twemoji>
           <InlineMarkdown content={commit.summary} />

--- a/src/views/projects/Header.svelte
+++ b/src/views/projects/Header.svelte
@@ -8,7 +8,6 @@
   import CloneButton from "@app/views/projects/CloneButton.svelte";
   import Icon from "@app/components/Icon.svelte";
   import Link from "@app/components/Link.svelte";
-  import ProjectLink from "@app/components/ProjectLink.svelte";
   import SquareButton from "@app/components/SquareButton.svelte";
 
   export let view: ProjectLoadedView;
@@ -42,13 +41,15 @@
 </style>
 
 <div class="header">
-  <ProjectLink
-    projectParams={{
-      view: { resource: "tree" },
-      path: "/",
-      peer: undefined,
-      route: undefined,
-      revision: undefined,
+  <Link
+    route={{
+      resource: "projects",
+      params: {
+        id: projectId,
+        baseUrl,
+        view: { resource: "tree" },
+        path: "/",
+      },
     }}>
     <SquareButton
       active={view.resource === "tree" ||
@@ -59,17 +60,18 @@
       </svelte:fragment>
       Source
     </SquareButton>
-  </ProjectLink>
-  <ProjectLink
-    projectParams={{
-      id: projectId,
-      view: {
-        resource: "issues",
-        params: { view: { resource: "list" } },
+  </Link>
+  <Link
+    route={{
+      resource: "projects",
+      params: {
+        id: projectId,
+        baseUrl,
+        view: {
+          resource: "issues",
+          params: { view: { resource: "list" } },
+        },
       },
-      peer: undefined,
-      revision: undefined,
-      path: undefined,
     }}>
     <SquareButton
       active={view.resource === "issues" || view.resource === "issue"}>
@@ -79,18 +81,19 @@
       <span class="txt-bold">{openIssueCount}</span>
       {pluralize("issue", openIssueCount)}
     </SquareButton>
-  </ProjectLink>
+  </Link>
 
-  <ProjectLink
-    projectParams={{
-      id: projectId,
-      view: {
-        resource: "patches",
-        params: { view: { resource: "list" } },
+  <Link
+    route={{
+      resource: "projects",
+      params: {
+        id: projectId,
+        baseUrl,
+        view: {
+          resource: "patches",
+          params: { view: { resource: "list" } },
+        },
       },
-      peer: undefined,
-      revision: undefined,
-      path: undefined,
     }}>
     <SquareButton
       active={view.resource === "patches" || view.resource === "patch"}>
@@ -100,7 +103,7 @@
       <span class="txt-bold">{openPatchCount}</span>
       {pluralize("patch", openPatchCount)}
     </SquareButton>
-  </ProjectLink>
+  </Link>
   <CloneButton {baseUrl} id={projectId} name={projectName} />
 
   <Link

--- a/src/views/projects/ProjectMeta.svelte
+++ b/src/views/projects/ProjectMeta.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
+  import type { BaseUrl } from "@httpd-client";
+
   import Clipboard from "@app/components/Clipboard.svelte";
   import dompurify from "dompurify";
-  import ProjectLink from "@app/components/ProjectLink.svelte";
+  import Link from "@app/components/Link.svelte";
   import { formatNodeId, twemoji } from "@app/lib/utils";
 
+  export let baseUrl: BaseUrl;
   export let nodeId: string | undefined = undefined;
   export let projectDescription: string;
   export let projectId: string;
@@ -84,18 +87,20 @@
 <header class="content">
   <div class="title">
     <span class="truncate">
-      <ProjectLink
-        projectParams={{
-          view: { resource: "tree" },
-          path: "/",
-          peer: undefined,
-          route: undefined,
-          revision: undefined,
+      <Link
+        route={{
+          resource: "projects",
+          params: {
+            id: projectId,
+            baseUrl,
+            view: { resource: "tree" },
+            path: "/",
+          },
         }}>
         <span class="project-name">
           {projectName}
         </span>
-      </ProjectLink>
+      </Link>
     </span>
     {#if nodeId}
       <span class="node-id">

--- a/src/views/projects/SourceBrowsingHeader.svelte
+++ b/src/views/projects/SourceBrowsingHeader.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Project, Remote } from "@httpd-client";
+  import type { BaseUrl, Project, Remote } from "@httpd-client";
   import type { ProjectLoadedView } from "@app/views/projects/router";
 
   import { closeFocused } from "@app/components/Floating.svelte";
@@ -7,11 +7,12 @@
 
   import BranchSelector from "@app/views/projects/BranchSelector.svelte";
   import PeerSelector from "@app/views/projects/PeerSelector.svelte";
-  import ProjectLink from "@app/components/ProjectLink.svelte";
+  import Link from "@app/components/Link.svelte";
   import SquareButton from "@app/components/SquareButton.svelte";
 
   export let project: Project;
   export let peer: string | undefined = undefined;
+  export let baseUrl: BaseUrl;
   export let revision: string | undefined;
   export let peers: Remote[];
   export let branches: Record<string, string>;
@@ -54,20 +55,25 @@
     on:click={() => closeFocused()}
     projectDefaultBranch={project.defaultBranch} />
 
-  <ProjectLink
-    projectParams={{
-      id: project.id,
-      view: {
-        resource: "history",
+  <Link
+    route={{
+      resource: "projects",
+      params: {
+        id: project.id,
+        baseUrl,
+        view: {
+          resource: "history",
+        },
+        peer,
+        revision,
       },
-      revision,
     }}>
     <SquareButton
       active={view.resource === "history" || view.resource === "commits"}>
       <span class="txt-bold">{commitCount}</span>
       {pluralize("commit", commitCount)}
     </SquareButton>
-  </ProjectLink>
+  </Link>
 
   <SquareButton hoverable={false}>
     <span class="txt-bold">{contributorCount}</span>

--- a/src/views/projects/View.svelte
+++ b/src/views/projects/View.svelte
@@ -47,6 +47,7 @@
     projectId={id}
     projectName={project.name}
     projectDescription={project.description}
+    {baseUrl}
     nodeId={peer} />
   <Header
     projectId={id}
@@ -64,6 +65,7 @@
       {project}
       {peer}
       {view}
+      {baseUrl}
       peers={view.params.loadedPeers}
       branches={view.params.loadedBranches}
       commitCount={view.params.loadedTree.stats.commits}

--- a/src/views/projects/router.ts
+++ b/src/views/projects/router.ts
@@ -511,7 +511,7 @@ export function createProjectRoute(
 }
 
 export function projectLinkHref(
-  projectRouteParams: Partial<ProjectsParams>,
+  projectRouteParams: Partial<Omit<ProjectsParams, "id" | "route" | "hash">>,
 ): string | undefined {
   const activeRoute = get(activeRouteStore);
 
@@ -525,7 +525,7 @@ export function projectLinkHref(
 }
 
 export async function updateProjectRoute(
-  projectRouteParams: Partial<ProjectsParams>,
+  projectRouteParams: Partial<Omit<ProjectsParams, "id" | "route" | "hash">>,
   opts: { replace: boolean } = { replace: false },
 ): Promise<void> {
   const activeRoute = get(activeRouteStore);


### PR DESCRIPTION
We use the new parameter instead of the shared revision parameter.

We also restricted the allowed parameters that are used for project-relative
navigation. This allows us to better understand which of the parameters are
used.