### PR TITLE
Cleanup shared peer and revision props for project route

### DIFF
--- a/src/views/projects/Commit.svelte
+++ b/src/views/projects/Commit.svelte
@@ -18,7 +18,6 @@
   export let peer: string | undefined = undefined;
   export let peers: Remote[];
   export let project: Project;
-  export let revision: string | undefined;
   export let view: LoadedSourceBrowsingView;
 
   const { commit: header } = commit;
@@ -68,7 +67,7 @@
   {contributorCount}
   {peers}
   {peer}
-  {revision}
+  revision={commit.commit.id}
   {view} />
 
 <div class="commit">

--- a/src/views/projects/View.svelte
+++ b/src/views/projects/View.svelte
@@ -20,8 +20,12 @@
   export let project: Project;
   export let view: ProjectLoadedView;
 
-  export let peer: string | undefined = undefined;
-  export let revision: string | undefined = undefined;
+  let peer: string | undefined;
+  $: if (view.resource === "tree" || view.resource === "history") {
+    peer = view.peer;
+  } else {
+    peer = undefined;
+  }
 </script>
 
 <style>
@@ -69,7 +73,7 @@
       {baseUrl}
       {peer}
       {project}
-      {revision}
+      revision={view.revision}
       {view} />
   {:else if view.resource === "history"}
     <History
@@ -82,7 +86,7 @@
       {baseUrl}
       {peer}
       {project}
-      {revision}
+      revision={view.revision}
       {view} />
   {:else if view.resource === "commits"}
     <Commit
@@ -94,7 +98,6 @@
       {baseUrl}
       {peer}
       {project}
-      {revision}
       {view} />
   {:else if view.resource === "issues"}
     {#if view.params.view.resource === "new"}

--- a/src/views/projects/router.ts
+++ b/src/views/projects/router.ts
@@ -66,9 +66,6 @@ export interface ProjectLoadedParams {
   id: string;
   project: Project;
   view: ProjectLoadedView;
-
-  peer?: string;
-  revision?: string;
 }
 
 interface LoadedSourceBrowsingParams {
@@ -84,6 +81,8 @@ export type BlobResult =
 export type LoadedSourceBrowsingView =
   | {
       resource: "tree";
+      peer: string | undefined;
+      revision: string | undefined;
       params: LoadedSourceBrowsingParams;
       path: string;
       blobResult: BlobResult;
@@ -95,6 +94,8 @@ export type LoadedSourceBrowsingView =
     }
   | {
       resource: "history";
+      peer: string | undefined;
+      revision: string | undefined;
       params: LoadedSourceBrowsingParams;
       commitHeaders: CommitHeader[];
       totalCommitCount: number;
@@ -244,10 +245,13 @@ export async function loadProjectRoute(
         return {
           resource: "projects",
           params: {
-            ...params,
+            id: params.id,
+            baseUrl: params.baseUrl,
             project,
             view: {
-              resource: params.view.resource,
+              resource: "tree",
+              peer: params.peer,
+              revision: params.revision,
               params: viewParams,
               path,
               blobResult,
@@ -264,10 +268,13 @@ export async function loadProjectRoute(
         return {
           resource: "projects",
           params: {
-            ...params,
+            id: params.id,
+            baseUrl: params.baseUrl,
             project,
             view: {
-              resource: params.view.resource,
+              resource: "history",
+              peer: params.peer,
+              revision: params.revision,
               params: viewParams,
               commitHeaders: commitsResponse.commits.map(c => c.commit),
               totalCommitCount: commitsResponse.stats.commits,
@@ -300,11 +307,11 @@ export async function loadProjectRoute(
       return {
         resource: "projects",
         params: {
-          ...params,
-          revision: params.view.commitId,
+          id: params.id,
+          baseUrl: params.baseUrl,
           project,
           view: {
-            resource: params.view.resource,
+            resource: "commits",
             params: viewParams,
             commit: loadedCommit,
           },
@@ -324,7 +331,8 @@ export async function loadProjectRoute(
         return {
           resource: "projects",
           params: {
-            ...params,
+            id: params.id,
+            baseUrl: params.baseUrl,
             project,
             view: {
               resource: "issue",
@@ -356,7 +364,8 @@ export async function loadProjectRoute(
         return {
           resource: "projects",
           params: {
-            ...params,
+            id: params.id,
+            baseUrl: params.baseUrl,
             project,
             view: {
               resource: "patch",
@@ -383,7 +392,8 @@ export async function loadProjectRoute(
       return {
         resource: "projects",
         params: {
-          ...params,
+          id: params.id,
+          baseUrl: params.baseUrl,
           view: {
             resource: "issues",
             params: { search: "", ...params.view.params },
@@ -396,7 +406,8 @@ export async function loadProjectRoute(
       return {
         resource: "projects",
         params: {
-          ...params,
+          id: params.id,
+          baseUrl: params.baseUrl,
           view: {
             resource: "patches",
             params: { search: "", ...params.view.params },


### PR DESCRIPTION
We move the `peer` and `revision` properties from the shared `ProjectLoadedParams` interface to the `tree` and `history` subroutes where they are needed.