### PR TITLE
Diff highlighting in the background with starry night

### DIFF
--- a/httpd-client/index.ts
+++ b/httpd-client/index.ts
@@ -1,7 +1,6 @@
 import type { BaseUrl } from "./lib/fetcher.js";
 import type {
   Blob,
-  CommitBlob,
   Project,
   Remote,
   Tree,
@@ -10,6 +9,8 @@ import type {
 import type { Comment } from "./lib/project/comment.js";
 import type {
   Commit,
+  CommitBlob,
+  CommitWithFiles,
   CommitHeader,
   Diff,
   DiffContent,
@@ -41,6 +42,7 @@ export type {
   BaseUrl,
   Blob,
   CommitBlob,
+  CommitWithFiles,
   CodeLocation,
   Comment,
   Commit,

--- a/httpd-client/index.ts
+++ b/httpd-client/index.ts
@@ -40,6 +40,7 @@ import { Fetcher } from "./lib/fetcher.js";
 export type {
   BaseUrl,
   Blob,
+  CommitBlob,
   CodeLocation,
   Comment,
   Commit,

--- a/httpd-client/index.ts
+++ b/httpd-client/index.ts
@@ -41,7 +41,6 @@ import { Fetcher } from "./lib/fetcher.js";
 export type {
   BaseUrl,
   Blob,
-  CommitBlob,
   CommitWithFiles,
   CodeLocation,
   Comment,

--- a/httpd-client/lib/project.ts
+++ b/httpd-client/lib/project.ts
@@ -1,8 +1,4 @@
-import type {
-  CommitHeader,
-  CommitWithFiles,
-  Commits,
-} from "./project/commit.js";
+import type { CommitWithFiles, Commits } from "./project/commit.js";
 import type { Fetcher, RequestOptions } from "./fetcher.js";
 import type {
   Issue,

--- a/httpd-client/lib/project.ts
+++ b/httpd-client/lib/project.ts
@@ -1,4 +1,4 @@
-import type { Commit, Commits } from "./project/commit.js";
+import type { Commit, CommitHeader, Commits } from "./project/commit.js";
 import type { Fetcher, RequestOptions } from "./fetcher.js";
 import type {
   Issue,
@@ -88,7 +88,8 @@ export type Blob = z.infer<typeof blobSchema>;
 
 const commitBlobSchema = object({
   binary: boolean(),
-  content: optional(string()),
+  content: string(),
+  id: string(),
   lastCommit: commitHeaderSchema,
 });
 

--- a/httpd-client/lib/project.ts
+++ b/httpd-client/lib/project.ts
@@ -1,4 +1,8 @@
-import type { Commit, CommitHeader, Commits } from "./project/commit.js";
+import type {
+  CommitHeader,
+  CommitWithFiles,
+  Commits,
+} from "./project/commit.js";
 import type { Fetcher, RequestOptions } from "./fetcher.js";
 import type {
   Issue,
@@ -29,8 +33,9 @@ import {
 } from "zod";
 
 import {
+  commitBlobSchema,
   commitHeaderSchema,
-  commitSchema,
+  commitSchemaWithFiles,
   commitsSchema,
   diffSchema,
 } from "./project/commit.js";
@@ -85,15 +90,6 @@ const blobSchema = object({
 });
 
 export type Blob = z.infer<typeof blobSchema>;
-
-const commitBlobSchema = object({
-  binary: boolean(),
-  content: string(),
-  id: string(),
-  lastCommit: commitHeaderSchema,
-});
-
-export type CommitBlob = z.infer<typeof commitBlobSchema>;
 
 const treeEntrySchema = object({
   path: string(),
@@ -305,14 +301,14 @@ export class Client {
     id: string,
     sha: string,
     options?: RequestOptions,
-  ): Promise<Commit> {
+  ): Promise<CommitWithFiles> {
     return this.#fetcher.fetchOk(
       {
         method: "GET",
         path: `projects/${id}/commits/${sha}`,
         options,
       },
-      commitSchema,
+      commitSchemaWithFiles,
     );
   }
 

--- a/httpd-client/lib/project/commit.ts
+++ b/httpd-client/lib/project/commit.ts
@@ -1,17 +1,35 @@
 import type { z } from "zod";
 export type {
+  Commit,
+  CommitHeader,
+  CommitWithFiles,
   Commits,
+  Diff,
+  DiffContent,
+  DiffFile,
   HunkLine,
   Hunks,
-  Commit,
-  Diff,
-  CommitHeader,
-  DiffFile,
-  DiffContent,
 };
 
-import { array, literal, number, object, optional, string, union } from "zod";
-export { commitHeaderSchema, diffSchema, commitSchema, commitsSchema };
+import {
+  array,
+  boolean,
+  literal,
+  number,
+  object,
+  optional,
+  record,
+  string,
+  union,
+} from "zod";
+export {
+  commitHeaderSchema,
+  commitSchemaWithFiles,
+  diffSchema,
+  commitSchema,
+  commitsSchema,
+  commitBlobSchema,
+};
 
 const gitPersonSchema = object({
   name: string(),
@@ -140,6 +158,15 @@ const diffSchema = object({
   }),
 });
 
+const commitBlobSchema = object({
+  binary: boolean(),
+  content: string(),
+  id: string(),
+  lastCommit: commitHeaderSchema,
+});
+
+export type CommitBlob = z.infer<typeof commitBlobSchema>;
+
 type Commit = z.infer<typeof commitSchema>;
 
 const commitSchema = object({
@@ -147,6 +174,12 @@ const commitSchema = object({
   diff: diffSchema,
   branches: array(string()),
 });
+
+type CommitWithFiles = z.infer<typeof commitSchemaWithFiles>;
+
+const commitSchemaWithFiles = commitSchema.merge(
+  object({ files: record(string(), commitBlobSchema) }),
+);
 
 type Commits = z.infer<typeof commitsSchema>;
 

--- a/src/components/Observer.svelte
+++ b/src/components/Observer.svelte
@@ -1,0 +1,39 @@
+<script lang="ts" context="module">
+  export function intersection(
+    node: HTMLElement,
+    observer: IntersectionObserver | undefined,
+  ) {
+    if (!observer) return;
+    observer.observe(node);
+    return {
+      destroy() {
+        observer.unobserve(node);
+      },
+    };
+  }
+</script>
+
+<script lang="ts">
+  import { onDestroy } from "svelte";
+
+  let observer: IntersectionObserver | undefined = undefined;
+  let filesVisibility = new Set<string>();
+
+  if ("IntersectionObserver" in window) {
+    observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          filesVisibility = filesVisibility.add(entry.target.id.substring(9));
+        }
+      });
+    });
+  }
+
+  onDestroy(() => {
+    if (observer) {
+      observer.disconnect();
+    }
+  });
+</script>
+
+<slot {observer} {filesVisibility} />

--- a/src/views/projects/Changeset.svelte
+++ b/src/views/projects/Changeset.svelte
@@ -91,6 +91,7 @@
       {projectId}
       {baseUrl}
       revision={revision ?? files[file.new.oid].lastCommit.id}
+      content={files[file.new.oid].content}
       filePath={file.path}
       fileDiff={{ ...file.diff, type: getFileType(file.diff, file.new) }}
       headerBadgeCaption="added" />
@@ -100,6 +101,7 @@
       {projectId}
       {baseUrl}
       revision={revision ?? files[file.old.oid].lastCommit.id}
+      content={files[file.old.oid].content}
       filePath={file.path}
       fileDiff={{ ...file.diff, type: getFileType(file.diff, file.old) }}
       headerBadgeCaption="deleted" />
@@ -109,6 +111,8 @@
       {projectId}
       {baseUrl}
       revision={revision ?? files[file.new.oid].lastCommit.id}
+      oldContent={files[file.old.oid].content}
+      content={files[file.new.oid].content}
       filePath={file.path}
       fileDiff={{ ...file.diff, type: getFileType(file.diff, file.new) }} />
   {/each}
@@ -118,6 +122,7 @@
         {projectId}
         {baseUrl}
         {revision}
+        content=""
         filePath={file.newPath}
         oldFilePath={file.oldPath}
         fileDiff={file.diff}

--- a/src/views/projects/Changeset.svelte
+++ b/src/views/projects/Changeset.svelte
@@ -91,7 +91,7 @@
       {projectId}
       {baseUrl}
       revision={revision ?? files[file.new.oid].lastCommit.id}
-      content={files[file.new.oid].content}
+      content={files[file.new.oid]?.content}
       filePath={file.path}
       fileDiff={{ ...file.diff, type: getFileType(file.diff, file.new) }}
       headerBadgeCaption="added" />
@@ -101,7 +101,7 @@
       {projectId}
       {baseUrl}
       revision={revision ?? files[file.old.oid].lastCommit.id}
-      content={files[file.old.oid].content}
+      content={files[file.old.oid]?.content}
       filePath={file.path}
       fileDiff={{ ...file.diff, type: getFileType(file.diff, file.old) }}
       headerBadgeCaption="deleted" />
@@ -111,8 +111,8 @@
       {projectId}
       {baseUrl}
       revision={revision ?? files[file.new.oid].lastCommit.id}
-      oldContent={files[file.old.oid].content}
-      content={files[file.new.oid].content}
+      oldContent={files[file.old.oid]?.content}
+      content={files[file.new.oid]?.content}
       filePath={file.path}
       fileDiff={{ ...file.diff, type: getFileType(file.diff, file.new) }} />
   {/each}

--- a/src/views/projects/Changeset/FileDiff.svelte
+++ b/src/views/projects/Changeset/FileDiff.svelte
@@ -65,7 +65,6 @@
     let highlightedOldContent: string[] | undefined = undefined;
     let highlightedContent: string[] | undefined = undefined;
 
-    console.log(content);
     if (extension && content) {
       highlightedContent = toHtml(
         await Syntax.highlight(content, extension),
@@ -328,6 +327,7 @@
     padding: 0 0.75rem 0 0.5rem;
   }
   .diff-line-content {
+    color: unset !important;
     white-space: pre-wrap;
     overflow-wrap: anywhere;
     width: 100%;

--- a/src/views/projects/Changeset/FileDiff.svelte
+++ b/src/views/projects/Changeset/FileDiff.svelte
@@ -80,8 +80,7 @@
     return undefined;
   }
 
-  // TODO: this is a hacky way to get the root element of the component
-  let root: any;
+  let root: { new: string[]; old?: string[] } | undefined = undefined;
   void highlightContent().then(r => (root = r));
 
   function updateSelection() {

--- a/src/views/projects/Changeset/FileDiff.svelte
+++ b/src/views/projects/Changeset/FileDiff.svelte
@@ -11,7 +11,7 @@
 
   export let filePath: string;
   export let oldContent: string | undefined = undefined;
-  export let content: string;
+  export let content: string | undefined = undefined;
   export let oldFilePath: string | undefined = undefined;
   export let fileDiff: DiffContent;
   export let revision: string | undefined = undefined;
@@ -65,7 +65,8 @@
     let highlightedOldContent: string[] | undefined = undefined;
     let highlightedContent: string[] | undefined = undefined;
 
-    if (extension) {
+    console.log(content);
+    if (extension && content) {
       highlightedContent = toHtml(
         await Syntax.highlight(content, extension),
       ).split("\n");

--- a/src/views/projects/Commit.svelte
+++ b/src/views/projects/Commit.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Commit, BaseUrl, Project } from "@httpd-client";
+  import type { CommitWithFiles, BaseUrl, Project } from "@httpd-client";
 
   import { formatCommit } from "@app/lib/utils";
 
@@ -10,7 +10,7 @@
   import Layout from "./Layout.svelte";
 
   export let baseUrl: BaseUrl;
-  export let commit: Commit;
+  export let commit: CommitWithFiles;
   export let project: Project;
 
   $: header = commit.commit;
@@ -72,6 +72,7 @@
     <Changeset
       projectId={project.id}
       {baseUrl}
+      files={commit.files}
       diff={commit.diff}
       revision={commit.commit.id} />
   </div>

--- a/src/views/projects/router.ts
+++ b/src/views/projects/router.ts
@@ -5,9 +5,9 @@ import type {
 import type {
   BaseUrl,
   Blob,
-  Commit,
   CommitBlob,
   CommitHeader,
+  CommitWithFiles,
   Diff,
   Issue,
   IssueState,
@@ -133,7 +133,7 @@ export type ProjectLoadedRoute =
       params: {
         baseUrl: BaseUrl;
         project: Project;
-        commit: Commit;
+        commit: CommitWithFiles;
       };
     }
   | {

--- a/src/views/projects/router.ts
+++ b/src/views/projects/router.ts
@@ -133,7 +133,6 @@ export type ProjectLoadedRoute =
       params: {
         baseUrl: BaseUrl;
         project: Project;
-
         commit: Commit;
       };
     }


### PR DESCRIPTION
This PR brings the long awaited diff syntax highlighting..
A few points:

- The blobs shown in the code browser are still highlighted in the router.
- For diffs we fetch the same endpoints, which in the meantime return also the files as part of the payload.
- So we take those files and highlight them in the `FileDiff` component (we can also go a bit higher if wanted)
- So we initially show the non highlighted content which is quick, and then in the background we highlight content and once ready switch the content for the highlighted one.


Pending
- [ ] Add some optimization to not render all files of a diff, but only the once that are viewed.
- [ ] Need a heartwood patch [0b5c437200f73960adcf51c2e4013b9c872f4e0c](https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5/patches/0b5c437200f73960adcf51c2e4013b9c872f4e0c) to be merged