### PR TITLE
fix: Change `rad web` command when httpd port changes

### DIFF
--- a/src/App/Header/Connect.svelte
+++ b/src/App/Header/Connect.svelte
@@ -14,11 +14,12 @@
   import Link from "@app/components/Link.svelte";
   import PortInput from "@app/App/Header/Connect/PortInput.svelte";
 
+  $: customUrl = `${httpd.api.baseUrl.scheme}://${httpd.api.baseUrl.hostname}:${customPort}`;
   $: command = import.meta.env.PROD
-    ? `rad web --backend ${httpd.api.url}`
-    : `rad web --frontend ${new URL(import.meta.url).origin} --backend ${
-        httpd.api.url
-      }`;
+    ? `rad web --backend ${customUrl}`
+    : `rad web --frontend ${
+        new URL(import.meta.url).origin
+      } --backend ${customUrl}`;
 
   let customPort = httpd.api.port;
   const buttonTitle: Record<HttpdState["state"], string> = {

--- a/src/config.json
+++ b/src/config.json
@@ -2,6 +2,7 @@
   "reactions": ["👍", "👎", "😄", "🎉", "🙁", "🚀", "👀"],
   "seeds": {
     "defaultHttpdPort": 443,
+    "defaultLocalHttpdPort": 8080,
     "defaultHttpdScheme": "https",
     "defaultNodePort": 8776,
     "pinned": [

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,6 +6,7 @@ export interface Config {
   reactions: string[];
   seeds: {
     defaultHttpdPort: number;
+    defaultLocalHttpdPort: number;
     defaultNodePort: number;
     defaultHttpdScheme: string;
     pinned: { baseUrl: BaseUrl }[];
@@ -25,6 +26,7 @@ function getConfig(): Config {
       reactions: [],
       seeds: {
         defaultHttpdPort: 8081,
+        defaultLocalHttpdPort: 8081,
         defaultHttpdScheme: "http",
         defaultNodePort: 8776,
         pinned: [],

--- a/src/lib/httpd.ts
+++ b/src/lib/httpd.ts
@@ -25,7 +25,7 @@ export const httpdStore = derived(store, s => s);
 
 export const api = new HttpdClient({
   hostname: "127.0.0.1",
-  port: config.seeds.defaultHttpdPort,
+  port: config.seeds.defaultLocalHttpdPort,
   scheme: "http",
 });
 

--- a/tests/e2e/httpd.spec.ts
+++ b/tests/e2e/httpd.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@tests/support/fixtures.js";
+
+test("rad web command reacts to port change", async ({ page, peerManager }) => {
+  const peer = await peerManager.startPeer({
+    name: "port-test",
+  });
+  await peer.startHttpd(8090);
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "radicle.local" }).click();
+
+  await expect(
+    page.getByText(
+      "rad web --frontend http://localhost:3001 --backend http://127.0.0.1:8081",
+    ),
+  ).toBeVisible();
+  await page.locator('input[name="port"]').fill("8090");
+  await page.locator('input[name="port"]').press("Enter");
+
+  await expect(
+    page.getByText(
+      "rad web --frontend http://localhost:3001 --backend http://127.0.0.1:8090",
+    ),
+  ).toBeVisible();
+
+  await peer.stopHttpd();
+});

--- a/tests/support/fixtures.ts
+++ b/tests/support/fixtures.ts
@@ -94,6 +94,7 @@ export const test = base.extend<{
             reactions: [],
             seeds: {
               defaultHttpdPort: 8081,
+              defaultLocalHttpdPort: 8081,
               defaultHttpdScheme: "http",
               defaultNodePort: 8776,
               pinned: [
@@ -231,6 +232,7 @@ export function appConfigWithFixture() {
     reactions: [],
     seeds: {
       defaultHttpdPort: 8081,
+      defaultLocalHttpdPort: 8081,
       defaultHttpdScheme: "http",
       defaultNodePort: 8776,
       pinned: [


### PR DESCRIPTION
Instead of using always the `config.seeds.defaultHttpdPort` which is 443, we should take into account the `customPort` variable that is set by the user.

Also adds a `config.defaultLocalHttpdPort` so we can define what we want the local httpd port to be in production.

Closes #965