### PR TITLE
Set the `httpd` port for the test suite to be 8081.

### DIFF
--- a/httpd-client/tests/client.test.ts
+++ b/httpd-client/tests/client.test.ts
@@ -1,9 +1,11 @@
 import { describe, test } from "vitest";
+
 import { HttpdClient } from "@httpd-client";
+import { defaultHttpdPort } from "@tests/support/fixtures";
 
 const api = new HttpdClient({
   hostname: "127.0.0.1",
-  port: 8080,
+  port: defaultHttpdPort,
   scheme: "http",
 });
 

--- a/httpd-client/tests/project.test.ts
+++ b/httpd-client/tests/project.test.ts
@@ -6,6 +6,7 @@ import {
   aliceRemote,
   bobRemote,
   cobRid,
+  defaultHttpdPort,
   sourceBrowsingRid,
 } from "@tests/support/fixtures.js";
 import {
@@ -20,7 +21,7 @@ import { testFixture as testWithAPI } from "@httpd-client/tests/support/fixtures
 describe("project", () => {
   const api = new HttpdClient({
     hostname: "127.0.0.1",
-    port: 8080,
+    port: defaultHttpdPort,
     scheme: "http",
   });
 

--- a/httpd-client/tests/support/globalSetup.ts
+++ b/httpd-client/tests/support/globalSetup.ts
@@ -10,6 +10,7 @@ import { createPeerManager } from "@tests/support/peerManager";
 import {
   createCobsFixture,
   createSourceBrowsingFixture,
+  defaultHttpdPort,
   gitOptions,
   startPalmHttpd,
 } from "@tests/support/fixtures";
@@ -45,7 +46,7 @@ export default async function globalSetup(): Promise<() => void> {
       name: "palm",
       gitOptions: gitOptions["alice"],
     });
-    await palm.startHttpd(8080);
+    await palm.startHttpd(defaultHttpdPort);
     await palm.startNode({ trackingPolicy: "track", trackingScope: "all" });
 
     console.log("Creating source-browsing fixture");
@@ -55,7 +56,7 @@ export default async function globalSetup(): Promise<() => void> {
     console.log("Running tests");
     await palm.stopNode();
   } else {
-    await startPalmHttpd(8080);
+    await startPalmHttpd(defaultHttpdPort);
   }
 
   return () => killAllProcesses();

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -24,7 +24,7 @@ function getConfig(): Config {
     return {
       reactions: [],
       seeds: {
-        defaultHttpdPort: 8080,
+        defaultHttpdPort: 8081,
         defaultHttpdScheme: "http",
         defaultNodePort: 8776,
         pinned: [],

--- a/src/lib/httpd.ts
+++ b/src/lib/httpd.ts
@@ -1,7 +1,8 @@
 import { derived, get, writable } from "svelte/store";
+import { withTimeout, Mutex, E_CANCELED, E_TIMEOUT } from "async-mutex";
 
 import { HttpdClient } from "@httpd-client";
-import { withTimeout, Mutex, E_CANCELED, E_TIMEOUT } from "async-mutex";
+import { config } from "@app/lib/config";
 
 export interface Session {
   id: string;
@@ -24,7 +25,7 @@ export const httpdStore = derived(store, s => s);
 
 export const api = new HttpdClient({
   hostname: "127.0.0.1",
-  port: 8080,
+  port: config.seeds.defaultHttpdPort,
   scheme: "http",
 });
 

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -151,13 +151,17 @@ export async function replace(newRoute: Route): Promise<void> {
 function extractBaseUrl(hostAndPort: string): BaseUrl {
   if (
     hostAndPort === "radicle.local" ||
-    hostAndPort === "radicle.local:8080" ||
+    hostAndPort === `radicle.local:${config.seeds.defaultHttpdPort}` ||
     hostAndPort === "0.0.0.0" ||
-    hostAndPort === "0.0.0.0:8080" ||
+    hostAndPort === `0.0.0.0:${config.seeds.defaultHttpdPort}` ||
     hostAndPort === "127.0.0.1" ||
-    hostAndPort === "127.0.0.1:8080"
+    hostAndPort === `127.0.0.1:${config.seeds.defaultHttpdPort}`
   ) {
-    return { hostname: "127.0.0.1", port: 8080, scheme: "http" };
+    return {
+      hostname: "127.0.0.1",
+      port: config.seeds.defaultHttpdPort,
+      scheme: "http",
+    };
   } else if (hostAndPort.includes(":")) {
     const [hostname, port] = hostAndPort.split(":");
     return {

--- a/tests/support/fixtures.ts
+++ b/tests/support/fixtures.ts
@@ -93,14 +93,14 @@ export const test = base.extend<{
           window.APP_CONFIG = {
             reactions: [],
             seeds: {
-              defaultHttpdPort: 8080,
+              defaultHttpdPort: 8081,
               defaultHttpdScheme: "http",
               defaultNodePort: 8776,
               pinned: [
                 {
                   baseUrl: {
                     hostname: "127.0.0.1",
-                    port: 8080,
+                    port: 8081,
                     scheme: "http",
                   },
                 },
@@ -230,14 +230,14 @@ export function appConfigWithFixture() {
   window.APP_CONFIG = {
     reactions: [],
     seeds: {
-      defaultHttpdPort: 8080,
+      defaultHttpdPort: 8081,
       defaultHttpdScheme: "http",
       defaultNodePort: 8776,
       pinned: [
         {
           baseUrl: {
             hostname: "127.0.0.1",
-            port: 8080,
+            port: 8081,
             scheme: "http",
           },
         },
@@ -250,7 +250,7 @@ export function appConfigWithFixture() {
           id: "rad:z4BwwjPCFNVP27FwVbDFgwVwkjcir",
           baseUrl: {
             hostname: "127.0.0.1",
-            port: 8080,
+            port: 8081,
             scheme: "http",
           },
         },
@@ -639,6 +639,7 @@ export const sourceBrowsingUrl = `/seeds/127.0.0.1/${sourceBrowsingRid}`;
 export const cobUrl = `/seeds/127.0.0.1/${cobRid}`;
 export const markdownUrl = `/seeds/127.0.0.1/${markdownRid}`;
 export const seedRemote = "z6MktULudTtAsAhRegYPiZ6631RV3viv12qd4GQF8z1xB22S";
+export const defaultHttpdPort = 8081;
 export const gitOptions = {
   alice: {
     GIT_AUTHOR_NAME: "Alice Liddell",

--- a/tests/support/globalSetup.ts
+++ b/tests/support/globalSetup.ts
@@ -10,6 +10,7 @@ import {
   createCobsFixture,
   createMarkdownFixture,
   createSourceBrowsingFixture,
+  defaultHttpdPort,
   gitOptions,
   startPalmHttpd,
 } from "@tests/support/fixtures.js";
@@ -49,7 +50,7 @@ export default async function globalSetup(): Promise<() => void> {
       name: "palm",
       gitOptions: gitOptions["alice"],
     });
-    await palm.startHttpd(8080);
+    await palm.startHttpd(defaultHttpdPort);
     await palm.startNode({ trackingPolicy: "track", trackingScope: "all" });
 
     console.log("Creating source-browsing fixture");
@@ -61,7 +62,7 @@ export default async function globalSetup(): Promise<() => void> {
     console.log("Running tests");
     await palm.stopNode();
   } else {
-    await startPalmHttpd(8080);
+    await startPalmHttpd(defaultHttpdPort);
   }
 
   return () => killAllProcesses();

--- a/tests/unit/router.test.ts
+++ b/tests/unit/router.test.ts
@@ -1,3 +1,4 @@
+import { defaultHttpdPort } from "@tests/support/fixtures.js";
 import { describe, expect, test } from "vitest";
 import { testExports, type Route } from "@app/lib/router";
 
@@ -222,7 +223,7 @@ describe("pathToRoute", () => {
         baseUrl: {
           hostname: "willow.radicle.garden",
           scheme: "http",
-          port: 8080,
+          port: defaultHttpdPort,
         },
         projectPageIndex: 0,
       },
@@ -237,7 +238,7 @@ describe("pathToRoute", () => {
         seed: {
           hostname: "willow.radicle.garden",
           scheme: "http",
-          port: 8080,
+          port: defaultHttpdPort,
         },
         project: "rad:zKtT7DmF9H34KkvcKj9PHW19WzjT",
         route: "",
@@ -253,7 +254,7 @@ describe("pathToRoute", () => {
         seed: {
           hostname: "willow.radicle.garden",
           scheme: "http",
-          port: 8080,
+          port: defaultHttpdPort,
         },
         project: "rad:zKtT7DmF9H34KkvcKj9PHW19WzjT",
         route: "",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
       "@app": path.resolve("./src"),
       "@public": path.resolve("./public"),
       "@httpd-client": path.resolve("./httpd-client"),
+      "@tests": path.resolve("./tests"),
     },
   },
   build: {


### PR DESCRIPTION
Also where possible use the `config.seeds.defaultHttpdPort` instead of hardcoding it.

This helps, when developers already have a `radicle-httpd` process running on their machines.
Also makes running the web client on a non 8080 port more stable.