### PR TITLE
Fix project sorting on node page when there is no activity data

### DIFF
--- a/src/views/nodes/router.ts
+++ b/src/views/nodes/router.ts
@@ -60,7 +60,7 @@ export async function loadProjects(
   );
   // Sorts projects by most recent commit descending.
   const sortedProjects = results.sort(
-    (a, b) => b.activity[0].time - a.activity[0].time,
+    (a, b) => b.activity[0]?.time - a.activity[0]?.time,
   );
 
   return {


### PR DESCRIPTION
TBD: add a testcase.