### PR TITLE
Sort projects in seed view by most recent activity

### DIFF
--- a/src/views/seeds/router.ts
+++ b/src/views/seeds/router.ts
@@ -58,10 +58,14 @@ export async function loadProjects(
       };
     }),
   );
+  // Sorts projects by most recent commit descending.
+  const sortedProjects = results.sort(
+    (a, b) => b.activity[0].time - a.activity[0].time,
+  );
 
   return {
     total: nodeStats.projects.count,
-    projects: results,
+    projects: sortedProjects,
   };
 }
 

--- a/tests/visual/seed.spec.ts
+++ b/tests/visual/seed.spec.ts
@@ -1,4 +1,3 @@
-import type { Project } from "@httpd-client";
 import { test, expect } from "@tests/support/fixtures.js";
 
 test("seed page", async ({ page }) => {
@@ -10,22 +9,6 @@ test("seed page", async ({ page }) => {
         shouldAdvanceTime: false,
       });
     };
-  });
-
-  // Repos in heartwood are read from storage with `fs::read_dir`
-  // which has no deterministic ordering, it depends on
-  // the filesystem and the operating system.
-  //
-  // > The order in which this iterator returns entries is platform and filesystem dependent.
-  // source: https://doc.rust-lang.org/std/fs/fn.read_dir.html
-  //
-  // So we sort the request here, to get a visually persistent listing.
-  // TODO: If at some point project sorting is introduced we can probably remove this.
-  await page.route("**/api/v1/projects?page=0&perPage=10", async route => {
-    const response = await route.fetch();
-    const json: Project[] = await response.json();
-    json.sort((a, b) => a.name.localeCompare(b.name));
-    await route.fulfill({ response, json });
   });
 
   await page.goto("/seeds/radicle.local", { waitUntil: "networkidle" });


### PR DESCRIPTION
Uses the projects activity, fetched from `/projects/${id}/activity` which is an array of commit timestamps.
So could suffer from some errors if commits with non current timestamps are being used.

Closes #967 