### PR TITLE
Get rid of project-specific routing

### DIFF
--- a/src/views/projects/Commit/CommitTeaser.svelte
+++ b/src/views/projects/Commit/CommitTeaser.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
-  import type { CommitHeader } from "@httpd-client";
+  import type { BaseUrl, CommitHeader } from "@httpd-client";
 
   import { formatCommit, twemoji } from "@app/lib/utils";
 
   import CommitAuthorship from "./CommitAuthorship.svelte";
   import Icon from "@app/components/Icon.svelte";
   import InlineMarkdown from "@app/components/InlineMarkdown.svelte";
-  import ProjectLink from "@app/components/ProjectLink.svelte";
+  import Link from "@app/components/Link.svelte";
 
+  export let baseUrl: BaseUrl;
   export let commit: CommitHeader;
+  export let peer: string | undefined = undefined;
+  export let projectId: string;
 
   let expandCommitMessage = false;
 </script>
@@ -94,14 +97,20 @@
 <div class="teaser">
   <div class="left">
     <div class="message">
-      <ProjectLink
-        projectParams={{
-          view: { resource: "commits", commitId: commit.id },
+      <Link
+        route={{
+          resource: "projects",
+          params: {
+            peer,
+            id: projectId,
+            baseUrl,
+            view: { resource: "commits", commitId: commit.id },
+          },
         }}>
         <div class="summary" use:twemoji>
           <InlineMarkdown content={commit.summary} />
         </div>
-      </ProjectLink>
+      </Link>
       {#if commit.description}
         <button
           class:expand-open={expandCommitMessage}
@@ -125,13 +134,18 @@
     <div
       class="browse"
       title="Browse the repository at this point in the history">
-      <ProjectLink
-        projectParams={{
-          view: { resource: "tree" },
-          revision: commit.id,
+      <Link
+        route={{
+          resource: "projects",
+          params: {
+            id: projectId,
+            baseUrl,
+            revision: commit.id,
+            view: { resource: "tree" },
+          },
         }}>
         <Icon name="browse" />
-      </ProjectLink>
+      </Link>
     </div>
   </div>
 </div>

--- a/src/views/projects/History.svelte
+++ b/src/views/projects/History.svelte
@@ -10,9 +10,10 @@
   import Loading from "@app/components/Loading.svelte";
   import { COMMITS_PER_PAGE } from "./router";
 
-  export let projectId: string;
   export let baseUrl: BaseUrl;
   export let commitHeaders: CommitHeader[];
+  export let peer: string | undefined = undefined;
+  export let projectId: string;
   export let totalCommitCount: number;
 
   const api = new HttpdClient(baseUrl);
@@ -79,7 +80,7 @@
     <div class="group">
       {#each group.commits as commit (commit.id)}
         <div class="teaser-wrapper">
-          <CommitTeaser {commit} />
+          <CommitTeaser {peer} {projectId} {baseUrl} {commit} />
         </div>
       {/each}
     </div>

--- a/src/views/projects/Issue/IssueTeaser.svelte
+++ b/src/views/projects/Issue/IssueTeaser.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Issue } from "@httpd-client";
+  import type { BaseUrl, Issue } from "@httpd-client";
 
   import { formatObjectId, formatTimestamp } from "@app/lib/utils";
 
@@ -7,9 +7,11 @@
   import Badge from "@app/components/Badge.svelte";
   import Icon from "@app/components/Icon.svelte";
   import InlineMarkdown from "@app/components/InlineMarkdown.svelte";
-  import ProjectLink from "@app/components/ProjectLink.svelte";
+  import Link from "@app/components/Link.svelte";
 
+  export let baseUrl: BaseUrl;
   export let issue: Issue;
+  export let projectId: string;
 
   $: commentCount = issue.discussion.reduce((acc, _curr, index) => {
     if (index !== 0) {
@@ -101,17 +103,22 @@
   </div>
   <div>
     <div class="summary">
-      <ProjectLink
-        projectParams={{
-          view: {
-            resource: "issue",
-            params: { issue: issue.id },
+      <Link
+        route={{
+          resource: "projects",
+          params: {
+            id: projectId,
+            baseUrl,
+            view: {
+              resource: "issue",
+              params: { issue: issue.id },
+            },
           },
         }}>
         <span class="issue-title">
           <InlineMarkdown content={issue.title} />
         </span>
-      </ProjectLink>
+      </Link>
       <span class="tags">
         {#each issue.tags.slice(0, 4) as tag}
           <Badge style="max-width:7rem" variant="secondary">

--- a/src/views/projects/Issues.svelte
+++ b/src/views/projects/Issues.svelte
@@ -16,9 +16,9 @@
   import Button from "@app/components/Button.svelte";
   import ErrorMessage from "@app/components/ErrorMessage.svelte";
   import IssueTeaser from "@app/views/projects/Issue/IssueTeaser.svelte";
+  import Link from "@app/components/Link.svelte";
   import Loading from "@app/components/Loading.svelte";
   import Placeholder from "@app/components/Placeholder.svelte";
-  import ProjectLink from "@app/components/ProjectLink.svelte";
   import SquareButton from "@app/components/SquareButton.svelte";
 
   export let search: string | undefined = undefined;
@@ -118,13 +118,18 @@
       <div style="display: flex; gap: 0.5rem;">
         {#each options as option}
           {#if !option.disabled}
-            <ProjectLink
-              projectParams={{
-                view: {
-                  resource: "issues",
-                  params: {
-                    view: { resource: "list" },
-                    search: `state=${option.value}`,
+            <Link
+              route={{
+                resource: "projects",
+                params: {
+                  id: projectId,
+                  baseUrl,
+                  view: {
+                    resource: "issues",
+                    params: {
+                      view: { resource: "list" },
+                      search: `state=${option.value}`,
+                    },
                   },
                 },
               }}>
@@ -134,7 +139,7 @@
                 disabled={option.disabled}>
                 {option.title}
               </SquareButton>
-            </ProjectLink>
+            </Link>
           {:else}
             <SquareButton
               clickable={option.disabled}
@@ -147,21 +152,26 @@
       </div>
     </div>
     {#if $httpdStore.state === "authenticated" && utils.isLocal(baseUrl.hostname)}
-      <ProjectLink
-        projectParams={{
-          view: {
-            resource: "issues",
-            params: { view: { resource: "new" } },
+      <Link
+        route={{
+          resource: "projects",
+          params: {
+            id: projectId,
+            baseUrl,
+            view: {
+              resource: "issues",
+              params: { view: { resource: "new" } },
+            },
           },
         }}>
         <SquareButton>New issue</SquareButton>
-      </ProjectLink>
+      </Link>
     {/if}
   </div>
   <div class="issues-list">
     {#each issues as issue}
       <div class="teaser">
-        <IssueTeaser {issue} />
+        <IssueTeaser {projectId} {baseUrl} {issue} />
       </div>
     {:else}
       {#if error}

--- a/src/views/projects/Patch.svelte
+++ b/src/views/projects/Patch.svelte
@@ -46,9 +46,9 @@
   import ErrorMessage from "@app/components/ErrorMessage.svelte";
   import Floating, { closeFocused } from "@app/components/Floating.svelte";
   import Icon from "@app/components/Icon.svelte";
+  import Link from "@app/components/Link.svelte";
   import Markdown from "@app/components/Markdown.svelte";
   import Placeholder from "@app/components/Placeholder.svelte";
-  import ProjectLink from "@app/components/ProjectLink.svelte";
   import RevisionComponent from "@app/views/projects/Cob/Revision.svelte";
   import SquareButton from "@app/components/SquareButton.svelte";
   import TagInput from "@app/views/projects/Cob/TagInput.svelte";
@@ -325,14 +325,19 @@
       <div style="display: flex; gap: 0.5rem;">
         {#each options as option}
           {#if !option.disabled}
-            <ProjectLink
-              projectParams={{
-                view: {
-                  resource: "patch",
-                  params: {
-                    patch: patch.id,
-                    revision,
-                    search: `tab=${option.value}`,
+            <Link
+              route={{
+                resource: "projects",
+                params: {
+                  id: projectId,
+                  baseUrl,
+                  view: {
+                    resource: "patch",
+                    params: {
+                      patch: patch.id,
+                      revision,
+                      search: `tab=${option.value}`,
+                    },
                   },
                 },
               }}>
@@ -343,7 +348,7 @@
                 disabled={option.disabled}>
                 {option.title}
               </SquareButton>
-            </ProjectLink>
+            </Link>
           {:else}
             <SquareButton
               size="small"
@@ -355,20 +360,25 @@
           {/if}
         {/each}
         {#if diff}
-          <ProjectLink
-            projectParams={{
-              view: {
-                resource: "patch",
-                params: {
-                  patch: patch.id,
-                  search: `diff=${diff}`,
+          <Link
+            route={{
+              resource: "projects",
+              params: {
+                id: projectId,
+                baseUrl,
+                view: {
+                  resource: "patch",
+                  params: {
+                    patch: patch.id,
+                    search: `diff=${diff}`,
+                  },
                 },
               },
             }}>
             <SquareButton size="small" active={true}>
               Diff {diff.substr(0, 6)}..{diff.split("..")[1].substr(0, 6)}
             </SquareButton>
-          </ProjectLink>
+          </Link>
         {/if}
       </div>
 
@@ -385,15 +395,21 @@
           <svelte:fragment slot="modal">
             <Dropdown items={patch.revisions}>
               <svelte:fragment slot="item" let:item>
-                <ProjectLink
-                  on:click={closeFocused}
-                  projectParams={{
-                    view: {
-                      resource: "patch",
-                      params: {
-                        patch: patch.id,
-                        revision: item.id,
-                        search: `tab=${currentTab}`,
+                <Link
+                  on:afterNavigate={closeFocused}
+                  route={{
+                    resource: "projects",
+                    params: {
+                      id: projectId,
+
+                      baseUrl,
+                      view: {
+                        resource: "patch",
+                        params: {
+                          patch: patch.id,
+                          revision: item.id,
+                          search: `tab=${currentTab}`,
+                        },
                       },
                     },
                   }}>
@@ -402,7 +418,7 @@
                     size="tiny">
                     Revision {utils.formatObjectId(item.id)}
                   </DropdownItem>
-                </ProjectLink>
+                </Link>
               </svelte:fragment>
             </Dropdown>
           </svelte:fragment>
@@ -448,7 +464,7 @@
       {#await api.project.getDiff(projectId, currentRevision.base, currentRevision.oid) then diff}
         <div class="commit-list">
           {#each diff.commits as commit}
-            <CommitTeaser {commit} />
+            <CommitTeaser {projectId} {baseUrl} {commit} />
           {/each}
         </div>
       {:catch e}

--- a/src/views/projects/Patch/PatchTeaser.svelte
+++ b/src/views/projects/Patch/PatchTeaser.svelte
@@ -10,7 +10,7 @@
   import DiffStatBadge from "@app/components/DiffStatBadge.svelte";
   import Icon from "@app/components/Icon.svelte";
   import InlineMarkdown from "@app/components/InlineMarkdown.svelte";
-  import ProjectLink from "@app/components/ProjectLink.svelte";
+  import Link from "@app/components/Link.svelte";
 
   export let projectId: string;
   export let baseUrl: BaseUrl;
@@ -126,17 +126,22 @@
   </div>
   <div>
     <div class="summary">
-      <ProjectLink
-        projectParams={{
-          view: {
-            resource: "patch",
-            params: { patch: patch.id },
+      <Link
+        route={{
+          resource: "projects",
+          params: {
+            id: projectId,
+            baseUrl,
+            view: {
+              resource: "patch",
+              params: { patch: patch.id },
+            },
           },
         }}>
         <span class="patch-title">
           <InlineMarkdown content={patch.title} />
         </span>
-      </ProjectLink>
+      </Link>
       <span class="tags">
         {#each patch.tags.slice(0, 4) as tag}
           <Badge style="max-width:7rem" variant="secondary">

--- a/src/views/projects/Patches.svelte
+++ b/src/views/projects/Patches.svelte
@@ -12,10 +12,10 @@
 
   import Button from "@app/components/Button.svelte";
   import ErrorMessage from "@app/components/ErrorMessage.svelte";
+  import Link from "@app/components/Link.svelte";
   import Loading from "@app/components/Loading.svelte";
   import PatchTeaser from "./Patch/PatchTeaser.svelte";
   import Placeholder from "@app/components/Placeholder.svelte";
-  import ProjectLink from "@app/components/ProjectLink.svelte";
   import SquareButton from "@app/components/SquareButton.svelte";
 
   export let search: string | undefined = undefined;
@@ -120,13 +120,18 @@
             {option.title}
           </SquareButton>
         {:else}
-          <ProjectLink
-            projectParams={{
-              view: {
-                resource: "patches",
-                params: {
-                  view: { resource: "list" },
-                  search: `state=${option.value}`,
+          <Link
+            route={{
+              resource: "projects",
+              params: {
+                id: projectId,
+                baseUrl,
+                view: {
+                  resource: "patches",
+                  params: {
+                    view: { resource: "list" },
+                    search: `state=${option.value}`,
+                  },
                 },
               },
             }}>
@@ -136,7 +141,7 @@
               disabled={option.disabled}>
               {option.title}
             </SquareButton>
-          </ProjectLink>
+          </Link>
         {/if}
       {/each}
     </div>

--- a/src/views/projects/View.svelte
+++ b/src/views/projects/View.svelte
@@ -85,6 +85,7 @@
     {:else if view.resource === "history"}
       <History
         projectId={id}
+        {peer}
         {baseUrl}
         totalCommitCount={view.totalCommitCount}
         commitHeaders={view.commitHeaders} />


### PR DESCRIPTION
We don't want to have a custom way to do routing within project views.