### PR TITLE
Fix vite reloading during e2e tests

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,10 @@ export default defineConfig({
   server: {
     host: "localhost",
     port: 3000,
+    watch: {
+      // reference: https://stackoverflow.com/a/75238360
+      useFsEvents: false,
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Okay let's rewrite this.. 😀 

So the issue is that having one vite dev server running on one port, and then starting the e2e or httpd-api test suite with playwright, there are moments that the vite dev server gets restarted due to changes to either `vite.config.ts` or `svelte.config.js`, 

So this PR adds the following glob patterns to be ignored by the vite file watcher, since they aren't code that we change often, and don't think we need hot reload for it.
```
[
  "**/vite.config.ts/**",
  "**/svelte.config.js/**",
],
```

So if we ignore those patterns for the vite file watcher (uses chokidar) the tests are running fine, and we still have hot reload for all the other files