### PR TITLE
Lift branch/peer selector data into main views

### DIFF
--- a/src/views/projects/Browser.svelte
+++ b/src/views/projects/Browser.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { BaseUrl, Project, Remote, Tree } from "@httpd-client";
   import type { BlobResult } from "./router";
-  import type { LoadedSourceBrowsingView } from "@app/views/projects/router";
+  import type { Route } from "@app/lib/router";
 
   import * as utils from "@app/lib/utils";
   import { HttpdClient } from "@httpd-client";
@@ -23,7 +23,6 @@
   export let project: Project;
   export let revision: string | undefined;
   export let tree: Tree;
-  export let view: LoadedSourceBrowsingView;
 
   export let blobResult: BlobResult;
 
@@ -46,6 +45,28 @@
         return undefined;
       });
   };
+
+  $: peersWithRoute = peers.map(remote => ({
+    remote,
+    selected: remote.id === peer,
+    route: {
+      resource: "project.tree",
+      seed: baseUrl,
+      project: project.id,
+      peer: remote.id,
+    } as Route,
+  }));
+
+  $: branchesWithRoute = Object.keys(branches || {}).map(name => ({
+    name,
+    route: {
+      resource: "project.tree",
+      seed: baseUrl,
+      project: project.id,
+      peer,
+      revision: name,
+    } as Route,
+  }));
 </script>
 
 <style>
@@ -132,13 +153,12 @@
   defaultBranch={project.defaultBranch}
   projectId={project.id}
   {baseUrl}
-  {branches}
+  branches={branchesWithRoute}
   {commitCount}
   {contributorCount}
-  {peers}
-  {peer}
+  peers={peersWithRoute}
   {revision}
-  {view} />
+  historyLinkActive={false} />
 
 <main>
   <!-- Mobile navigation -->

--- a/src/views/projects/History.svelte
+++ b/src/views/projects/History.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { BaseUrl, CommitHeader, Project, Remote } from "@httpd-client";
-  import type { LoadedSourceBrowsingView } from "@app/views/projects/router";
+  import type { Route } from "@app/lib/router";
 
   import { HttpdClient } from "@httpd-client";
   import { groupCommits } from "@app/lib/commit";
@@ -22,7 +22,6 @@
   export let project: Project;
   export let revision: string | undefined;
   export let totalCommitCount: number;
-  export let view: LoadedSourceBrowsingView;
 
   const api = new HttpdClient(baseUrl);
 
@@ -55,6 +54,28 @@
     }
     loading = false;
   }
+
+  $: peersWithRoute = peers.map(remote => ({
+    remote,
+    selected: remote.id === peer,
+    route: {
+      resource: "project.history",
+      seed: baseUrl,
+      project: project.id,
+      peer: remote.id,
+    } as Route,
+  }));
+
+  $: branchesWithRoute = Object.keys(branches || {}).map(name => ({
+    name,
+    route: {
+      resource: "project.history",
+      seed: baseUrl,
+      project: project.id,
+      peer,
+      revision: name,
+    } as Route,
+  }));
 </script>
 
 <style>
@@ -87,13 +108,12 @@
   projectId={project.id}
   commitId={commitHeaders[0].id}
   {baseUrl}
-  {branches}
+  branches={branchesWithRoute}
   {commitCount}
   {contributorCount}
-  {peers}
-  {peer}
+  peers={peersWithRoute}
   {revision}
-  {view} />
+  historyLinkActive={true} />
 
 <div class="history">
   {#each groupCommits(allCommitHeaders) as group (group.time)}

--- a/src/views/projects/View.svelte
+++ b/src/views/projects/View.svelte
@@ -73,8 +73,7 @@
       {baseUrl}
       {peer}
       {project}
-      revision={view.revision}
-      {view} />
+      revision={view.revision} />
   {:else if view.resource === "history"}
     <History
       branches={view.params.loadedBranches}
@@ -86,8 +85,7 @@
       {baseUrl}
       {peer}
       {project}
-      revision={view.revision}
-      {view} />
+      revision={view.revision} />
   {:else if view.resource === "commit"}
     <Commit commit={view.commit} {baseUrl} {project} />
   {:else if view.resource === "issues"}

--- a/src/views/projects/router.ts
+++ b/src/views/projects/router.ts
@@ -100,7 +100,8 @@ export interface ProjectLoadedParams {
   project: Project;
   view: ProjectLoadedView;
 }
-export type LoadedSourceBrowsingView =
+
+export type ProjectLoadedView =
   | {
       resource: "tree";
       peer: string | undefined;
@@ -116,16 +117,7 @@ export type LoadedSourceBrowsingView =
       params: LoadedSourceBrowsingParams;
       commitHeaders: CommitHeader[];
       totalCommitCount: number;
-    };
-
-interface LoadedSourceBrowsingParams {
-  loadedBranches: Record<string, string> | undefined;
-  loadedPeers: Remote[];
-  loadedTree: Tree;
-}
-
-export type ProjectLoadedView =
-  | LoadedSourceBrowsingView
+    }
   | {
       resource: "commit";
       commit: Commit;
@@ -135,6 +127,12 @@ export type ProjectLoadedView =
   | { resource: "newIssue" }
   | { resource: "patches"; search: string }
   | PatchView;
+
+interface LoadedSourceBrowsingParams {
+  loadedBranches: Record<string, string> | undefined;
+  loadedPeers: Remote[];
+  loadedTree: Tree;
+}
 
 export type BlobResult =
   | { ok: true; blob: Blob; highlighted: Syntax.Root | undefined }


### PR DESCRIPTION
We prepare the data for `PeerSelector` and `BranchSelector` in the `History` and `Browser` instead of `SourceBrowsingHeader`. This makes the component APIs overall simpler and allows us to remove `LoadedSourceBrowsingView`.