### PR TITLE
Add missing httpd api tests

### DIFF
--- a/httpd-client/lib/project.ts
+++ b/httpd-client/lib/project.ts
@@ -5,7 +5,12 @@ import type {
   IssueCreated,
   IssueUpdateAction,
 } from "./project/issue.js";
-import type { Patch, PatchUpdateAction } from "./project/patch.js";
+import type {
+  Patch,
+  PatchCreate,
+  PatchCreated,
+  PatchUpdateAction,
+} from "./project/patch.js";
 import type { SuccessResponse } from "./shared.js";
 import type { ZodSchema } from "zod";
 
@@ -35,7 +40,11 @@ import {
   issuesSchema,
 } from "./project/issue.js";
 
-import { patchSchema, patchesSchema } from "./project/patch.js";
+import {
+  patchSchema,
+  patchesSchema,
+  patchCreatedSchema,
+} from "./project/patch.js";
 
 export interface Project {
   id: string;
@@ -466,6 +475,24 @@ export class Client {
         options,
       },
       patchesSchema,
+    );
+  }
+
+  public async createPatch(
+    id: string,
+    body: PatchCreate,
+    authToken: string,
+    options?: RequestOptions,
+  ): Promise<PatchCreated> {
+    return this.#fetcher.fetchOk(
+      {
+        method: "POST",
+        path: `projects/${id}/patches`,
+        headers: { Authorization: `Bearer ${authToken}` },
+        body,
+        options,
+      },
+      patchCreatedSchema,
     );
   }
 

--- a/httpd-client/lib/project/patch.ts
+++ b/httpd-client/lib/project/patch.ts
@@ -1,10 +1,11 @@
 import type { Comment, ThreadUpdateAction } from "./comment.js";
-import type { ZodSchema } from "zod";
+import type { ZodSchema, z } from "zod";
 
 import { commentSchema } from "./comment.js";
 
 import {
   array,
+  boolean,
   literal,
   number,
   optional,
@@ -136,3 +137,20 @@ export type PatchUpdateAction =
     }
   | { type: "merge"; revision: string; commit: string }
   | { type: "thread"; revision: string; action: ThreadUpdateAction };
+
+export const patchCreateSchema = object({
+  title: string(),
+  description: string(),
+  target: string(),
+  oid: string(),
+  tags: array(string()),
+});
+
+export type PatchCreate = z.infer<typeof patchCreateSchema>;
+
+export const patchCreatedSchema = object({
+  success: boolean(),
+  id: string(),
+});
+
+export type PatchCreated = z.infer<typeof patchCreatedSchema>;

--- a/httpd-client/lib/session.ts
+++ b/httpd-client/lib/session.ts
@@ -1,10 +1,18 @@
 import type { Fetcher, RequestOptions } from "./fetcher.js";
 import type { SuccessResponse } from "./shared.js";
-import type { ZodSchema } from "zod";
+import type { ZodSchema, z } from "zod";
 
 import { number, object, string } from "zod";
 
 import { successResponseSchema } from "./shared.js";
