### PR TITLE
Make diff line selectable and shareable

### DIFF
--- a/tests/e2e/project.spec.ts
+++ b/tests/e2e/project.spec.ts
@@ -6,6 +6,7 @@ import {
   bobHead,
   bobRemote,
   expect,
+  cobUrl,
   markdownUrl,
   sourceBrowsingRid,
   sourceBrowsingUrl,
@@ -448,4 +449,14 @@ test("external markdown link", async ({ page }) => {
   await page.getByRole("link", { name: "https://example.com" }).click();
   await page.pause();
   await expect(page).toHaveURL("https://example.com");
+});
+
+test("diff selection de-select", async ({ page }) => {
+  await page.goto(
+    `${cobUrl}/patches/013f8b2734df1840b2e33d52ff5632c8d66b199a?tab=files#README.md:H0L0H0L3`,
+  );
+  await page.getByText("Add subtitle to README").click();
+  await expect(page).toHaveURL(
+    `${cobUrl}/patches/013f8b2734df1840b2e33d52ff5632c8d66b199a?tab=files`,
+  );
 });

--- a/tests/visual/project.spec.ts
+++ b/tests/visual/project.spec.ts
@@ -1,6 +1,7 @@
 import {
   test,
   expect,
+  cobUrl,
   sourceBrowsingUrl,
   aliceRemote,
 } from "@tests/support/fixtures.js";
@@ -48,5 +49,22 @@ test("commit page", async ({ page }) => {
     )}/commits/1aded56c3ad55299df9f06c326af50b802a05949`,
   );
   await expect(page.getByText("subconscious.txt added")).toBeVisible();
+  await expect(page).toHaveScreenshot({ fullPage: true });
+});
+
+test("diff selection", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.initializeTestStubs = () => {
+      window.e2eTestStubs.FakeTimers.install({
+        now: new Date("November 24 2022 12:00:00").valueOf(),
+        shouldClearNativeTimers: true,
+        shouldAdvanceTime: false,
+      });
+    };
+  });
+
+  await page.goto(
+    `${cobUrl}/patches/013f8b2734df1840b2e33d52ff5632c8d66b199a?tab=files#README.md:H0L0H0L3`,
+  );
   await expect(page).toHaveScreenshot({ fullPage: true });
 });


### PR DESCRIPTION
Right now I'm using screenshots to reference a specific part of a diff. A better option would be a link, like GitHub.

![Screenshot from 2023-07-13 21-52-53](https://github.com/radicle-dev/radicle-interface/assets/14107758/8e061b9f-0013-4b22-af2d-c41b6ca52c73)

For example the link for the picture would be:

`/seeds/radicle.local/rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5/patches/e6d27cade05288b5bfa79f0e3c47bb07fdc3c2a0?diff=1ddfa4fe94adca5096a82316fbaf7b147e3b5d9a..5242a14b5e9fefd07db040940223b7f37ba72988#radicle-cli/src/commands/patch/edit.rsH1R9`

0. Right now, the link wouldn't scroll to the line, as we load things in 2 stages, but it shouldn't matter as we're eventually moving to a single stage. Scrolls on GitHub doesn't work that well either anyway, highlighting is the most important part.

1. GitHub uses a different format, `#diff-86922c6cf991e9927a1a37a653efc6e9c1db5dfacb4a99a772798d30d4b0f3dbR69`, we can achieve a similar format by using a hash function.

2. I'm using a `resetHighlights` fn to undo the selection of other lines (if any), is there a better pattern for this?  also if I move the line `line.highlighted = true;` inside a function and call it with `fn(line)`, it wouldn't have the same effect, and I don't know why, any ideas?

3. Since in `Changeset.svelte`, each diff is a separate component, selecting in one file, doesn't undo select in another. Somehow a selected-file var has to be shared among `FileDiff`s, any thoughts how to do this? We can use the first part of  `window.location.hash` if we don't hash it, but something needs to re-trigger render of the components.

4. Do we have a way of adding hash to `window.location` right now?