### PR TITLE
Don’t intercept navigation to external URLs in Markdown

### DIFF
--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -45,8 +45,10 @@
       return;
     }
 
-    event.preventDefault();
-    void router.navigateToUrl("push", url);
+    if (url.origin === window.origin) {
+      event.preventDefault();
+      void router.navigateToUrl("push", url);
+    }
   }
 
   function render(content: string): string {

--- a/tests/e2e/project.spec.ts
+++ b/tests/e2e/project.spec.ts
@@ -438,14 +438,11 @@ test.describe("browser error handling", () => {
 });
 
 test("external markdown link", async ({ page }) => {
-  await page.route("http://github.github.com/**", route => {
+  await page.route("https://example.com/**", route => {
     return route.fulfill({ body: "hello", contentType: "text/plain" });
   });
-  await page.goto(`${markdownUrl}/tree/main/cheatsheet.md`);
-  await page
-    .getByRole("link", { name: "Github-flavored Markdown info page" })
-    .click();
-  await expect(page).toHaveURL(
-    "http://github.github.com/github-flavored-markdown/",
-  );
+  await page.goto(`${markdownUrl}/tree/main/footnotes.md`);
+  await page.getByRole("link", { name: "https://example.com" }).click();
+  await page.pause();
+  await expect(page).toHaveURL("https://example.com");
 });

--- a/tests/e2e/project.spec.ts
+++ b/tests/e2e/project.spec.ts
@@ -436,3 +436,16 @@ test.describe("browser error handling", () => {
     await expect(page.locator("text=Not able to load file")).toBeVisible();
   });
 });
+
+test("external markdown link", async ({ page }) => {
+  await page.route("http://github.github.com/**", route => {
+    return route.fulfill({ body: "hello", contentType: "text/plain" });
+  });
+  await page.goto(`${markdownUrl}/tree/main/cheatsheet.md`);
+  await page
+    .getByRole("link", { name: "Github-flavored Markdown info page" })
+    .click();
+  await expect(page).toHaveURL(
+    "http://github.github.com/github-flavored-markdown/",
+  );
+});


### PR DESCRIPTION
Fixes #928

Also includes a commit that improves Playwright route mocking:

We determine URLs to mock with a URL matcher instead of mocking every URL and determining the behavior in the route handler. This should be slightly faster and should result in better debugging experience because we don’t come across the `route.continue()` event that often.