### PR TITLE
Stop handling URL hash through routing

### DIFF
--- a/src/App/Header/Search.svelte
+++ b/src/App/Header/Search.svelte
@@ -55,7 +55,6 @@
             id: project.id,
             peer: undefined,
             baseUrl,
-            hash: undefined,
           },
         });
       } else {

--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -11,7 +11,6 @@
   import { Renderer } from "@app/lib/markdown";
 
   export let content: string;
-  export let hash: string | undefined = undefined;
   // If present, resolve all relative links with respect to this URL
   export let linkBaseUrl: string | undefined = undefined;
   export let path: string = "/";
@@ -69,8 +68,6 @@
       }
     }
 
-    if (hash) scrollIntoView(hash);
-
     // Iterate over all images, and replace the source with a canonicalized URL
     // pointing at the projects /raw endpoint.
     if (rawPath) {
@@ -112,6 +109,10 @@
     }
 
     await Promise.allSettled(treeChanges);
+
+    if (window.location.hash) {
+      scrollIntoView(window.location.hash.substring(1));
+    }
   });
 </script>
 

--- a/src/views/projects/Blob.svelte
+++ b/src/views/projects/Blob.svelte
@@ -16,7 +16,6 @@
   export let peer: string | undefined;
   export let revision: string | undefined;
   export let path: string;
-  export let hash: string | undefined = undefined;
   export let blob: Blob;
   export let highlighted: Syntax.Root | undefined;
   export let rawPath: string;
@@ -267,8 +266,7 @@
         {revision}
         content={blob.content}
         {rawPath}
-        {path}
-        {hash} />
+        {path} />
     {:else if content}
       <table class="code no-scrollbar">
         {@html toHtml(content)}

--- a/src/views/projects/Browser.svelte
+++ b/src/views/projects/Browser.svelte
@@ -18,7 +18,6 @@
   export let commit: string;
   export let commitCount: number;
   export let contributorCount: number;
-  export let hash: string | undefined;
   export let path: string;
   export let peer: string | undefined;
   export let peers: Remote[];
@@ -181,7 +180,6 @@
             {peer}
             {revision}
             {path}
-            {hash}
             blob={blobResult.blob}
             highlighted={blobResult.highlighted}
             rawPath={utils.getRawBasePath(project.id, baseUrl, commit)} />

--- a/src/views/projects/Readme.svelte
+++ b/src/views/projects/Readme.svelte
@@ -9,7 +9,6 @@
   export let baseUrl: BaseUrl;
   export let revision: string | undefined;
   export let content: string;
-  export let hash: string | undefined = undefined;
   export let path: string;
   export let rawPath: string;
 
@@ -53,5 +52,5 @@
 </style>
 
 <article>
-  <Markdown {linkBaseUrl} {content} {hash} {rawPath} {path} />
+  <Markdown {linkBaseUrl} {content} {rawPath} {path} />
 </article>

--- a/src/views/projects/View.svelte
+++ b/src/views/projects/View.svelte
@@ -20,7 +20,6 @@
   export let project: Project;
   export let view: ProjectLoadedView;
 
-  export let hash: string | undefined = undefined;
   export let peer: string | undefined = undefined;
   export let revision: string | undefined = undefined;
 </script>
@@ -69,7 +68,6 @@
       peers={view.params.loadedPeers}
       tree={view.params.loadedTree}
       {baseUrl}
-      {hash}
       {peer}
       {project}
       {revision}

--- a/src/views/projects/router.ts
+++ b/src/views/projects/router.ts
@@ -55,7 +55,6 @@ export interface ProjectsParams {
         params: { patch: string; revision?: string; search?: string };
       };
 
-  hash?: string;
   path?: string;
   peer?: string;
   revision?: string;
@@ -68,7 +67,6 @@ export interface ProjectLoadedParams {
   project: Project;
   view: ProjectLoadedView;
 
-  hash?: string;
   peer?: string;
   revision?: string;
 }
@@ -474,7 +472,6 @@ export function resolveProjectRoute(
   }
 
   if (!content || content === "tree") {
-    const hash = url.href.match(/#{1}[^#.]+$/)?.pop();
     return {
       view: { resource: "tree" },
       baseUrl,
@@ -482,7 +479,6 @@ export function resolveProjectRoute(
       peer,
       path: undefined,
       revision: undefined,
-      hash: hash?.substring(1),
       route: segments.join("/"),
     };
   } else if (content === "history") {
@@ -605,10 +601,6 @@ export function projectRouteToPath(params: ProjectsParams): string {
     if (params.path && params.path !== "/") {
       suffix += `/${params.path}`;
     }
-  }
-
-  if (params.hash) {
-    suffix += `#${params.hash}`;
   }
 
   if (params.view.resource === "tree") {


### PR DESCRIPTION
We stop handling the URL hash through the routing system. Hashes are local to the current view and can be handled by the shown components.