### PR TITLE
Improve node view error handling

### DIFF
--- a/src/views/nodes/router.ts
+++ b/src/views/nodes/router.ts
@@ -109,11 +109,15 @@ export async function loadNodeRoute(
       },
     };
   } catch (error: any) {
-    return {
-      resource: "notFound",
-      params: {
-        title: "Node not found",
-      },
-    };
+    if (error.message === "Failed to fetch") {
+      return {
+        resource: "notFound",
+        params: {
+          title: "Node not found",
+        },
+      };
+    } else {
+      throw error;
+    }
   }
 }

--- a/tests/e2e/project.spec.ts
+++ b/tests/e2e/project.spec.ts
@@ -447,7 +447,6 @@ test("external markdown link", async ({ page }) => {
   });
   await page.goto(`${markdownUrl}/tree/main/footnotes.md`);
   await page.getByRole("link", { name: "https://example.com" }).click();
-  await page.pause();
   await expect(page).toHaveURL("https://example.com");
 });
 


### PR DESCRIPTION
We only show "Node not found" on load errors. All other errors will be rethrown.