### PR TITLE
tests: Add e2e tests for patch and issue counters

### DIFF
--- a/tests/e2e/project/issues.spec.ts
+++ b/tests/e2e/project/issues.spec.ts
@@ -19,6 +19,40 @@ test("navigate single issue", async ({ page }) => {
   );
 });
 
+test("test issue counters", async ({ page, authenticatedPeer }) => {
+  const { rid, projectFolder } = await createProject(
+    authenticatedPeer,
+    "issue-counters",
+  );
+  await authenticatedPeer.rad(
+    [
+      "issue",
+      "open",
+      "--title",
+      "First issue to test counters",
+      "--description",
+      "Let's see",
+    ],
+    { cwd: projectFolder },
+  );
+  await page.goto(`${authenticatedPeer.uiUrl()}/${rid}/issues`);
+  await authenticatedPeer.rad(
+    [
+      "issue",
+      "open",
+      "--title",
+      "Second issue to test counters",
+      "--description",
+      "Let's see",
+    ],
+    { cwd: projectFolder },
+  );
+  await page.getByRole("button", { name: "1 open" }).click();
+  await expect(page.getByRole("button", { name: "2 issues" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "2 open" })).toBeVisible();
+  await expect(page.locator(".issues-list .teaser")).toHaveCount(2);
+});
+
 test("test issue editing failing", async ({ page, authenticatedPeer }) => {
   const { rid, projectFolder } = await createProject(
     authenticatedPeer,


### PR DESCRIPTION
When creating a new patch or issue, we want the counters to reflect on that on navigation.

Closes #974 