### PR TITLE
Only log errors when something unexpected happens in local node connection

### DIFF
--- a/src/lib/httpd.ts
+++ b/src/lib/httpd.ts
@@ -85,7 +85,6 @@ export async function disconnect() {
       }
     })
     .catch(error => {
-      console.error(error);
       if (error !== E_CANCELED) {
         throw error;
       }
@@ -126,12 +125,13 @@ async function checkState() {
           update({ state: "running" });
         }
       } catch (error) {
-        console.error(error);
+        if (error instanceof TypeError && error.message !== "Failed to fetch") {
+          console.error(error);
+        }
         update({ state: "stopped" });
       }
     })
     .catch(error => {
-      console.error(error);
       if (error !== E_CANCELED && error !== E_TIMEOUT) {
         throw error;
       }


### PR DESCRIPTION
We remove a couple of calls to `console.error()` in the code for the local node connection. It’s not necessary to log errors that are expected, for example, if the node is down.