### PR TITLE
Add key to each loop in project listing

### DIFF
--- a/src/components/ProjectCard.svelte
+++ b/src/components/ProjectCard.svelte
@@ -5,13 +5,12 @@
 
   import ActivityDiagram from "@app/components/ActivityDiagram.svelte";
 
+  export let activity: WeeklyActivity[];
   export let compact = false;
   export let description: string;
   export let head: string;
   export let id: string;
   export let name: string;
-
-  export let activity: WeeklyActivity[];
 </script>
 
 <style>

--- a/src/views/nodes/View.svelte
+++ b/src/views/nodes/View.svelte
@@ -121,7 +121,7 @@
 
   <div style:margin-bottom="5rem">
     <div style:margin-top="1rem">
-      {#each projects as { project, activity }}
+      {#each projects as { project, activity } (project.id)}
         <div style:margin-bottom="0.5rem">
           <Link
             route={{


### PR DESCRIPTION
This fix a regression we started to have after #1002, when starting to sort projects after loading more.
Fixed by adding a key to the each loop.

- [ ] Should add a visual test with loading multiple projects and see that nothing breaks.