### PR TITLE
Use non-dev port for webserver during end-to-end tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,7 @@ const config: PlaywrightTestConfig = {
   globalSetup: "./tests/support/globalSetup",
   use: {
     actionTimeout: 0,
-    baseURL: "http://localhost:3000",
+    baseURL: "http://localhost:3001",
     trace: "retain-on-failure",
   },
 
@@ -58,15 +58,14 @@ const config: PlaywrightTestConfig = {
         ...devices["Desktop Chrome"],
         actionTimeout: 0,
         deviceScaleFactor: 2,
-        baseURL: "http://localhost:3000",
         trace: "off",
       },
     },
   ],
 
   webServer: {
-    command: "npm run start",
-    port: 3000,
+    command: "npm run start -- --strictPort --port 3001",
+    port: 3001,
   },
 };
 

--- a/playwright.ipfs.config.ts
+++ b/playwright.ipfs.config.ts
@@ -6,8 +6,8 @@ const config: PlaywrightTestConfig = {
   ...base,
   testIgnore: undefined,
   webServer: {
-    command: "npm run start:ipfs",
-    port: 3000,
+    command: "npm run start:ipfs -- --strictPort --port 3001",
+    port: 3001,
   },
 };
 

--- a/tests/support/fixtures.ts
+++ b/tests/support/fixtures.ts
@@ -174,7 +174,7 @@ export const test = base.extend<{
     const { stdout } = await peer.rad([
       "web",
       "--frontend",
-      "http://localhost:3000",
+      "http://localhost:3001",
       "--backend",
       "http://127.0.0.1:8070",
       "--json",
@@ -182,9 +182,7 @@ export const test = base.extend<{
     const result = authSchema.safeParse(JSON.parse(stdout));
     if (result.success) {
       const { sessionId, publicKey, signature } = result.data;
-      await page.goto(
-        `http://localhost:3000/session/${sessionId}?pk=${publicKey}&sig=${signature}`,
-      );
+      await page.goto(`/session/${sessionId}?pk=${publicKey}&sig=${signature}`);
       await expect(page.getByText("Authenticated")).toBeVisible();
       await page.getByRole("button", { name: "Close" }).click();
     } else {


### PR DESCRIPTION
The end-to-end tests no run against the app served on port 3001 so that we don’t need to shut down the development server.