### PR TITLE
Set page title in the router

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
       import { Buffer } from "buffer";
       window.Buffer = Buffer;
     </script>
-    <title>Radicle Interface</title>
+    <title>Radicle</title>
   </head>
   <body>
     <script type="module" src="/src/index.ts"></script>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -51,10 +51,6 @@
   }
 </style>
 
-<svelte:head>
-  <title>Radicle</title>
-</svelte:head>
-
 {#if $activeRouteStore.resource !== "booting"}
   <LoadingBar />
 {/if}

--- a/src/views/home/Index.svelte
+++ b/src/views/home/Index.svelte
@@ -51,10 +51,6 @@
   }
 </style>
 
-<svelte:head>
-  <title>Radicle &ndash; Home</title>
-</svelte:head>
-
 <div class="wrapper">
   <div class="blurb">
     <p use:twemoji>

--- a/src/views/projects/router.ts
+++ b/src/views/projects/router.ts
@@ -651,4 +651,37 @@ export function projectRouteToPath(params: ProjectsParams): string {
   }
 }
 
+export function projectTitle(loadedRoute: ProjectLoadedRoute) {
+  const title: string[] = [];
+
+  if (loadedRoute.params.view.resource === "tree") {
+    title.push(loadedRoute.params.project.name);
+    title.push(loadedRoute.params.project.description);
+  } else if (loadedRoute.params.view.resource === "commits") {
+    title.push(loadedRoute.params.view.commit.commit.summary);
+    title.push("commit");
+  } else if (loadedRoute.params.view.resource === "history") {
+    title.push(loadedRoute.params.project.name);
+    title.push("history");
+  } else if (loadedRoute.params.view.resource === "newIssue") {
+    title.push("new issue");
+  } else if (loadedRoute.params.view.resource === "issue") {
+    title.push(loadedRoute.params.view.issue.title);
+    title.push("issue");
+  } else if (loadedRoute.params.view.resource === "issues") {
+    title.push(loadedRoute.params.project.name);
+    title.push("issues");
+  } else if (loadedRoute.params.view.resource === "patch") {
+    title.push(loadedRoute.params.view.patch.title);
+    title.push("patch");
+  } else if (loadedRoute.params.view.resource === "patches") {
+    title.push(loadedRoute.params.project.name);
+    title.push("patches");
+  } else {
+    return unreachable(loadedRoute.params.view);
+  }
+
+  return title;
+}
+
 export const testExports = { isOid };

--- a/src/views/seeds/View.svelte
+++ b/src/views/seeds/View.svelte
@@ -92,10 +92,6 @@
   }
 </style>
 
-<svelte:head>
-  <title>{hostname}</title>
-</svelte:head>
-
 <div class="wrapper">
   <div class="header">
     {hostname}


### PR DESCRIPTION
This improves UX making it easier to find the tab that I'm looking for when I have multiple tabs open.

We can come up with a more elaborate structure, but for now this might be sufficient.

<img width="1439" alt="Screenshot 2023-07-11 at 17 30 59" src="https://github.com/radicle-dev/radicle-interface/assets/158411/b8a0b7fd-7a4f-4d6c-bd32-36800effc127">
