### PR TITLE
Switch to flat project route type

### DIFF
--- a/src/App/Header/Search.svelte
+++ b/src/App/Header/Search.svelte
@@ -49,13 +49,9 @@
       if (searchResult.results.length === 1) {
         const { project, baseUrl } = searchResult.results[0];
         void router.push({
-          resource: "projects",
-          params: {
-            view: { resource: "tree" },
-            id: project.id,
-            peer: undefined,
-            baseUrl,
-          },
+          resource: "project.tree",
+          project: project.id,
+          seed: baseUrl,
         });
       } else {
         modal.show({

--- a/src/App/Header/SearchResultsModal.svelte
+++ b/src/App/Header/SearchResultsModal.svelte
@@ -37,12 +37,9 @@
             <Link
               on:afterNavigate={modal.hide}
               route={{
-                resource: "projects",
-                params: {
-                  view: { resource: "tree" },
-                  baseUrl: result.baseUrl,
-                  id: result.project.id,
-                },
+                resource: "project.tree",
+                seed: result.baseUrl,
+                project: result.project.id,
               }}>
               <span title={result.baseUrl.hostname}>
                 <span>{result.project.name}</span>

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -187,19 +187,13 @@ function pathToRoute(url: URL): Route | null {
         const baseUrl = extractBaseUrl(hostAndPort);
         const id = segments.shift();
         if (id) {
-          const params = resolveProjectRoute(baseUrl, id, segments, url.search);
-          if (params) {
-            return {
-              resource: "projects",
-              params: params,
-            };
-          }
-          return null;
+          return resolveProjectRoute(baseUrl, id, segments, url.search);
+        } else {
+          return {
+            resource: "seeds",
+            params: { baseUrl, projectPageIndex: 0 },
+          };
         }
-        return {
-          resource: "seeds",
-          params: { baseUrl, projectPageIndex: 0 },
-        };
       }
       return null;
     }
@@ -235,8 +229,17 @@ export function routeToPath(route: Route): string {
     return seedPath(route.params.baseUrl);
   } else if (route.resource === "loadError") {
     return "";
-  } else if (route.resource === "projects") {
-    return projectRouteToPath(route.params);
+  } else if (
+    route.resource === "project.tree" ||
+    route.resource === "project.history" ||
+    route.resource === "project.commit" ||
+    route.resource === "project.issues" ||
+    route.resource === "project.newIssue" ||
+    route.resource === "project.issue" ||
+    route.resource === "project.patches" ||
+    route.resource === "project.patch"
+  ) {
+    return projectRouteToPath(route);
   } else if (route.resource === "booting") {
     return "";
   } else if (route.resource === "notFound") {

--- a/src/lib/router/definitions.ts
+++ b/src/lib/router/definitions.ts
@@ -55,8 +55,17 @@ export async function loadRoute(route: Route): Promise<LoadedRoute> {
     return await loadSeedRoute(route.params);
   } else if (route.resource === "home") {
     return await loadHomeRoute();
-  } else if (route.resource === "projects") {
-    return await loadProjectRoute(route.params);
+  } else if (
+    route.resource === "project.tree" ||
+    route.resource === "project.history" ||
+    route.resource === "project.commit" ||
+    route.resource === "project.issues" ||
+    route.resource === "project.newIssue" ||
+    route.resource === "project.issue" ||
+    route.resource === "project.patches" ||
+    route.resource === "project.patch"
+  ) {
+    return await loadProjectRoute(route);
   } else {
     return route;
   }

--- a/src/views/home/Index.svelte
+++ b/src/views/home/Index.svelte
@@ -70,14 +70,9 @@
         <div class="project">
           <Link
             route={{
-              resource: "projects",
-              params: {
-                view: { resource: "tree" },
-                id: project.id,
-                baseUrl,
-                peer: undefined,
-                revision: undefined,
-              },
+              resource: "project.tree",
+              project: project.id,
+              seed: baseUrl,
             }}>
             <ProjectCard
               compact

--- a/src/views/projects/BranchSelector.svelte
+++ b/src/views/projects/BranchSelector.svelte
@@ -2,7 +2,7 @@
   import type { BaseUrl } from "@httpd-client";
   import type {
     LoadedSourceBrowsingView,
-    ProjectsParams,
+    ProjectRoute,
   } from "@app/views/projects/router";
 
   import * as utils from "@app/lib/utils";
@@ -27,21 +27,32 @@
   $: showSelector = branchList.length > 1;
   $: selectedCommitShortId = utils.formatCommit(selectedCommitId);
 
-  function routeParamsView(
+  function routeFromView(
+    revision: string,
     view: LoadedSourceBrowsingView,
-  ): ProjectsParams["view"] {
+  ): ProjectRoute {
     if (view.resource === "tree") {
       return {
-        resource: "tree",
+        resource: "project.tree",
+        seed: baseUrl,
+        project: projectId,
+        peer,
+        revision,
       };
     } else if (view.resource === "history") {
       return {
-        resource: "history",
+        resource: "project.history",
+        seed: baseUrl,
+        project: projectId,
+        peer,
+        revision,
       };
     } else if (view.resource === "commits") {
       return {
-        resource: "commits",
-        commitId: view.commit.commit.id,
+        resource: "project.commit",
+        seed: baseUrl,
+        project: projectId,
+        commit: view.commit.commit.id,
       };
     } else {
       return utils.unreachable(view);
@@ -105,16 +116,7 @@
           <Dropdown items={branchList}>
             <svelte:fragment slot="item" let:item>
               <Link
-                route={{
-                  resource: "projects",
-                  params: {
-                    id: projectId,
-                    baseUrl,
-                    peer,
-                    revision: item.value,
-                    view: routeParamsView(view),
-                  },
-                }}
+                route={routeFromView(item.value, view)}
                 on:afterNavigate={() => closeFocused()}>
                 <DropdownItem
                   selected={item.value === selectedBranch}

--- a/src/views/projects/Cob/Revision.svelte
+++ b/src/views/projects/Cob/Revision.svelte
@@ -211,18 +211,11 @@
               previousRevOid,
             )}..{utils.formatObjectId(revisionOid)}"
             route={{
-              resource: "projects",
-              params: {
-                id: projectId,
-                baseUrl,
-                view: {
-                  resource: "patch",
-                  params: {
-                    patch: patchId,
-                    search: `diff=${previousRevOid}..${revisionOid}`,
-                  },
-                },
-              },
+              resource: "project.patch",
+              project: projectId,
+              seed: baseUrl,
+              patch: patchId,
+              search: `diff=${previousRevOid}..${revisionOid}`,
             }}>
             <Icon name="diff" />
           </Link>
@@ -240,18 +233,11 @@
                 <Link
                   title="{item}..{revisionOid}"
                   route={{
-                    resource: "projects",
-                    params: {
-                      id: projectId,
-                      baseUrl,
-                      view: {
-                        resource: "patch",
-                        params: {
-                          patch: patchId,
-                          search: `diff=${item}..${revisionOid}`,
-                        },
-                      },
-                    },
+                    resource: "project.patch",
+                    project: projectId,
+                    seed: baseUrl,
+                    patch: patchId,
+                    search: `diff=${item}..${revisionOid}`,
                   }}>
                   {#if item === projectHead}
                     <DropdownItem selected={false} size="small">
@@ -305,12 +291,10 @@
                     <Avatar inline nodeId={revisionAuthor.id} />
                     <Link
                       route={{
-                        resource: "projects",
-                        params: {
-                          id: projectId,
-                          baseUrl,
-                          view: { resource: "commits", commitId: commit.id },
-                        },
+                        resource: "project.commit",
+                        project: projectId,
+                        seed: baseUrl,
+                        commit: commit.id,
                       }}>
                       <div class="commit-summary" use:twemoji>
                         <InlineMarkdown

--- a/src/views/projects/Commit/CommitTeaser.svelte
+++ b/src/views/projects/Commit/CommitTeaser.svelte
@@ -10,7 +10,6 @@
 
   export let baseUrl: BaseUrl;
   export let commit: CommitHeader;
-  export let peer: string | undefined = undefined;
   export let projectId: string;
 
   let expandCommitMessage = false;
@@ -99,13 +98,10 @@
     <div class="message">
       <Link
         route={{
-          resource: "projects",
-          params: {
-            peer,
-            id: projectId,
-            baseUrl,
-            view: { resource: "commits", commitId: commit.id },
-          },
+          resource: "project.commit",
+          project: projectId,
+          seed: baseUrl,
+          commit: commit.id,
         }}>
         <div class="summary" use:twemoji>
           <InlineMarkdown content={commit.summary} />
@@ -136,13 +132,10 @@
       title="Browse the repository at this point in the history">
       <Link
         route={{
-          resource: "projects",
-          params: {
-            id: projectId,
-            baseUrl,
-            revision: commit.id,
-            view: { resource: "tree" },
-          },
+          resource: "project.tree",
+          project: projectId,
+          seed: baseUrl,
+          revision: commit.id,
         }}>
         <Icon name="browse" />
       </Link>

--- a/src/views/projects/Header.svelte
+++ b/src/views/projects/Header.svelte
@@ -43,13 +43,10 @@
 <div class="header">
   <Link
     route={{
-      resource: "projects",
-      params: {
-        id: projectId,
-        baseUrl,
-        view: { resource: "tree" },
-        path: "/",
-      },
+      resource: "project.tree",
+      project: projectId,
+      seed: baseUrl,
+      path: "/",
     }}>
     <SquareButton
       active={resource === "tree" ||
@@ -63,15 +60,9 @@
   </Link>
   <Link
     route={{
-      resource: "projects",
-      params: {
-        id: projectId,
-        baseUrl,
-        view: {
-          resource: "issues",
-          params: { view: { resource: "list" } },
-        },
-      },
+      resource: "project.issues",
+      project: projectId,
+      seed: baseUrl,
     }}>
     <SquareButton active={resource === "issues" || resource === "issue"}>
       <svelte:fragment slot="icon">
@@ -84,15 +75,9 @@
 
   <Link
     route={{
-      resource: "projects",
-      params: {
-        id: projectId,
-        baseUrl,
-        view: {
-          resource: "patches",
-          params: { view: { resource: "list" } },
-        },
-      },
+      resource: "project.patches",
+      project: projectId,
+      seed: baseUrl,
     }}>
     <SquareButton active={resource === "patches" || resource === "patch"}>
       <svelte:fragment slot="icon">

--- a/src/views/projects/History.svelte
+++ b/src/views/projects/History.svelte
@@ -101,7 +101,7 @@
     <div class="group">
       {#each group.commits as commit (commit.id)}
         <div class="teaser-wrapper">
-          <CommitTeaser {peer} projectId={project.id} {baseUrl} {commit} />
+          <CommitTeaser projectId={project.id} {baseUrl} {commit} />
         </div>
       {/each}
     </div>

--- a/src/views/projects/Issue.svelte
+++ b/src/views/projects/Issue.svelte
@@ -167,15 +167,10 @@
       );
       if (status === "success") {
         void router.push({
-          resource: "projects",
-          params: {
-            id: projectId,
-            baseUrl,
-            view: {
-              resource: "issue",
-              params: { issue: issue.id },
-            },
-          },
+          resource: "project.issue",
+          project: projectId,
+          seed: baseUrl,
+          issue: issue.id,
         });
       }
     }

--- a/src/views/projects/Issue/IssueTeaser.svelte
+++ b/src/views/projects/Issue/IssueTeaser.svelte
@@ -105,15 +105,10 @@
     <div class="summary">
       <Link
         route={{
-          resource: "projects",
-          params: {
-            id: projectId,
-            baseUrl,
-            view: {
-              resource: "issue",
-              params: { issue: issue.id },
-            },
-          },
+          resource: "project.issue",
+          project: projectId,
+          seed: baseUrl,
+          issue: issue.id,
         }}>
         <span class="issue-title">
           <InlineMarkdown content={issue.title} />

--- a/src/views/projects/Issue/New.svelte
+++ b/src/views/projects/Issue/New.svelte
@@ -52,15 +52,10 @@
       );
 
       void router.push({
-        resource: "projects",
-        params: {
-          id: projectId,
-          baseUrl,
-          view: {
-            resource: "issue",
-            params: { issue: result.id },
-          },
-        },
+        resource: "project.issue",
+        project: projectId,
+        seed: baseUrl,
+        issue: result.id,
       });
     } catch {
       modal.show({

--- a/src/views/projects/Issues.svelte
+++ b/src/views/projects/Issues.svelte
@@ -120,18 +120,10 @@
           {#if !option.disabled}
             <Link
               route={{
-                resource: "projects",
-                params: {
-                  id: projectId,
-                  baseUrl,
-                  view: {
-                    resource: "issues",
-                    params: {
-                      view: { resource: "list" },
-                      search: `state=${option.value}`,
-                    },
-                  },
-                },
+                resource: "project.issues",
+                project: projectId,
+                seed: baseUrl,
+                search: `state=${option.value}`,
               }}>
               <SquareButton
                 clickable={option.disabled}
@@ -154,15 +146,9 @@
     {#if $httpdStore.state === "authenticated" && utils.isLocal(baseUrl.hostname)}
       <Link
         route={{
-          resource: "projects",
-          params: {
-            id: projectId,
-            baseUrl,
-            view: {
-              resource: "issues",
-              params: { view: { resource: "new" } },
-            },
-          },
+          resource: "project.newIssue",
+          project: projectId,
+          seed: baseUrl,
         }}>
         <SquareButton>New issue</SquareButton>
       </Link>

--- a/src/views/projects/Patch.svelte
+++ b/src/views/projects/Patch.svelte
@@ -327,19 +327,12 @@
           {#if !option.disabled}
             <Link
               route={{
-                resource: "projects",
-                params: {
-                  id: projectId,
-                  baseUrl,
-                  view: {
-                    resource: "patch",
-                    params: {
-                      patch: patch.id,
-                      revision,
-                      search: `tab=${option.value}`,
-                    },
-                  },
-                },
+                resource: "project.patch",
+                project: projectId,
+                seed: baseUrl,
+                patch: patch.id,
+                revision,
+                search: `tab=${option.value}`,
               }}>
               <SquareButton
                 size="small"
@@ -362,18 +355,11 @@
         {#if diff}
           <Link
             route={{
-              resource: "projects",
-              params: {
-                id: projectId,
-                baseUrl,
-                view: {
-                  resource: "patch",
-                  params: {
-                    patch: patch.id,
-                    search: `diff=${diff}`,
-                  },
-                },
-              },
+              resource: "project.patch",
+              project: projectId,
+              seed: baseUrl,
+              patch: patch.id,
+              search: `diff=${diff}`,
             }}>
             <SquareButton size="small" active={true}>
               Diff {diff.substr(0, 6)}..{diff.split("..")[1].substr(0, 6)}
@@ -398,20 +384,12 @@
                 <Link
                   on:afterNavigate={closeFocused}
                   route={{
-                    resource: "projects",
-                    params: {
-                      id: projectId,
-
-                      baseUrl,
-                      view: {
-                        resource: "patch",
-                        params: {
-                          patch: patch.id,
-                          revision: item.id,
-                          search: `tab=${currentTab}`,
-                        },
-                      },
-                    },
+                    resource: "project.patch",
+                    project: projectId,
+                    seed: baseUrl,
+                    patch: patch.id,
+                    revision: item.id,
+                    search: `tab=${currentTab}`,
                   }}>
                   <DropdownItem
                     selected={item.id === currentRevision.id}

--- a/src/views/projects/Patch/PatchTeaser.svelte
+++ b/src/views/projects/Patch/PatchTeaser.svelte
@@ -128,15 +128,10 @@
     <div class="summary">
       <Link
         route={{
-          resource: "projects",
-          params: {
-            id: projectId,
-            baseUrl,
-            view: {
-              resource: "patch",
-              params: { patch: patch.id },
-            },
-          },
+          resource: "project.patch",
+          project: projectId,
+          seed: baseUrl,
+          patch: patch.id,
         }}>
         <span class="patch-title">
           <InlineMarkdown content={patch.title} />

--- a/src/views/projects/Patches.svelte
+++ b/src/views/projects/Patches.svelte
@@ -122,18 +122,10 @@
         {:else}
           <Link
             route={{
-              resource: "projects",
-              params: {
-                id: projectId,
-                baseUrl,
-                view: {
-                  resource: "patches",
-                  params: {
-                    view: { resource: "list" },
-                    search: `state=${option.value}`,
-                  },
-                },
-              },
+              resource: "project.patches",
+              project: projectId,
+              seed: baseUrl,
+              search: `state=${option.value}`,
             }}>
             <SquareButton
               clickable={option.disabled}

--- a/src/views/projects/PeerSelector.svelte
+++ b/src/views/projects/PeerSelector.svelte
@@ -2,7 +2,7 @@
   import type { BaseUrl, Remote } from "@httpd-client";
   import type {
     LoadedSourceBrowsingView,
-    ProjectsParams,
+    ProjectRoute,
   } from "@app/views/projects/router";
 
   import { closeFocused } from "@app/components/Floating.svelte";
@@ -32,21 +32,30 @@
       : `${nodeId} is a peer tracked by this node`;
   }
 
-  function routeParamsView(
+  function routeFromView(
+    peer: string,
     view: LoadedSourceBrowsingView,
-  ): ProjectsParams["view"] {
+  ): ProjectRoute {
     if (view.resource === "tree") {
       return {
-        resource: "tree",
+        resource: "project.tree",
+        seed: baseUrl,
+        project: projectId,
+        peer,
       };
     } else if (view.resource === "history") {
       return {
-        resource: "history",
+        resource: "project.history",
+        seed: baseUrl,
+        project: projectId,
+        peer,
       };
     } else if (view.resource === "commits") {
       return {
-        resource: "commits",
-        commitId: view.commit.commit.id,
+        resource: "project.commit",
+        seed: baseUrl,
+        project: projectId,
+        commit: view.commit.commit.id,
       };
     } else {
       return unreachable(view);
@@ -133,16 +142,7 @@
         <div class="dropdown-item">
           <Link
             on:afterNavigate={() => closeFocused()}
-            route={{
-              resource: "projects",
-              params: {
-                id: projectId,
-                baseUrl,
-                peer: item.id,
-                revision: undefined,
-                view: routeParamsView(view),
-              },
-            }}>
+            route={routeFromView(item.id, view)}>
             <DropdownItem
               selected={item.id === peer}
               title={createTitle(item)}

--- a/src/views/projects/ProjectMeta.svelte
+++ b/src/views/projects/ProjectMeta.svelte
@@ -89,13 +89,9 @@
     <span class="truncate">
       <Link
         route={{
-          resource: "projects",
-          params: {
-            id: projectId,
-            baseUrl,
-            view: { resource: "tree" },
-            path: "/",
-          },
+          resource: "project.tree",
+          project: projectId,
+          seed: baseUrl,
         }}>
         <span class="project-name">
           {projectName}

--- a/src/views/projects/Readme.svelte
+++ b/src/views/projects/Readme.svelte
@@ -23,15 +23,12 @@
       // Markdown.
       linkBaseUrl = new URL(
         routeToPath({
-          resource: "projects",
-          params: {
-            id: projectId,
-            baseUrl,
-            view: { resource: "tree" },
-            peer,
-            revision,
-            path: "README.md",
-          },
+          resource: "project.tree",
+          project: projectId,
+          seed: baseUrl,
+          peer,
+          revision,
+          path: "README.md",
         }),
         window.origin,
       ).href;

--- a/src/views/projects/SourceBrowser/FileDiff.svelte
+++ b/src/views/projects/SourceBrowser/FileDiff.svelte
@@ -175,14 +175,11 @@
     <div class="browse" title="View file">
       <Link
         route={{
-          resource: "projects",
-          params: {
-            id: projectId,
-            baseUrl,
-            view: { resource: "tree" },
-            path: file.path,
-            revision,
-          },
+          resource: "project.tree",
+          project: projectId,
+          seed: baseUrl,
+          path: file.path,
+          revision,
         }}>
         <Icon name="browse" />
       </Link>

--- a/src/views/projects/SourceBrowser/FileLocationChange.svelte
+++ b/src/views/projects/SourceBrowser/FileLocationChange.svelte
@@ -53,14 +53,11 @@
     <div class="browse" title="View file">
       <Link
         route={{
-          resource: "projects",
-          params: {
-            id: projectId,
-            baseUrl,
-            view: { resource: "tree" },
-            path: file.newPath,
-            revision,
-          },
+          resource: "project.tree",
+          project: projectId,
+          seed: baseUrl,
+          path: file.newPath,
+          revision,
         }}>
         <Icon name="browse" />
       </Link>

--- a/src/views/projects/SourceBrowsingHeader.svelte
+++ b/src/views/projects/SourceBrowsingHeader.svelte
@@ -30,7 +30,7 @@
   $: if (revision === commitId) {
     selectedBranch = undefined;
   } else {
-    selectedBranch = revision ?? defaultBranch;
+    selectedBranch = revision || defaultBranch;
   }
 </script>
 
@@ -72,14 +72,11 @@
 
   <Link
     route={{
-      resource: "projects",
-      params: {
-        id: projectId,
-        baseUrl,
-        peer,
-        revision,
-        view: { resource: "history" },
-      },
+      resource: "project.history",
+      project: projectId,
+      seed: baseUrl,
+      peer,
+      revision,
     }}>
     <SquareButton
       active={view.resource === "history" || view.resource === "commits"}>

--- a/src/views/projects/Tree.svelte
+++ b/src/views/projects/Tree.svelte
@@ -36,15 +36,12 @@
   {:else}
     <Link
       route={{
-        resource: "projects",
-        params: {
-          id: projectId,
-          baseUrl,
-          path: entry.path,
-          peer,
-          revision,
-          view: { resource: "tree" },
-        },
+        resource: "project.tree",
+        project: projectId,
+        seed: baseUrl,
+        path: entry.path,
+        peer,
+        revision,
       }}
       on:afterNavigate={() => onSelect({ detail: entry.path })}>
       <File active={entry.path === path} name={entry.name} />

--- a/src/views/projects/Tree/Folder.svelte
+++ b/src/views/projects/Tree/Folder.svelte
@@ -98,15 +98,12 @@
           {:else}
             <Link
               route={{
-                resource: "projects",
-                params: {
-                  id: projectId,
-                  baseUrl,
-                  path: entry.path,
-                  peer,
-                  revision,
-                  view: { resource: "tree" },
-                },
+                resource: "project.tree",
+                project: projectId,
+                seed: baseUrl,
+                path: entry.path,
+                peer,
+                revision,
               }}
               on:afterNavigate={() => onSelectFile({ detail: entry.path })}>
               <File active={entry.path === currentPath} name={entry.name} />

--- a/src/views/seeds/View.svelte
+++ b/src/views/seeds/View.svelte
@@ -123,12 +123,9 @@
         <div style:margin-bottom="0.5rem">
           <Link
             route={{
-              resource: "projects",
-              params: {
-                view: { resource: "tree" },
-                id: project.id,
-                baseUrl,
-              },
+              resource: "project.tree",
+              project: project.id,
+              seed: baseUrl,
             }}>
             <ProjectCard
               {activity}

--- a/tests/e2e/project/commit.spec.ts
+++ b/tests/e2e/project/commit.spec.ts
@@ -7,9 +7,7 @@ import {
   aliceRemote,
 } from "@tests/support/fixtures.js";
 
-const modifiedFileFixture = `${sourceBrowsingUrl}/remotes/${bobRemote.substring(
-  8,
-)}/commits/${bobHead}`;
+const commitUrl = `${sourceBrowsingUrl}/commits/${bobHead}`;
 
 test("navigation from commit list", async ({ page }) => {
   await page.goto(sourceBrowsingUrl);
@@ -18,7 +16,7 @@ test("navigation from commit list", async ({ page }) => {
   await page.locator('role=link[name="7 commits"]').click();
 
   await page.locator("text=Update readme").click();
-  await expect(page).toHaveURL(modifiedFileFixture);
+  await expect(page).toHaveURL(commitUrl);
 });
 
 test("relative timestamps", async ({ page }) => {
@@ -31,14 +29,14 @@ test("relative timestamps", async ({ page }) => {
       });
     };
   });
-  await page.goto(modifiedFileFixture);
+  await page.goto(commitUrl);
   await expect(
     page.locator(`.commit .header >> text=${"Bob Belcher committed now"}`),
   ).toBeVisible();
 });
 
 test("modified file", async ({ page }) => {
-  await page.goto(modifiedFileFixture);
+  await page.goto(commitUrl);
 
   // Commit header.
   {

--- a/tests/unit/router.test.ts
+++ b/tests/unit/router.test.ts
@@ -6,7 +6,7 @@ window.origin = "http://localhost:3000";
 
 describe("route invariant when parsed", () => {
   const origin = "http://localhost:3000";
-  const baseUrl = {
+  const seed = {
     hostname: "willow.radicle.garden",
     port: 8000,
     scheme: "http",
@@ -22,252 +22,180 @@ describe("route invariant when parsed", () => {
         // TODO: This only works with the value 0. The value is not actually
         // extract.
         projectPageIndex: 0,
-        baseUrl,
+        baseUrl: seed,
       },
     });
   });
   test("projects.tree", () => {
     expectParsingInvariant({
-      resource: "projects",
-      params: {
-        view: { resource: "tree" },
-        baseUrl,
-        id: "rad:zKtT7DmF9H34KkvcKj9PHW19WzjT",
-        route: "",
-      },
+      resource: "project.tree",
+      seed,
+      project: "rad:zKtT7DmF9H34KkvcKj9PHW19WzjT",
+      route: "",
     });
   });
 
   test("projects.tree with peer", () => {
     expectParsingInvariant({
-      resource: "projects",
-      params: {
-        view: { resource: "tree" },
-        baseUrl,
-        id: "PROJECT",
-        peer: "PEER",
-        route: "",
-      },
+      resource: "project.tree",
+      seed,
+      project: "PROJECT",
+      peer: "PEER",
+      route: "",
     });
   });
 
   test("projects.tree with peer and revision", () => {
     const route: Route = {
-      resource: "projects",
-      params: {
-        view: { resource: "tree" },
-        baseUrl,
-        id: "PROJECT",
-        peer: "PEER",
-        revision: "REVISION",
-        route: "",
-      },
+      resource: "project.tree",
+      seed,
+      project: "PROJECT",
+      peer: "PEER",
+      revision: "REVISION",
+      route: "",
     };
     const path = testExports.routeToPath(route);
-    route.params.revision = undefined;
-    route.params.route = "REVISION";
+    route.revision = undefined;
+    route.route = "REVISION";
     expect(testExports.pathToRoute(new URL(path, origin))).toEqual(route);
   });
 
   test("projects.tree with peer and revision and path", () => {
     const route: Route = {
-      resource: "projects",
-      params: {
-        view: { resource: "tree" },
-        baseUrl,
-        id: "PROJECT",
-        peer: "PEER",
-        path: "PATH",
-        revision: "REVISION",
-        route: "",
-      },
+      resource: "project.tree",
+      seed,
+      project: "PROJECT",
+      peer: "PEER",
+      path: "PATH",
+      revision: "REVISION",
+      route: "",
     };
     const path = testExports.routeToPath(route);
-    route.params.revision = undefined;
-    route.params.path = undefined;
-    route.params.route = "REVISION/PATH";
+    route.revision = undefined;
+    route.path = undefined;
+    route.route = "REVISION/PATH";
     expect(testExports.pathToRoute(new URL(path, origin))).toEqual(route);
   });
 
   test("projects.history", () => {
     expectParsingInvariant({
-      resource: "projects",
-      params: {
-        view: { resource: "history" },
-        baseUrl,
-        id: "PROJECT",
-        route: "",
-      },
+      resource: "project.history",
+      seed,
+      project: "PROJECT",
+      revision: "",
     });
   });
 
   test("projects.history with revision", () => {
-    const route: Route = {
-      resource: "projects",
-      params: {
-        view: { resource: "history" },
-        baseUrl,
-        id: "PROJECT",
-        peer: "PEER",
-        revision: "REVISION",
-      },
-    };
-    const path = testExports.routeToPath(route);
-    route.params.revision = undefined;
-    route.params.route = "REVISION";
-    expect(testExports.pathToRoute(new URL(path, origin))).toEqual(route);
+    expectParsingInvariant({
+      resource: "project.history",
+      seed,
+      project: "PROJECT",
+      revision: "REVISION",
+    });
   });
 
   test("projects.commits", () => {
     expectParsingInvariant({
-      resource: "projects",
-      params: {
-        view: { resource: "commits", commitId: "COMMIT" },
-        baseUrl,
-        id: "PROJECT",
-        peer: "PEER",
-      },
+      resource: "project.commit",
+      seed,
+      project: "PROJECT",
+      commit: "COMMIT",
     });
   });
 
   test("projects.issues", () => {
     expectParsingInvariant({
-      resource: "projects",
-      params: {
-        view: {
-          resource: "issues",
-          params: { view: { resource: "list" }, search: "" },
-        },
-        baseUrl,
-        id: "PROJECT",
-      },
+      resource: "project.issues",
+      seed,
+      project: "PROJECT",
+      search: "",
     });
   });
 
   test("projects.issues with search", () => {
     expectParsingInvariant({
-      resource: "projects",
-      params: {
-        view: {
-          resource: "issues",
-          params: { view: { resource: "list" }, search: "SEARCH" },
-        },
-        baseUrl,
-        id: "PROJECT",
-      },
+      resource: "project.issues",
+      seed,
+      project: "PROJECT",
+      search: "SEARCH",
     });
   });
 
-  test("projects.issues.new", () => {
+  test("projects.newIssue", () => {
     expectParsingInvariant({
-      resource: "projects",
-      params: {
-        view: {
-          resource: "issues",
-          params: { view: { resource: "new" }, search: "" },
-        },
-        baseUrl,
-        id: "PROJECT",
-      },
+      resource: "project.newIssue",
+      seed,
+      project: "PROJECT",
     });
   });
 
   test("projects.issue", () => {
     expectParsingInvariant({
-      resource: "projects",
-      params: {
-        view: {
-          resource: "issue",
-          params: { issue: "ISSUE" },
-        },
-        baseUrl,
-        id: "PROJECT",
-      },
+      resource: "project.issue",
+      seed,
+      project: "PROJECT",
+      issue: "ISSUE",
     });
   });
 
   test("projects.patches"),
     () => {
       expectParsingInvariant({
-        resource: "projects",
-        params: {
-          view: {
-            resource: "patches",
-            params: { view: { resource: "list" }, search: "" },
-          },
-          baseUrl,
-          id: "PROJECT",
-        },
+        resource: "project.patches",
+        seed,
+        project: "PROJECT",
       });
     };
 
   test("projects.patches with search", () => {
     expectParsingInvariant({
-      resource: "projects",
-      params: {
-        view: {
-          resource: "patches",
-          params: { view: { resource: "list" }, search: "SEARCH" },
-        },
-        baseUrl,
-        id: "PROJECT",
-      },
+      resource: "project.patches",
+      seed,
+      project: "PROJECT",
+      search: "SEARCH",
     });
   });
 
   test("projects.patch", () => {
     expectParsingInvariant({
-      resource: "projects",
-      params: {
-        view: {
-          resource: "patch",
-          params: { patch: "PATCH", search: "" },
-        },
-        baseUrl,
-        id: "PROJECT",
-      },
+      resource: "project.patch",
+      seed,
+      project: "PROJECT",
+      patch: "PATCH",
+      search: "",
     });
   });
 
   test("projects.patch with revision", () => {
     expectParsingInvariant({
-      resource: "projects",
-      params: {
-        view: {
-          resource: "patch",
-          params: { patch: "PATCH", search: "", revision: "REVISION" },
-        },
-        baseUrl,
-        id: "PROJECT",
-      },
+      resource: "project.patch",
+      seed,
+      project: "PROJECT",
+      patch: "PATCH",
+      search: "",
+      revision: "REVISION",
     });
   });
 
   test("projects.patch with search", () => {
     expectParsingInvariant({
-      resource: "projects",
-      params: {
-        view: {
-          resource: "patch",
-          params: { patch: "PATCH", search: "SEARCH" },
-        },
-        baseUrl,
-        id: "PROJECT",
-      },
+      resource: "project.patch",
+      seed,
+      project: "PROJECT",
+      patch: "PATCH",
+      search: "SEARCH",
     });
   });
 
   test("projects.patch with revision and search", () => {
     expectParsingInvariant({
-      resource: "projects",
-      params: {
-        view: {
-          resource: "patch",
-          params: { patch: "PATCH", search: "SEARCH", revision: "REVISION" },
-        },
-        baseUrl,
-        id: "PROJECT",
-      },
+      resource: "project.patch",
+      seed,
+      project: "PROJECT",
+      patch: "PATCH",
+      revision: "REVISION",
+      search: "SEARCH",
     });
   });
 
@@ -316,18 +244,14 @@ describe("pathToRoute", () => {
         dummyUrl,
       ),
       output: {
-        resource: "projects",
-        params: {
-          view: { resource: "tree" },
-          baseUrl: {
-            hostname: "willow.radicle.garden",
-            scheme: "http",
-            port: 8080,
-          },
-          peer: undefined,
-          id: "rad:zKtT7DmF9H34KkvcKj9PHW19WzjT",
-          route: "",
+        resource: "project.tree",
+        seed: {
+          hostname: "willow.radicle.garden",
+          scheme: "http",
+          port: 8080,
         },
+        project: "rad:zKtT7DmF9H34KkvcKj9PHW19WzjT",
+        route: "",
       },
       description: "Seed Project Route w trailing slash",
     },
@@ -345,18 +269,14 @@ describe("pathToRoute", () => {
         dummyUrl,
       ),
       output: {
-        resource: "projects",
-        params: {
-          view: { resource: "tree" },
-          baseUrl: {
-            hostname: "willow.radicle.garden",
-            scheme: "http",
-            port: 8080,
-          },
-          peer: undefined,
-          id: "rad:zKtT7DmF9H34KkvcKj9PHW19WzjT",
-          route: "",
+        resource: "project.tree",
+        seed: {
+          hostname: "willow.radicle.garden",
+          scheme: "http",
+          port: 8080,
         },
+        project: "rad:zKtT7DmF9H34KkvcKj9PHW19WzjT",
+        route: "",
       },
       description: "Seed Project Route w/o trailing slash",
     },


### PR DESCRIPTION
We switch to a project route type that is just a union. This has the following advantages

* It’s much easier to construct project routes. Fewer properties are needed and there are no nested objects.
* We eliminate the implicitly shared properties `path`, `peer`, `revision` and `route` which only belonged to the tree route.
* The structure of the project route is more regular and thus easier to understand.