### PR TITLE
Add local projects to landing page, if available

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -28,8 +28,7 @@
 
   const activeRouteStore = router.activeRouteStore;
 
-  void router.loadFromLocation();
-  httpd.initialize();
+  void httpd.initialize().finally(() => void router.loadFromLocation());
 
   if (!window.VITEST && !window.PLAYWRIGHT && import.meta.env.PROD) {
     const plausible = Plausible({

--- a/src/lib/httpd.ts
+++ b/src/lib/httpd.ts
@@ -147,7 +147,7 @@ function pollSession() {
   pollHttpdStateHandle = window.setInterval(() => checkState(), 10_000);
 }
 
-export function initialize() {
+export async function initialize() {
   // Sync session state changes with other open tabs and windows.
   addEventListener("storage", event => {
     if (
@@ -159,7 +159,7 @@ export function initialize() {
     }
   });
 
-  void checkState();
+  await checkState();
 
   // Properly clean up setInterval and restart session polling when Vite
   // performs hot module reload on file changes.

--- a/src/views/home/Index.svelte
+++ b/src/views/home/Index.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   import type { ProjectBaseUrlActivity } from "./router";
 
+  import { api } from "@app/lib/httpd";
   import { twemoji } from "@app/lib/utils";
 
   import Link from "@app/components/Link.svelte";
   import ProjectCard from "@app/components/ProjectCard.svelte";
 
   export let projects: ProjectBaseUrlActivity[];
+
+  $: localProjects = projects[0]?.baseUrl === api.baseUrl;
 </script>
 
 <style>
@@ -61,8 +64,13 @@
 
   {#if projects.length > 0}
     <div class="heading">
-      Explore <span class="txt-bold">projects</span>
-      on the Radicle network.
+      {#if localProjects}
+        Explore <span class="txt-bold">projects</span>
+        on your local node.
+      {:else}
+        Explore <span class="txt-bold">projects</span>
+        on the Radicle network.
+      {/if}
     </div>
 
     <div class="projects">

--- a/tests/e2e/landingPage.spec.ts
+++ b/tests/e2e/landingPage.spec.ts
@@ -13,7 +13,7 @@ test("show pinned projects", async ({ page }) => {
   await page.addInitScript(appConfigWithFixture);
   await page.goto("/");
   await expect(
-    page.getByText("Explore projects on the Radicle network."),
+    page.getByText("Explore projects on your local node."),
   ).toBeVisible();
 
   // Shows pinned project name.

--- a/tests/support/fixtures.ts
+++ b/tests/support/fixtures.ts
@@ -226,11 +226,11 @@ function log(text: string, label: string, outputLog: Stream.Writable) {
   }
 }
 
-export function appConfigWithFixture() {
+export function appConfigWithFixture(defaultLocalHttpdPort = 8081) {
   window.APP_CONFIG = {
     nodes: {
       defaultHttpdPort: 8081,
-      defaultLocalHttpdPort: 8081,
+      defaultLocalHttpdPort: defaultLocalHttpdPort,
       defaultHttpdScheme: "http",
       defaultNodePort: 8776,
       pinned: [

--- a/tests/visual/landingPage.spec.ts
+++ b/tests/visual/landingPage.spec.ts
@@ -36,7 +36,7 @@ test("load error", async ({ page }) => {
     route => route.fulfill({ status: 500 }),
   );
 
-  await page.addInitScript(appConfigWithFixture);
+  await page.addInitScript(appConfigWithFixture, 8090);
   await page.goto("/", { waitUntil: "networkidle" });
   await expect(page).toHaveScreenshot();
 });


### PR DESCRIPTION
This PR shows either the projects found on a local node to the landing page, or fallback to the pinned ones in `config.projects.pinned`