### PR TITLE
Use ESlint warnings and Prettier config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,6 +8,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:svelte/recommended",
+    "prettier",
   ],
   parser: "@typescript-eslint/parser",
   parserOptions: {
@@ -38,10 +39,7 @@ module.exports = {
   },
   plugins: ["@typescript-eslint", "no-only-tests"],
   rules: {
-    semi: "off",
-    "no-only-tests/no-only-tests": "error",
-    curly: ["error", "multi-line", "consistent"],
-    "keyword-spacing": ["error"],
+    "no-only-tests/no-only-tests": "warn",
     "no-implicit-globals": ["error"],
     "no-restricted-globals": [
       "error",
@@ -54,27 +52,9 @@ module.exports = {
       "origin",
       "status",
     ],
-    "no-trailing-spaces": ["error"],
-    "no-multi-spaces": ["error"],
-    "no-multiple-empty-lines": ["error"],
-    "space-before-blocks": ["error"],
-    "object-curly-spacing": ["error", "always"],
-    "array-bracket-spacing": ["error", "never"],
-    "space-before-function-paren": [
-      "error",
-      {
-        anonymous: "always",
-        named: "never",
-        asyncArrow: "always",
-      },
-    ],
-    "eol-last": ["error"],
-    "key-spacing": ["error"],
-    "@typescript-eslint/no-floating-promises": "error",
-    "@typescript-eslint/object-curly-spacing": ["error", "always"],
-    "@typescript-eslint/type-annotation-spacing": ["error"],
+    "@typescript-eslint/no-floating-promises": "warn",
     "@typescript-eslint/naming-convention": [
-      "error",
+      "warn",
       {
         selector: "enumMember",
         format: ["PascalCase"],
@@ -108,43 +88,29 @@ module.exports = {
     ],
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-namespace": ["error", { allowDeclarations: true }],
-    "@typescript-eslint/semi": ["error"],
-    "@typescript-eslint/member-delimiter-style": [
-      "error",
-      {
-        multiline: {
-          delimiter: "semi",
-          requireLast: true,
-        },
-        singleline: {
-          delimiter: "semi",
-          requireLast: false,
-        },
-      },
-    ],
     "@typescript-eslint/member-ordering": [
-      "error",
+      "warn",
       { default: ["field", "signature", "constructor", "method"] },
     ],
 
-    "@typescript-eslint/no-invalid-void-type": ["error"],
+    "@typescript-eslint/no-invalid-void-type": ["warn"],
     // Disallow Unused Variables.
     // https://eslint.org/docs/rules/no-unused-vars
-    "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
     // Require using arrow functions as callbacks.
     // https://eslint.org/docs/rules/prefer-arrow-callback
-    "prefer-arrow-callback": "error",
+    "prefer-arrow-callback": "warn",
     // Require using const for variables that are never modified after declared.
     // https://eslint.org/docs/rules/prefer-const
-    "prefer-const": "error",
+    "prefer-const": "warn",
     // Disallow modifying variables that are declared using const.
     // https://eslint.org/docs/rules/no-const-assign
     "no-const-assign": "error",
     // Require let or const instead of var.
     // https://eslint.org/docs/rules/no-var
-    "no-var": "error",
+    "no-var": "warn",
     // Require `===` and `!==` comparisons.
-    eqeqeq: "error",
+    eqeqeq: "warn",
     // Allow explict type annotations for additional clarity.
     "@typescript-eslint/no-inferrable-types": "off",
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@typescript-eslint/eslint-plugin": "^5.61.0",
         "chalk": "^5.3.0",
         "eslint": "^8.44.0",
+        "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-no-only-tests": "^3.1.0",
         "eslint-plugin-svelte": "^2.32.2",
         "execa": "^7.1.1",
@@ -1936,6 +1937,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-plugin-no-only-tests": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@typescript-eslint/eslint-plugin": "^5.61.0",
     "chalk": "^5.3.0",
     "eslint": "^8.44.0",
+    "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-svelte": "^2.32.2",
     "execa": "^7.1.1",

--- a/scripts/check
+++ b/scripts/check
@@ -2,6 +2,6 @@
 set -e
 
 npx tsc --noEmit
-npx svelte-check --tsconfig tsconfig.json
-npx eslint --cache --cache-location node_modules/.cache/eslint .
+npx svelte-check --tsconfig tsconfig.json --fail-on-warnings
+npx eslint --cache --cache-location node_modules/.cache/eslint --max-warnings 0 .
 npx prettier "**/*.@(ts|js|svelte|json|css|html|yml)" --ignore-path .gitignore --check --cache


### PR DESCRIPTION
* We remove all styling related lints and use `eslint-config-prettier`. There’s no need to bother developers with styling lints because Prettier already takes care of that. (This is the [recommended integration with Prettier][1])

* We use the “warning” level for lints that are code style related. This allows developers to distinguish issues that need to be fixed now (like type errors) and issues that can be fixed later (like style errors). We do enforce all lints on CI by settings `--max-warnings=0`.

[1]: https://prettier.io/docs/en/integrating-with-linters.html