### PR TITLE
Remove source browsing header from commit view

### DIFF
--- a/src/views/projects/Commit.svelte
+++ b/src/views/projects/Commit.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import type { Commit, BaseUrl, Remote, Project } from "@httpd-client";
-  import type { LoadedSourceBrowsingView } from "@app/views/projects/router";
+  import type { Commit, BaseUrl, Project } from "@httpd-client";
 
   import { formatCommit } from "@app/lib/utils";
 
@@ -8,24 +7,17 @@
   import Clipboard from "@app/components/Clipboard.svelte";
   import CommitAuthorship from "@app/views/projects/Commit/CommitAuthorship.svelte";
   import InlineMarkdown from "@app/components/InlineMarkdown.svelte";
-  import SourceBrowsingHeader from "./SourceBrowsingHeader.svelte";
 
   export let baseUrl: BaseUrl;
-  export let branches: Record<string, string> | undefined;
   export let commit: Commit;
-  export let commitCount: number;
-  export let contributorCount: number;
-  export let peer: string | undefined = undefined;
-  export let peers: Remote[];
   export let project: Project;
-  export let view: LoadedSourceBrowsingView;
 
-  const { commit: header } = commit;
+  $: header = commit.commit;
 </script>
 
 <style>
   .commit {
-    padding: 0 2rem 0 8rem;
+    padding: 1rem 2rem 0 8rem;
   }
   .header {
     padding: 1rem;
@@ -56,19 +48,6 @@
     }
   }
 </style>
-
-<SourceBrowsingHeader
-  defaultBranch={project.defaultBranch}
-  projectId={project.id}
-  commitId={commit.commit.id}
-  {baseUrl}
-  {branches}
-  {commitCount}
-  {contributorCount}
-  {peers}
-  {peer}
-  revision={commit.commit.id}
-  {view} />
 
 <div class="commit">
   <div class="header">

--- a/src/views/projects/Header.svelte
+++ b/src/views/projects/Header.svelte
@@ -48,10 +48,7 @@
       seed: baseUrl,
       path: "/",
     }}>
-    <SquareButton
-      active={resource === "tree" ||
-        resource === "history" ||
-        resource === "commits"}>
+    <SquareButton active={resource === "tree" || resource === "history"}>
       <svelte:fragment slot="icon">
         <Icon size="small" name="chevron-left-right" />
       </svelte:fragment>

--- a/src/views/projects/Issue.svelte
+++ b/src/views/projects/Issue.svelte
@@ -256,7 +256,7 @@
   .issue {
     display: grid;
     grid-template-columns: minmax(0, 3fr) 1fr;
-    padding: 0 2rem 0 8rem;
+    padding: 1rem 2rem 0 8rem;
     margin-bottom: 4.5rem;
   }
   .metadata {

--- a/src/views/projects/Patch.svelte
+++ b/src/views/projects/Patch.svelte
@@ -230,7 +230,7 @@
   .patch {
     display: grid;
     grid-template-columns: minmax(0, 3fr) 1fr;
-    padding: 0 2rem 0 8rem;
+    padding: 1rem 2rem 0 8rem;
     margin-bottom: 4.5rem;
   }
   .metadata {

--- a/src/views/projects/SourceBrowsingHeader.svelte
+++ b/src/views/projects/SourceBrowsingHeader.svelte
@@ -56,13 +56,6 @@
         project: projectId,
         peer,
       };
-    } else if (view.resource === "commits") {
-      return {
-        resource: "project.commit",
-        seed: baseUrl,
-        project: projectId,
-        commit: view.commit.commit.id,
-      };
     } else {
       return unreachable(view);
     }
@@ -92,13 +85,6 @@
         project: projectId,
         peer,
         revision,
-      };
-    } else if (view.resource === "commits") {
-      return {
-        resource: "project.commit",
-        seed: baseUrl,
-        project: projectId,
-        commit: view.commit.commit.id,
       };
     } else {
       return unreachable(view);
@@ -146,8 +132,7 @@
       peer,
       revision,
     }}>
-    <SquareButton
-      active={view.resource === "history" || view.resource === "commits"}>
+    <SquareButton active={view.resource === "history"}>
       <span class="txt-bold">{commitCount}</span>
       {pluralize("commit", commitCount)}
     </SquareButton>

--- a/src/views/projects/View.svelte
+++ b/src/views/projects/View.svelte
@@ -88,17 +88,8 @@
       {project}
       revision={view.revision}
       {view} />
-  {:else if view.resource === "commits"}
-    <Commit
-      branches={view.params.loadedBranches}
-      commit={view.commit}
-      commitCount={view.params.loadedTree.stats.commits}
-      contributorCount={view.params.loadedTree.stats.contributors}
-      peers={view.params.loadedPeers}
-      {baseUrl}
-      {peer}
-      {project}
-      {view} />
+  {:else if view.resource === "commit"}
+    <Commit commit={view.commit} {baseUrl} {project} />
   {:else if view.resource === "issues"}
     <Issues
       {baseUrl}


### PR DESCRIPTION
For a single commit view the source browsing header (peer selector, branch selector, commits, contributor count) does not contain meaningful information. We remove the header and simply show the commit.

See #938.

Before:
![image](https://github.com/radicle-dev/radicle-interface/assets/3919579/4bc1f1bb-a68c-4fec-b747-99b2850085d2)

After:
![image](https://github.com/radicle-dev/radicle-interface/assets/3919579/adfe31d7-6c7c-4c55-94b0-888e55fc5c74)
