### PR TITLE
prettier: Remove some values that are now defaults

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,5 @@
 {
   "arrowParens": "avoid",
-  "trailingComma": "all",
   "plugins": ["prettier-plugin-svelte"],
   "svelteSortOrder": "options-scripts-styles-markup",
   "bracketSameLine": true,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:ipfs": "VITE_HASH_ROUTING=1 vite build --base ./",
     "postinstall": "scripts/copy-katex-assets && scripts/install-twemoji-assets",
     "check": "scripts/check",
-    "format": "npx prettier '**/*.@(ts|js|svelte|json|css|html|yml)' --ignore-path .gitignore --write",
+    "format": "npx prettier '**/*.@(ts|js|svelte|json|css|html|yml)' --write",
     "test:unit": "TZ='UTC' vitest run",
     "test:e2e": "TZ='UTC' playwright test",
     "test:e2e:ipfs": "TZ='UTC' playwright test ./tests/e2e/hashRouter.spec.ts --config playwright.ipfs.config.ts",


### PR DESCRIPTION
- [prettier assumes now that we want to ignore files listed in .gitignore by default](https://prettier.io/blog/2023/07/05/3.0.0.html#ignore-gitignored-files-by-default-14731httpsgithubcomprettierprettierpull14731-by-fiskerhttpsgithubcomfisker)
- [trailingComma: all is now the default value](https://prettier.io/blog/2023/07/05/3.0.0.html#change-the-default-value-for-trailingcomma-to-all-11479httpsgithubcomprettierprettierpull11479-by-fiskerhttpsgithubcomfisker-13143httpsgithubcomprettierprettierpull13143-by-sosukesuzukihttpsgithubcomsosukesuzuki)

Related: #977