### PR TITLE
Don’t replace path on internal navigation

### DIFF
--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -1,13 +1,12 @@
 import type { BaseUrl } from "@httpd-client";
 import type { LoadedRoute, Route } from "@app/lib/router/definitions";
 
-import { get, writable } from "svelte/store";
+import { writable } from "svelte/store";
 
 import * as mutexExecutor from "@app/lib/mutexExecutor";
 import * as utils from "@app/lib/utils";
 import { config } from "@app/lib/config";
 import {
-  createProjectRoute,
   projectRouteToPath,
   resolveProjectRoute,
 } from "@app/views/projects/router";
@@ -61,22 +60,9 @@ export async function loadFromLocation(): Promise<void> {
 
   const relativeUrl = pathname + window.location.search + (hash || "");
   const url = new URL(relativeUrl, window.origin);
-  let route = pathToRoute(url);
+  const route = pathToRoute(url);
 
   if (route) {
-    const activeRoute = get(activeRouteStore);
-    if (
-      activeRoute.resource === "projects" &&
-      route.resource === "projects" &&
-      route.params.hash
-    ) {
-      if (route.params.hash.match(/^L\d+$/)) {
-        route = createProjectRoute(activeRoute, {});
-      } else {
-        route = createProjectRoute(activeRoute, { hash: route.params.hash });
-      }
-    }
-
     await replace(route);
   } else {
     await replace({ resource: "notFound", params: { url: relativeUrl } });
@@ -99,7 +85,7 @@ async function navigate(
   if (action === "push") {
     window.history.pushState(newRoute, DOCUMENT_TITLE, path);
   } else if (action === "replace") {
-    window.history.replaceState(newRoute, DOCUMENT_TITLE, path);
+    window.history.replaceState(newRoute, DOCUMENT_TITLE);
   }
   currentUrl = new URL(window.location.href);
 

--- a/src/views/projects/router.ts
+++ b/src/views/projects/router.ts
@@ -463,7 +463,7 @@ function sanitizeQueryString(queryString: string): string {
   return queryString.startsWith("?") ? queryString.substring(1) : queryString;
 }
 
-export function createProjectRoute(
+function createProjectRoute(
   activeRoute: ProjectRoute,
   projectRouteParams: Partial<ProjectsParams>,
 ): ProjectRoute {

--- a/tests/e2e/hashRouter.spec.ts
+++ b/tests/e2e/hashRouter.spec.ts
@@ -31,7 +31,7 @@ test("navigation between seed and project pages", async ({ page }) => {
   await project.click();
   await expect(page).toHaveURL(`/#${sourceBrowsingUrl}`);
 
-  await expectBackAndForwardNavigationWorks("/#/seeds/127.0.0.1", page);
+  await expectBackAndForwardNavigationWorks("/#/seeds/radicle.local", page);
   await expectUrlPersistsReload(page);
 
   await page.locator('role=link[name="radicle.local"]').click();

--- a/tests/e2e/historyRouter.spec.ts
+++ b/tests/e2e/historyRouter.spec.ts
@@ -31,7 +31,7 @@ test("navigation between seed and project pages", async ({ page }) => {
   await project.click();
   await expect(page).toHaveURL(sourceBrowsingUrl);
 
-  await expectBackAndForwardNavigationWorks("/seeds/127.0.0.1", page);
+  await expectBackAndForwardNavigationWorks("/seeds/radicle.local", page);
   await expectUrlPersistsReload(page);
 
   await page.locator('role=link[name="radicle.local"]').click();


### PR DESCRIPTION
We don’t replace the path when we navigate internally. This means we keep the hash part of the URL even if it is not part of the route and we can remove the workaround for that.

This also means that we keep the original URL if the parsed route would result in a different URL. This change is visible through a slight adjustments in the tests.