### PR TITLE
Fix navigating to history when a file is selected

### DIFF
--- a/src/views/projects/Browser.svelte
+++ b/src/views/projects/Browser.svelte
@@ -175,7 +175,7 @@
         <div class="source-tree sticky">
           <TreeComponent
             projectId={project.id}
-            revision={revision ?? project.defaultBranch}
+            {revision}
             {baseUrl}
             {fetchTree}
             {path}

--- a/src/views/projects/Tree.svelte
+++ b/src/views/projects/Tree.svelte
@@ -12,7 +12,7 @@
   export let path: string;
   export let peer: string | undefined;
   export let projectId: string;
-  export let revision: string;
+  export let revision: string | undefined;
   export let tree: Tree;
 
   const dispatch = createEventDispatcher<{ select: string }>();

--- a/src/views/projects/Tree/Folder.svelte
+++ b/src/views/projects/Tree/Folder.svelte
@@ -15,7 +15,7 @@
   export let peer: string | undefined;
   export let prefix: string;
   export let projectId: string;
-  export let revision: string;
+  export let revision: string | undefined;
 
   $: expanded = currentPath.indexOf(prefix) === 0;
   $: tree = expanded

--- a/tests/e2e/hashRouter.spec.ts
+++ b/tests/e2e/hashRouter.spec.ts
@@ -55,39 +55,67 @@ test.describe("project page navigation", () => {
   });
 
   test("navigate between tree and commit history", async ({ page }) => {
-    const projectTreeURL = `/#${sourceBrowsingUrl}`;
+    const projectTreeURL = `/#${sourceBrowsingUrl}/tree/${aliceMainHead}`;
 
     await page.goto(projectTreeURL);
+    await page
+      .getByRole("progressbar", { name: "Page loading" })
+      .waitFor({ state: "hidden" });
     await expect(page).toHaveURL(projectTreeURL);
 
     await page.getByRole("link", { name: "6 commits" }).click();
-    await expect(page).toHaveURL(`/#${sourceBrowsingUrl}/history`);
+    await expect(page).toHaveURL(
+      `/#${sourceBrowsingUrl}/history/${aliceMainHead}`,
+    );
 
     await expectBackAndForwardNavigationWorks(projectTreeURL, page);
     await expectUrlPersistsReload(page);
   });
 
