### PR TITLE
Remove redundant project route props

### DIFF
--- a/src/views/projects/BranchSelector.svelte
+++ b/src/views/projects/BranchSelector.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import type { BaseUrl } from "@httpd-client";
-  import type { LoadedSourceBrowsingView } from "@app/views/projects/router";
+  import type {
+    LoadedSourceBrowsingView,
+    ProjectsParams,
+  } from "@app/views/projects/router";
 
   import * as utils from "@app/lib/utils";
   import { closeFocused } from "@app/components/Floating.svelte";
@@ -23,6 +26,27 @@
     .map(b => ({ key: b, value: b, title: `Switch to ${b}`, badge: null }));
   $: showSelector = branchList.length > 1;
   $: selectedCommitShortId = utils.formatCommit(selectedCommitId);
+
+  function routeParamsView(
+    view: LoadedSourceBrowsingView,
+  ): ProjectsParams["view"] {
+    if (view.resource === "tree") {
+      return {
+        resource: "tree",
+      };
+    } else if (view.resource === "history") {
+      return {
+        resource: "history",
+      };
+    } else if (view.resource === "commits") {
+      return {
+        resource: "commits",
+        commitId: view.commit.commit.id,
+      };
+    } else {
+      return utils.unreachable(view);
+    }
+  }
 </script>
 
 <style>
@@ -88,7 +112,7 @@
                     baseUrl,
                     peer,
                     revision: item.value,
-                    view,
+                    view: routeParamsView(view),
                   },
                 }}
                 on:afterNavigate={() => closeFocused()}>

--- a/src/views/projects/Browser.svelte
+++ b/src/views/projects/Browser.svelte
@@ -15,7 +15,6 @@
 
   export let baseUrl: BaseUrl;
   export let branches: Record<string, string> | undefined;
-  export let commit: string;
   export let commitCount: number;
   export let contributorCount: number;
   export let path: string;
@@ -34,16 +33,18 @@
   const api = new HttpdClient(baseUrl);
 
   const fetchTree = async (path: string) => {
-    return api.project.getTree(project.id, commit, path).catch(() => {
-      blobResult = {
-        ok: false,
-        error: {
-          message: "Not able to expand directory",
-          path,
-        },
-      };
-      return undefined;
-    });
+    return api.project
+      .getTree(project.id, tree.lastCommit.id, path)
+      .catch(() => {
+        blobResult = {
+          ok: false,
+          error: {
+            message: "Not able to expand directory",
+            path,
+          },
+        };
+        return undefined;
+      });
   };
 </script>
 
@@ -182,7 +183,11 @@
             {path}
             blob={blobResult.blob}
             highlighted={blobResult.highlighted}
-            rawPath={utils.getRawBasePath(project.id, baseUrl, commit)} />
+            rawPath={utils.getRawBasePath(
+              project.id,
+              baseUrl,
+              tree.lastCommit.id,
+            )} />
         {:else}
           <Placeholder emoji="🍂">
             <span slot="title">

--- a/src/views/projects/PeerSelector.svelte
+++ b/src/views/projects/PeerSelector.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
   import type { BaseUrl, Remote } from "@httpd-client";
-  import type { LoadedSourceBrowsingView } from "@app/views/projects/router";
+  import type {
+    LoadedSourceBrowsingView,
+    ProjectsParams,
+  } from "@app/views/projects/router";
 
   import { closeFocused } from "@app/components/Floating.svelte";
-  import { formatNodeId, truncateId } from "@app/lib/utils";
+  import { formatNodeId, truncateId, unreachable } from "@app/lib/utils";
   import { pluralize } from "@app/lib/pluralize";
 
   import Avatar from "@app/components/Avatar.svelte";
@@ -27,6 +30,27 @@
     return p.delegate
       ? `${nodeId} is a delegate of this project`
       : `${nodeId} is a peer tracked by this node`;
+  }
+
+  function routeParamsView(
+    view: LoadedSourceBrowsingView,
+  ): ProjectsParams["view"] {
+    if (view.resource === "tree") {
+      return {
+        resource: "tree",
+      };
+    } else if (view.resource === "history") {
+      return {
+        resource: "history",
+      };
+    } else if (view.resource === "commits") {
+      return {
+        resource: "commits",
+        commitId: view.commit.commit.id,
+      };
+    } else {
+      return unreachable(view);
+    }
   }
 </script>
 
@@ -116,7 +140,7 @@
                 baseUrl,
                 peer: item.id,
                 revision: undefined,
-                view,
+                view: routeParamsView(view),
               },
             }}>
             <DropdownItem

--- a/src/views/projects/View.svelte
+++ b/src/views/projects/View.svelte
@@ -61,7 +61,6 @@
     <Browser
       blobResult={view.blobResult}
       branches={view.params.loadedBranches}
-      commit={view.params.selectedCommit}
       commitCount={view.params.loadedTree.stats.commits}
       contributorCount={view.params.loadedTree.stats.contributors}
       path={view.path}

--- a/src/views/projects/router.ts
+++ b/src/views/projects/router.ts
@@ -91,8 +91,6 @@ export type LoadedSourceBrowsingView =
   | {
       resource: "commits";
       params: LoadedSourceBrowsingParams;
-      // FIXME: We need the ID so that `updateProjectRoute()` type checks.
-      commitId: string;
       commit: Commit;
     }
   | {
@@ -308,7 +306,6 @@ export async function loadProjectRoute(
           view: {
             resource: params.view.resource,
             params: viewParams,
-            commitId: params.view.commitId,
             commit: loadedCommit,
           },
         },

--- a/src/views/projects/router.ts
+++ b/src/views/projects/router.ts
@@ -75,7 +75,6 @@ interface LoadedSourceBrowsingParams {
   loadedBranches: Record<string, string> | undefined;
   loadedPeers: Remote[];
   loadedTree: Tree;
-  selectedCommit: string;
 }
 
 export type BlobResult =
@@ -202,7 +201,6 @@ export async function loadProjectRoute(
         loadedBranches: branches,
         loadedPeers: peers,
         loadedTree: tree,
-        selectedCommit: commit,
       };
       if (params.view.resource === "tree") {
         let blobResult: BlobResult;
@@ -295,7 +293,6 @@ export async function loadProjectRoute(
         loadedBranches: undefined,
         loadedPeers: peers,
         loadedTree: tree,
-        selectedCommit: params.view.commitId,
       };
       const loadedCommit = await api.project.getCommitBySha(
         params.id,


### PR DESCRIPTION
This PR consists of two commits that remove redundant properties from the project route types.

We remove the requirement that `LoadedSourceBrowsingView` needs to be assignable to `ProjectParams["view"]`. This decouples `ProjectRoute` and `ProjectLoadedRoute` and lets us modify them independently.

I did not use a common `routeParamsView` function because I prefer the flexibility of being able to modify them independently while this area of code changes a lot.