### PR TITLE
Simplify History, Browser and SourceBrowsingHeader props

### DIFF
--- a/src/views/projects/Browser.svelte
+++ b/src/views/projects/Browser.svelte
@@ -14,16 +14,13 @@
   import TreeComponent from "./Tree.svelte";
 
   export let baseUrl: BaseUrl;
-  export let branches: Record<string, string> | undefined;
-  export let commitCount: number;
-  export let contributorCount: number;
+  export let branches: string[];
   export let path: string;
   export let peer: string | undefined;
   export let peers: Remote[];
   export let project: Project;
   export let revision: string | undefined;
   export let tree: Tree;
-
   export let blobResult: BlobResult;
 
   // Whether the mobile file tree is visible.
@@ -57,7 +54,7 @@
     } as Route,
   }));
 
-  $: branchesWithRoute = Object.keys(branches || {}).map(name => ({
+  $: branchesWithRoute = branches.map(name => ({
     name,
     route: {
       resource: "project.tree",
@@ -154,8 +151,8 @@
   projectId={project.id}
   {baseUrl}
   branches={branchesWithRoute}
-  {commitCount}
-  {contributorCount}
+  commitCount={tree.stats.commits}
+  contributorCount={tree.stats.contributors}
   peers={peersWithRoute}
   {revision}
   historyLinkActive={false} />

--- a/src/views/projects/Browser.svelte
+++ b/src/views/projects/Browser.svelte
@@ -146,15 +146,12 @@
 </style>
 
 <SourceBrowsingHeader
-  commitId={tree.lastCommit.id}
-  defaultBranch={project.defaultBranch}
-  projectId={project.id}
-  {baseUrl}
-  branches={branchesWithRoute}
-  commitCount={tree.stats.commits}
-  contributorCount={tree.stats.contributors}
+  seed={baseUrl}
+  {project}
   peers={peersWithRoute}
+  branches={branchesWithRoute}
   {revision}
+  {tree}
   historyLinkActive={false} />
 
 <main>

--- a/src/views/projects/History.svelte
+++ b/src/views/projects/History.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import type { BaseUrl, CommitHeader, Project, Remote } from "@httpd-client";
+  import type {
+    BaseUrl,
+    CommitHeader,
+    Project,
+    Remote,
+    Tree,
+  } from "@httpd-client";
   import type { Route } from "@app/lib/router";
 
   import { HttpdClient } from "@httpd-client";
@@ -13,15 +19,14 @@
   import { COMMITS_PER_PAGE } from "./router";
 
   export let baseUrl: BaseUrl;
-  export let branches: Record<string, string> | undefined;
-  export let commitCount: number;
+  export let branches: string[];
   export let commitHeaders: CommitHeader[];
-  export let contributorCount: number;
   export let peer: string | undefined;
   export let peers: Remote[];
   export let project: Project;
   export let revision: string | undefined;
   export let totalCommitCount: number;
+  export let tree: Tree;
 
   const api = new HttpdClient(baseUrl);
 
@@ -66,7 +71,7 @@
     } as Route,
   }));
 
-  $: branchesWithRoute = Object.keys(branches || {}).map(name => ({
+  $: branchesWithRoute = branches.map(name => ({
     name,
     route: {
       resource: "project.history",
@@ -109,8 +114,8 @@
   commitId={commitHeaders[0].id}
   {baseUrl}
   branches={branchesWithRoute}
-  {commitCount}
-  {contributorCount}
+  commitCount={tree.stats.commits}
+  contributorCount={tree.stats.contributors}
   peers={peersWithRoute}
   {revision}
   historyLinkActive={true} />

--- a/src/views/projects/History.svelte
+++ b/src/views/projects/History.svelte
@@ -109,15 +109,12 @@
 </style>
 
 <SourceBrowsingHeader
-  defaultBranch={project.defaultBranch}
-  projectId={project.id}
-  commitId={commitHeaders[0].id}
-  {baseUrl}
-  branches={branchesWithRoute}
-  commitCount={tree.stats.commits}
-  contributorCount={tree.stats.contributors}
+  seed={baseUrl}
+  {project}
   peers={peersWithRoute}
+  branches={branchesWithRoute}
   {revision}
+  {tree}
   historyLinkActive={true} />
 
 <div class="history">

--- a/src/views/projects/SourceBrowsingHeader.svelte
+++ b/src/views/projects/SourceBrowsingHeader.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { BaseUrl, Remote } from "@httpd-client";
+  import type { BaseUrl, Project, Remote, Tree } from "@httpd-client";
   import { type Route } from "@app/lib/router";
 
   import { pluralize } from "@app/lib/pluralize";
@@ -9,29 +9,25 @@
   import Link from "@app/components/Link.svelte";
   import SquareButton from "@app/components/SquareButton.svelte";
 
-  export let baseUrl: BaseUrl;
+  export let seed: BaseUrl;
   export let branches: Array<{ name: string; route: Route }>;
-  export let commitCount: number;
-  export let contributorCount: number;
-  export let defaultBranch: string;
   export let peers: Array<{ remote: Remote; selected: boolean; route: Route }>;
-  export let projectId: string;
   export let historyLinkActive: boolean;
   export let revision: string | undefined;
-  export let commitId: string;
+  export let tree: Tree;
+  export let project: Project;
 
   let selectedBranch: string | undefined;
 
   // Revision may be a commit ID, a branch name or `undefined` which means the
   // default branch. We assign `selectedBranch` accordingly.
-  // TODO: Move this logic out of here and have `selectedBranch` be passed as a
-  // prop.
   $: if (revision === commitId) {
     selectedBranch = undefined;
   } else {
-    selectedBranch = revision || defaultBranch;
+    selectedBranch = revision || project.defaultBranch;
   }
 
+  $: commitId = tree.lastCommit.id;
   $: peer = peers.find(p => p.selected)?.remote.id;
 </script>
 
@@ -67,19 +63,19 @@
   <Link
     route={{
       resource: "project.history",
-      project: projectId,
-      seed: baseUrl,
+      project: project.id,
+      seed: seed,
       peer,
       revision,
     }}>
     <SquareButton active={historyLinkActive}>
-      <span class="txt-bold">{commitCount}</span>
-      {pluralize("commit", commitCount)}
+      <span class="txt-bold">{tree.stats.commits}</span>
+      {pluralize("commit", tree.stats.commits)}
     </SquareButton>
   </Link>
 
   <SquareButton hoverable={false}>
-    <span class="txt-bold">{contributorCount}</span>
-    {pluralize("contributor", contributorCount)}
+    <span class="txt-bold">{tree.stats.contributors}</span>
+    {pluralize("contributor", tree.stats.contributors)}
   </SquareButton>
 </div>

--- a/src/views/projects/View.svelte
+++ b/src/views/projects/View.svelte
@@ -62,30 +62,9 @@
 
 <main>
   {#if view.resource === "tree"}
-    <Browser
-      blobResult={view.blobResult}
-      branches={view.params.loadedBranches}
-      commitCount={view.params.loadedTree.stats.commits}
-      contributorCount={view.params.loadedTree.stats.contributors}
-      path={view.path}
-      peers={view.params.loadedPeers}
-      tree={view.params.loadedTree}
-      {baseUrl}
-      {peer}
-      {project}
-      revision={view.revision} />
+    <Browser {...view} {baseUrl} {project} />
   {:else if view.resource === "history"}
-    <History
-      branches={view.params.loadedBranches}
-      commitCount={view.params.loadedTree.stats.commits}
-      commitHeaders={view.commitHeaders}
-      contributorCount={view.params.loadedTree.stats.contributors}
-      peers={view.params.loadedPeers}
-      totalCommitCount={view.totalCommitCount}
-      {baseUrl}
-      {peer}
-      {project}
-      revision={view.revision} />
+    <History {...view} {baseUrl} {project} />
   {:else if view.resource === "commit"}
     <Commit commit={view.commit} {baseUrl} {project} />
   {:else if view.resource === "issues"}


### PR DESCRIPTION
We simplify the `History`, `Browser` and `SourceBrowsingHeader` components by requiring fewer props and streamlining the view shape.