+
+export const sessionPayloadSchema = object({
+  sessionId: string(),
+  signature: string(),
+  publicKey: string(),
+});
+
+export type SessionPayload = z.infer<typeof sessionPayloadSchema>;
 
 interface Session {
   sessionId: string;
@@ -34,6 +42,17 @@ export class Client {
       {
         method: "GET",
         path: `sessions/${id}`,
+        options,
+      },
+      sessionSchema,
+    );
+  }
+
+  public async create(options?: RequestOptions): Promise<Session> {
+    return this.#fetcher.fetchOk(
+      {
+        method: "POST",
+        path: "sessions",
         options,
       },
       sessionSchema,

--- a/httpd-client/tests/client.test.ts
+++ b/httpd-client/tests/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, test } from "vitest";
-import { HttpdClient } from "../index";
+import { HttpdClient } from "@httpd-client";
 
 const api = new HttpdClient({
   hostname: "127.0.0.1",

--- a/httpd-client/tests/project.test.ts
+++ b/httpd-client/tests/project.test.ts
@@ -4,16 +4,26 @@ import { HttpdClient } from "@httpd-client";
 import {
   aliceMainHead,
   aliceRemote,
+  bobRemote,
+  cobRid,
   sourceBrowsingRid,
-} from "@tests/support/fixtures";
-
-const api = new HttpdClient({
-  hostname: "127.0.0.1",
-  port: 8080,
-  scheme: "http",
-});
+} from "@tests/support/fixtures.js";
+import {
+  assertIssue,
+  assertPatch,
+  createIssueToBeModified,
+  createPatchToBeModified,
+} from "@httpd-client/tests/support/support";
+import { authenticate } from "@httpd-client/tests/support/httpd.js";
+import { testFixture as testWithAPI } from "@httpd-client/tests/support/fixtures.js";
 
 describe("project", () => {
+  const api = new HttpdClient({
+    hostname: "127.0.0.1",
+    port: 8080,
+    scheme: "http",
+  });
+
   test("#getByDelegate(delegateId)", async () => {
     await api.project.getByDelegate(aliceRemote);
   });
@@ -76,12 +86,191 @@ describe("project", () => {
     await api.project.getCommitBySha(sourceBrowsingRid, aliceMainHead);
   });
 
-  test.todo("#getDiff(id, revisionBase, revisionOid)");
-  test.todo("#getIssueById(id, issueId)");
-  test.todo("#getAllIssues(id)");
-  test.todo("#createIssue(id, { title, description, assignees, tags })");
-  test.todo("#updateIssue(id, issueId, issueUpdateAction, authToken)");
-  test.todo("#getPatchById(id, patchId)");
-  test.todo("#getAllPatches(id)");
-  test.todo("#updatePatch(id, patchId, patchUpdateAction, authToken)");
+  test("#getDiff(id, revisionBase, revisionOid)", async () => {
+    await api.project.getDiff(
+      sourceBrowsingRid,
+      "90f6d058ece12f75f349bc7bbe88142187fe0379",
+      aliceMainHead,
+    );
+  });
+
+  test("#getIssueById(id, issueId)", async () => {
+    await api.project.getIssueById(
+      cobRid,
+      "4fc727e722d3979fd2073d9b56b2751658a4ae79",
+    );
+  });
+
+  test("#getAllIssues(id)", async () => {
+    await api.project.getAllIssues(cobRid, {
+      page: 0,
+      perPage: 5,
+      state: "open",
+    });
+  });
+
+  testWithAPI(
+    "#createIssue(id, { title, description, assignees, tags })",
+    async ({ httpd: { api, peer } }) => {
+      const sessionId = await authenticate(api, peer);
+      const { id: issueId } = await api.project.createIssue(
+        cobRid,
+        {
+          title: "aaa",
+          description: "bbb",
+          assignees: [],
+          tags: ["bug", "documentation"],
+        },
+        sessionId,
+      );
+      await assertIssue(
+        issueId,
+        {
+          title: "aaa",
+          discussion: [{ body: "bbb" }],
+          assignees: [],
+          tags: ["bug", "documentation"],
+        },
+        api,
+      );
+    },
+  );
+
+  testWithAPI(
+    "#updateIssue(id, issueId, { type: 'edit' }, authToken)",
+    async ({ httpd: { api, peer } }) => {
+      const sessionId = await authenticate(api, peer);
+      const issueId = await createIssueToBeModified(api, sessionId);
+      await api.project.updateIssue(
+        cobRid,
+        issueId,
+        { type: "edit", title: "ccc" },
+        sessionId,
+      );
+      await assertIssue(issueId, { title: "ccc" }, api);
+    },
+  );
+
+  testWithAPI(
+    "#updateIssue(id, issueId, { type: 'tag' }, authToken)",
+    async ({ httpd: { api, peer } }) => {
+      const sessionId = await authenticate(api, peer);
+      const issueId = await createIssueToBeModified(api, sessionId);
+      await api.project.updateIssue(
+        cobRid,
+        issueId,
+        { type: "tag", add: ["bug"], remove: [] },
+        sessionId,
+      );
+      await assertIssue(issueId, { tags: ["bug"] }, api);
+    },
+  );
+
+  testWithAPI(
+    "#updateIssue(id, issueId, { type: 'assign' }, authToken)",
+    async ({ httpd: { api, peer } }) => {
+      const sessionId = await authenticate(api, peer);
+      const issueId = await createIssueToBeModified(api, sessionId);
+      const assignee = bobRemote.replace("did:key:", "");
+      await api.project.updateIssue(
+        cobRid,
+        issueId,
+        {
+          type: "assign",
+          add: [assignee],
+          remove: [],
+        },
+        sessionId,
+      );
+      await assertIssue(issueId, { assignees: [`did:key:${assignee}`] }, api);
+    },
+  );
+
+  testWithAPI(
+    "#updateIssue(id, issueId, { type: 'lifecycle' }, authToken)",
+    async ({ httpd: { api, peer } }) => {
+      const sessionId = await authenticate(api, peer);
+      const issueId = await createIssueToBeModified(api, sessionId);
+      await api.project.updateIssue(
+        cobRid,
+        issueId,
+        { type: "lifecycle", state: { status: "closed", reason: "solved" } },
+        sessionId,
+      );
+      await assertIssue(
+        issueId,
+        {
+          state: { status: "closed", reason: "solved" },
+        },
+        api,
+      );
+    },
+  );
+
+  test("#getPatchById(id, patchId)", async () => {
+    await api.project.getPatchById(
+      cobRid,
+      "013f8b2734df1840b2e33d52ff5632c8d66b199a",
+    );
+  });
+
+  test("#getAllPatches(id)", async () => {
+    await api.project.getAllPatches(cobRid);
+  });
+
+  testWithAPI(
+    "#createPatch(id, patchCreate, authToken)",
+    async ({ httpd: { api, peer } }) => {
+      const sessionId = await authenticate(api, peer);
+      const { id: oid } = await api.project.createPatch(
+        cobRid,
+        {
+          title: "ppp",
+          description: "qqq",
+          target: "d7dd8cecae16b1108234e09dbdb5d64ae394bc25",
+          oid: "38c225e2a0b47ba59def211f4e4825c31d9463ec",
+          tags: [],
+        },
+        sessionId,
+      );
+      await assertPatch(
+        oid,
+        {
+          title: "ppp",
+          state: { status: "open" },
+          target: "delegates",
+          tags: [],
+          revisions: [
+            {
+              description: "qqq",
+              base: "d7dd8cecae16b1108234e09dbdb5d64ae394bc25",
+              oid: "38c225e2a0b47ba59def211f4e4825c31d9463ec",
+            },
+          ],
+        },
+        api,
+      );
+    },
+  );
+
+  testWithAPI(
+    "#updatePatch(id, patchId, { type: 'edit' }, authToken)",
+    async ({ httpd: { api, peer } }) => {
+      const sessionId = await authenticate(api, peer);
+      const patchId = await createPatchToBeModified(api, sessionId);
+      await api.project.updatePatch(
+        cobRid,
+        patchId,
+        { type: "tag", add: ["bug"], remove: [] },
+        sessionId,
+      );
+      await assertPatch(
+        patchId,
+        {
+          tags: ["bug"],
+        },
+        api,
+      );
+    },
+  );
 });

--- a/httpd-client/tests/project.test.ts
+++ b/httpd-client/tests/project.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from "vitest";
 
-import { HttpdClient } from "../index";
+import { HttpdClient } from "@httpd-client";
 import {
   aliceMainHead,
   aliceRemote,

--- a/httpd-client/tests/session.test.ts
+++ b/httpd-client/tests/session.test.ts
@@ -1,7 +1,50 @@
+import * as FsSync from "node:fs";
+import * as Path from "node:path";
 import { describe, test } from "vitest";
 
-describe("session", () => {
-  test.todo("#getById(id)");
-  test.todo("#update(id, {sig, pk})");
-  test.todo("#delete(id)");
+import { HttpdClient } from "@httpd-client";
+import { authenticate } from "@httpd-client/tests/support/httpd.js";
+import { createPeerManager } from "@tests/support/peerManager.js";
+import { gitOptions } from "@tests/support/fixtures.js";
+import { sessionPayloadSchema } from "@httpd-client/lib/session";
+import { tmpDir } from "@tests/support/support.js";
+
+describe("session", async () => {
+  const peerManager = await createPeerManager({
+    dataDir: Path.resolve(Path.join(tmpDir, "peers")),
+    outputLog: FsSync.createWriteStream(
+      Path.join(tmpDir, "peerManager.log"),
+    ).setMaxListeners(16),
+  });
+  const peer = await peerManager.startPeer({
+    name: "session",
+    gitOptions: gitOptions["alice"],
+  });
+  await peer.startHttpd();
+  const api = new HttpdClient(peer.httpdBaseUrl);
+
+  test("#getById(id)", async () => {
+    const id = await authenticate(api, peer);
+    await api.session.getById(id);
+  });
+
+  test("#update(id, {sig, pk})", async () => {
+    const { stdout } = await peer.rad(["web", "--backend", api.url, "--json"]);
+    const session = sessionPayloadSchema.safeParse(JSON.parse(stdout));
+
+    if (!session.success) {
+      throw new Error("Failed to parse session payload");
+    }
+
+    const { sessionId, signature, publicKey } = session.data;
+    await api.session.update(sessionId, {
+      sig: signature,
+      pk: publicKey,
+    });
+  });
+
+  test("#delete(id)", async () => {
+    const id = await authenticate(api, peer);
+    await api.session.delete(id);
+  });
 });

--- a/httpd-client/tests/support/fixtures.ts
+++ b/httpd-client/tests/support/fixtures.ts
@@ -1,0 +1,32 @@
+import * as FsSync from "node:fs";
+import * as Path from "node:path";
+import { test } from "vitest";
+
+import { HttpdClient } from "@httpd-client";
+import { RadiclePeer, createPeerManager } from "@tests/support/peerManager.js";
+import { gitOptions } from "@tests/support/fixtures.js";
+import { tmpDir } from "@tests/support/support.js";
+
+interface TestFixtures {
+  httpd: { api: HttpdClient; peer: RadiclePeer };
+}
+
+export const testFixture = test.extend<TestFixtures>({
+  // eslint-disable-next-line no-empty-pattern
+  httpd: async ({}, use) => {
+    const peerManager = await createPeerManager({
+      dataDir: Path.resolve(Path.join(tmpDir, "peers")),
+      outputLog: FsSync.createWriteStream(
+        Path.join(tmpDir, "peerManager.log"),
+      ).setMaxListeners(16),
+    });
+    const peer = await peerManager.startPeer({
+      name: "palm",
+      gitOptions: gitOptions["alice"],
+    });
+    await peer.startHttpd();
+    const api = new HttpdClient(peer.httpdBaseUrl);
+    await use({ api, peer });
+    await peer.stopHttpd();
+  },
+});

--- a/httpd-client/tests/support/globalSetup.ts
+++ b/httpd-client/tests/support/globalSetup.ts
@@ -8,6 +8,7 @@ import {
 } from "@tests/support/support.js";
 import { createPeerManager } from "@tests/support/peerManager";
 import {
+  createCobsFixture,
   createSourceBrowsingFixture,
   gitOptions,
   startPalmHttpd,
@@ -49,6 +50,8 @@ export default async function globalSetup(): Promise<() => void> {
 
     console.log("Creating source-browsing fixture");
     await createSourceBrowsingFixture(peerManager, palm);
+    console.log("Creating cobs fixture");
+    await createCobsFixture(palm);
     console.log("Running tests");
     await palm.stopNode();
   } else {

--- a/httpd-client/tests/support/httpd.ts
+++ b/httpd-client/tests/support/httpd.ts
@@ -1,0 +1,24 @@
+import type { HttpdClient } from "@httpd-client";
+import type { RadiclePeer } from "@tests/support/peerManager.js";
+
+import { sessionPayloadSchema } from "@httpd-client/lib/session.js";
+
+export async function authenticate(
+  api: HttpdClient,
+  peer: RadiclePeer,
+): Promise<string> {
+  const { stdout } = await peer.rad(["web", "--backend", api.url, "--json"]);
+  const session = sessionPayloadSchema.safeParse(JSON.parse(stdout));
+
+  if (!session.success) {
+    throw new Error("Failed to parse session payload");
+  }
+
+  const { sessionId, signature, publicKey } = session.data;
+  await api.session.update(sessionId, {
+    sig: signature,
+    pk: publicKey,
+  });
+
+  return sessionId;
+}

--- a/httpd-client/tests/support/support.ts
+++ b/httpd-client/tests/support/support.ts
@@ -1,0 +1,59 @@
+import type { HttpdClient } from "@httpd-client";
+
+import { expect } from "vitest";
+import { isMatch } from "lodash";
+
+import { cobRid } from "@tests/support/fixtures";
+
+export async function createIssueToBeModified(
+  api: HttpdClient,
+  sessionId: string,
+) {
+  const { id } = await api.project.createIssue(
+    cobRid,
+    { title: "aaa", description: "bbb", assignees: [], tags: [] },
+    sessionId,
+  );
+
+  return id;
+}
+
+export async function createPatchToBeModified(
+  api: HttpdClient,
+  sessionId: string,
+) {
+  const { id } = await api.project.createPatch(
+    cobRid,
+    {
+      title: "rrr",
+      description: "ttt",
+      target: "d7dd8cecae16b1108234e09dbdb5d64ae394bc25",
+      oid: "38c225e2a0b47ba59def211f4e4825c31d9463ec",
+      tags: [],
+    },
+    sessionId,
+  );
+
+  return id;
+}
+export async function assertIssue(
+  oid: string,
+  change: Record<string, any>,
+  api: HttpdClient,
+) {
+  expect(
+    //@prettier-ignore looks more readable than what prettier suggests.
+    isMatch(await api.project.getIssueById(cobRid, oid), change),
+  ).toBe(true);
+}
+
+export async function assertPatch(
+  oid: string,
+  change: Record<string, any>,
+  api: HttpdClient,
+) {
+  expect(
+    //@prettier-ignore looks more readable than what prettier suggests.
+    isMatch(await api.project.getPatchById(cobRid, oid), change),
+  ).toBe(true);
+}

--- a/httpd-client/vite.config.ts
+++ b/httpd-client/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     alias: {
       "@tests": path.resolve("./tests"),
       "@app": path.resolve("./src"),
+      "@httpd-client": path.resolve("./httpd-client"),
     },
   },
 });

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:unit": "TZ='UTC' vitest run",
     "test:e2e": "TZ='UTC' playwright test",
     "test:e2e:ipfs": "TZ='UTC' playwright test ./tests/e2e/hashRouter.spec.ts --config playwright.ipfs.config.ts",
-    "test:httpd-api:unit": "TZ='UTC' vitest run --config httpd-client/vite.config.ts --reporter verbose --threads false"
+    "test:httpd-api:unit": "TZ='UTC' vitest run --config httpd-client/vite.config.ts --reporter verbose"
   },
   "type": "module",
   "engines": {


### PR DESCRIPTION
This PR tests some of the missing httpd endpoints and adds some more.

Also adds a `httpd` fixture to the httpd-api unit tests that setups a `RadiclePeer` and a `HttpdClient` to do some nice stuff
And we have enough test isolation to run these tests in parallel with more than one thread.

See commits for more information

Closes #896 
Closes #915 