### PR TITLE
Make pathToRoute tests more readable

### DIFF
--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -69,7 +69,7 @@ export async function navigateToUrl(
 
   const relativeUrl = pathname + url.search + (hash || "");
   url = new URL(relativeUrl, window.origin);
-  const route = pathToRoute(url);
+  const route = urlToRoute(url);
 
   if (route) {
     await replace(route);
@@ -176,7 +176,7 @@ function extractBaseUrl(hostAndPort: string): BaseUrl {
   }
 }
 
-function pathToRoute(url: URL): Route | null {
+function urlToRoute(url: URL): Route | null {
   const segments = url.pathname.substring(1).split("/");
 
   const resource = segments.shift();
@@ -249,4 +249,4 @@ export function routeToPath(route: Route): string {
   }
 }
 
-export const testExports = { pathToRoute, routeToPath };
+export const testExports = { urlToRoute, routeToPath };


### PR DESCRIPTION
We switch the test for `pathToRoute` from a paramterized test to regular tests. I had a lot of trouble finding the right properties to change when a test in this group failed. The line number was not helpful at all and the test description was burried inside an object.

We also rename `pathToRoute` to `urlToRoute` because the function takes a `URL` as an argument.