### PR TITLE
Replace marked namespaces with Marked instance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@types/dompurify": "^3.0.2",
         "@types/katex": "^0.16.0",
         "@types/lodash": "^4.14.195",
-        "@types/marked": "^5.0.0",
+        "@types/marked": "^5.0.1",
         "@types/md5": "^2.3.2",
         "@types/node": "^18.16.12",
         "@types/sinon": "^10.0.15",
@@ -836,9 +836,9 @@
       "dev": true
     },
     "node_modules/@types/marked": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-5.0.0.tgz",
-      "integrity": "sha512-YcZe50jhltsCq7rc9MNZC/4QB/OnA2Pd6hrOSTOFajtabN+38slqgDDCeE/0F83SjkKBQcsZUj7VLWR0H5cKRA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-5.0.1.tgz",
+      "integrity": "sha512-Y3pAUzHKh605fN6fvASsz5FDSWbZcs/65Q6xYRmnIP9ZIYz27T4IOmXfH9gWJV1dpi7f1e7z7nBGUTx/a0ptpA==",
       "dev": true
     },
     "node_modules/@types/md5": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/dompurify": "^3.0.2",
     "@types/katex": "^0.16.0",
     "@types/lodash": "^4.14.195",
-    "@types/marked": "^5.0.0",
+    "@types/marked": "^5.0.1",
     "@types/md5": "^2.3.2",
     "@types/node": "^18.16.12",
     "@types/sinon": "^10.0.15",

--- a/src/components/InlineMarkdown.svelte
+++ b/src/components/InlineMarkdown.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
   import dompurify from "dompurify";
-  import { marked } from "marked";
 
+  import markdown from "@app/lib/markdown";
   import { twemoji } from "@app/lib/utils";
 
   export let content: string;
   export let fontSize: "tiny" | "small" | "medium" = "small";
 
   const render = (content: string): string =>
-    dompurify.sanitize(marked.parseInline(content));
+    dompurify.sanitize(markdown.parseInline(content));
 </script>
 
 <style>

--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -2,13 +2,13 @@
   import dompurify from "dompurify";
   import matter from "@radicle/gray-matter";
   import { afterUpdate } from "svelte";
-  import { marked } from "marked";
   import { toDom } from "hast-util-to-dom";
 
   import * as router from "@app/lib/router";
+  import markdown from "@app/lib/markdown";
+  import { Renderer } from "@app/lib/markdown";
   import { highlight } from "@app/lib/syntax";
   import { isUrl, twemoji, scrollIntoView, canonicalize } from "@app/lib/utils";
-  import { Renderer } from "@app/lib/markdown";
 
   export let content: string;
   // If present, resolve all relative links with respect to this URL
@@ -53,12 +53,7 @@
 
   function render(content: string): string {
     return dompurify.sanitize(
-      marked.parse(content, {
-        renderer: new Renderer(linkBaseUrl),
-        // TODO: Disables deprecated options, remove once removed from marked
-        mangle: false,
-        headerIds: false,
-      }),
+      markdown.parse(content, { renderer: new Renderer(linkBaseUrl) }),
     );
   }
 


### PR DESCRIPTION
Based on a new addition to marked, this commits replaces the imported marked namespaces with a Marked class, that doesn't change when `marked.use` introduces new options or extensions.

Also changes the naming slighty to use `markdown` as module, so it sounds more generic.

Reference: https://github.com/markedjs/marked/pull/2831

Closes #919 