### PR TITLE
Replace deprecated `substr` with `substring`

### DIFF
--- a/src/views/projects/Blob.svelte
+++ b/src/views/projects/Blob.svelte
@@ -36,7 +36,7 @@
   }
 
   function updateSelectedLineId() {
-    const fragmentId = window.location.hash.substr(1);
+    const fragmentId = window.location.hash.substring(1);
     if (fragmentId && fragmentId.match(/^L\d+$/)) {
       selectedLineId = fragmentId;
     } else {

--- a/src/views/projects/SourceBrowser/FileDiff.svelte
+++ b/src/views/projects/SourceBrowser/FileDiff.svelte
@@ -55,7 +55,7 @@
   }
 
   function updateSelection() {
-    const fragment = window.location.hash.substr(1);
+    const fragment = window.location.hash.substring(1);
     const match = fragment.match(/(.+):H(\d+)L(\d+)(H(\d+)L(\d+))?/);
     if (match && match[1] === file.path) {
       selection = {


### PR DESCRIPTION
Closes: https://github.com/radicle-dev/radicle-interface/issues/951.