-  test("navigate project paths", async ({ page }) => {
+  test("navigate between tree and commit history while a file is selected", async ({
+    page,
+  }) => {
     const projectTreeURL = `/#${sourceBrowsingUrl}`;
+
+    await page.goto(projectTreeURL);
+    await page
+      .getByRole("progressbar", { name: "Page loading" })
+      .waitFor({ state: "hidden" });
+    await expect(page).toHaveURL(projectTreeURL);
+
+    await page.getByText(".hidden").click();
+    await expect(page).toHaveURL(`${projectTreeURL}/tree/.hidden`);
+
+    await page.getByRole("link", { name: "6 commits" }).click();
+    await expect(page).toHaveURL(`${projectTreeURL}/history`);
+  });
+
+  test("navigate project paths", async ({ page }) => {
+    const projectTreeURL = `/#${sourceBrowsingUrl}/tree/${aliceMainHead}`;
 
     await page.goto(projectTreeURL);
     await expect(page).toHaveURL(projectTreeURL);
 
     await page.getByText(".hidden").click();
-    await expect(page).toHaveURL(`${projectTreeURL}/tree/main/.hidden`);
+    await expect(page).toHaveURL(`${projectTreeURL}/.hidden`);
 
     await page.getByText("bin/").click();
     await page.getByText("true").click();
-    await expect(page).toHaveURL(`${projectTreeURL}/tree/main/bin/true`);
+    await expect(page).toHaveURL(`${projectTreeURL}/bin/true`);
 
     await expectBackAndForwardNavigationWorks(
-      `${projectTreeURL}/tree/main/.hidden`,
+      `${projectTreeURL}/.hidden`,
       page,
     );
     await expectUrlPersistsReload(page);
   });
 
-  test("navigate project paths with a selected peer", async ({ page }) => {
+  test("navigate project paths with an explicitly selected peer", async ({
+    page,
+  }) => {
+    // If a branch isn't explicitly specified, the code assumes the project
+    // default branch is selected. We omit showing the default branch in the URL.
+
     const projectTreeURL = `/#${sourceBrowsingUrl}/remotes/${aliceRemote.substring(
       8,
     )}`;
@@ -96,14 +124,38 @@ test.describe("project page navigation", () => {
     await expect(page).toHaveURL(projectTreeURL);
 
     await page.getByText(".hidden").click();
-    await expect(page).toHaveURL(`${projectTreeURL}/tree/main/.hidden`);
+    await expect(page).toHaveURL(`${projectTreeURL}/tree/.hidden`);
 
     await page.getByText("bin/").click();
     await page.getByText("true").click();
-    await expect(page).toHaveURL(`${projectTreeURL}/tree/main/bin/true`);
+    await expect(page).toHaveURL(`${projectTreeURL}/tree/bin/true`);
 
     await expectBackAndForwardNavigationWorks(
-      `${projectTreeURL}/tree/main/.hidden`,
+      `${projectTreeURL}/tree/.hidden`,
+      page,
+    );
+    await expectUrlPersistsReload(page);
+  });
+
+  test("navigate project paths with an explicitly selected peer and branch", async ({
+    page,
+  }) => {
+    const projectTreeURL = `/#${sourceBrowsingUrl}/remotes/${aliceRemote.substring(
+      8,
+    )}/tree/main`;
+
+    await page.goto(projectTreeURL);
+    await expect(page).toHaveURL(projectTreeURL);
+
+    await page.getByText(".hidden").click();
+    await expect(page).toHaveURL(`${projectTreeURL}/.hidden`);
+
+    await page.getByText("bin/").click();
+    await page.getByText("true").click();
+    await expect(page).toHaveURL(`${projectTreeURL}/bin/true`);
+
+    await expectBackAndForwardNavigationWorks(
+      `${projectTreeURL}/.hidden`,
       page,
     );
     await expectUrlPersistsReload(page);

--- a/tests/e2e/historyRouter.spec.ts
+++ b/tests/e2e/historyRouter.spec.ts
@@ -72,6 +72,24 @@ test.describe("project page navigation", () => {
     await expectUrlPersistsReload(page);
   });
 
+  test("navigate between tree and commit history while a file is selected", async ({
+    page,
+  }) => {
+    const projectTreeURL = `${sourceBrowsingUrl}`;
+
+    await page.goto(projectTreeURL);
+    await page
+      .getByRole("progressbar", { name: "Page loading" })
+      .waitFor({ state: "hidden" });
+    await expect(page).toHaveURL(projectTreeURL);
+
+    await page.getByText(".hidden").click();
+    await expect(page).toHaveURL(`${projectTreeURL}/tree/.hidden`);
+
+    await page.getByRole("link", { name: "6 commits" }).click();
+    await expect(page).toHaveURL(`${sourceBrowsingUrl}/history`);
+  });
+
   test("navigate project paths", async ({ page }) => {
     const projectTreeURL = `${sourceBrowsingUrl}/tree/${aliceMainHead}`;
 
@@ -92,7 +110,12 @@ test.describe("project page navigation", () => {
     await expectUrlPersistsReload(page);
   });
 
-  test("navigate project paths with a selected peer", async ({ page }) => {
+  test("navigate project paths with an explicitly selected peer", async ({
+    page,
+  }) => {
+    // If a branch isn't explicitly specified, the code assumes the project
+    // default branch is selected. We omit showing the default branch in the URL.
+
     const projectTreeURL = `${sourceBrowsingUrl}/remotes/${aliceRemote.substring(
       8,
     )}`;
@@ -101,14 +124,38 @@ test.describe("project page navigation", () => {
     await expect(page).toHaveURL(projectTreeURL);
 
     await page.getByText(".hidden").click();
-    await expect(page).toHaveURL(`${projectTreeURL}/tree/main/.hidden`);
+    await expect(page).toHaveURL(`${projectTreeURL}/tree/.hidden`);
 
     await page.getByText("bin/").click();
     await page.getByText("true").click();
-    await expect(page).toHaveURL(`${projectTreeURL}/tree/main/bin/true`);
+    await expect(page).toHaveURL(`${projectTreeURL}/tree/bin/true`);
 
     await expectBackAndForwardNavigationWorks(
-      `${projectTreeURL}/tree/main/.hidden`,
+      `${projectTreeURL}/tree/.hidden`,
+      page,
+    );
+    await expectUrlPersistsReload(page);
+  });
+
+  test("navigate project paths with an explicitly selected peer and branch", async ({
+    page,
+  }) => {
+    const projectTreeURL = `${sourceBrowsingUrl}/remotes/${aliceRemote.substring(
+      8,
+    )}/tree/main`;
+
+    await page.goto(projectTreeURL);
+    await expect(page).toHaveURL(projectTreeURL);
+
+    await page.getByText(".hidden").click();
+    await expect(page).toHaveURL(`${projectTreeURL}/.hidden`);
+
+    await page.getByText("bin/").click();
+    await page.getByText("true").click();
+    await expect(page).toHaveURL(`${projectTreeURL}/bin/true`);
+
+    await expectBackAndForwardNavigationWorks(
+      `${projectTreeURL}/.hidden`,
       page,
     );
     await expectUrlPersistsReload(page);


### PR DESCRIPTION
This fixes not being able to navigate to the commit history while a file is selected on the default peer/branch.