### PR TITLE
Add `parents` property to `CommitHeader` type

### DIFF
--- a/httpd-client/lib/project/commit.ts
+++ b/httpd-client/lib/project/commit.ts
@@ -16,6 +16,7 @@ export interface CommitHeader {
   author: GitPerson;
   summary: string;
   description: string;
+  parents: string[];
   committer: GitPerson & { time: number };
 }
 
@@ -24,6 +25,7 @@ export const commitHeaderSchema = object({
   author: gitPersonSchema,
   summary: string(),
   description: string(),
+  parents: array(string()),
   committer: gitPersonSchema.merge(object({ time: number() })),
 }) satisfies ZodSchema<CommitHeader>;
 


### PR DESCRIPTION
Adds new `parents` property on `CommitHeader` introduced in https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5/commits/5cb4d5cd7629d30e95413d91356d1182d34383f1