### PR TITLE
Reverse revision commit ordering

### DIFF
--- a/src/views/projects/Cob/Revision.svelte
+++ b/src/views/projects/Cob/Revision.svelte
@@ -295,7 +295,7 @@
           </Authorship>
           {#if response?.commits}
             <div class="commits txt-tiny">
-              {#each response.commits as commit, i}
+              {#each response.commits.reverse() as commit, i}
                 <div class="commit-event">
                   <span>
                     <span class="commit-pointer">╰─</span>


### PR DESCRIPTION
Fixes: https://github.com/radicle-dev/radicle-interface/issues/940.

Turns out we did have a visual spec for this:

![patch-page-5-diff](https://github.com/radicle-dev/radicle-interface/assets/158411/b178ada8-e16f-496e-bd65-0d146067ce81)
![patch-page-4-diff](https://github.com/radicle-dev/radicle-interface/assets/158411/ef34f80c-ae54-4607-8b1a-56156a31c864)
