### PR TITLE
Improve binary detection

### DIFF
--- a/httpd-client/index.ts
+++ b/httpd-client/index.ts
@@ -13,6 +13,7 @@ import type {
   CommitHeader,
   Diff,
   DiffContent,
+  DiffFile,
   HunkLine,
 } from "./lib/project/commit.js";
 import type { Issue, IssueState } from "./lib/project/issue.js";
@@ -46,6 +47,7 @@ export type {
   CommitHeader,
   Diff,
   DiffContent,
+  DiffFile,
   DiffResponse,
   HunkLine,
   Issue,

--- a/httpd-client/lib/project/commit.ts
+++ b/httpd-client/lib/project/commit.ts
@@ -1,5 +1,14 @@
 import type { z } from "zod";
-export type { Commits, HunkLine, Commit, Diff, CommitHeader, DiffContent };
+export type {
+  Commits,
+  HunkLine,
+  Hunks,
+  Commit,
+  Diff,
+  CommitHeader,
+  DiffFile,
+  DiffContent,
+};
 
 import { array, literal, number, object, optional, string, union } from "zod";
 export { commitHeaderSchema, diffSchema, commitSchema, commitsSchema };
@@ -36,6 +45,8 @@ const deletionHunkLineSchema = object({
   type: literal("deletion"),
 });
 
+type DiffFile = z.infer<typeof diffFileSchema>;
+
 const diffFileSchema = object({
   oid: string(),
   mode: union([
@@ -63,6 +74,8 @@ const hunkLineSchema = union([
   deletionHunkLineSchema,
   contextHunkLineSchema,
 ]);
+
+type Hunks = z.infer<typeof changesetHunkSchema>;
 
 const changesetHunkSchema = object({
   header: string(),

--- a/tests/e2e/project/commit.spec.ts
+++ b/tests/e2e/project/commit.spec.ts
@@ -103,6 +103,13 @@ test("copied file", async ({ page }) => {
   await expect(page.getByText("copied", { exact: true })).toBeVisible();
 });
 
+test("binary file detection in diffs", async ({ page }) => {
+  await page.goto(
+    `${sourceBrowsingUrl}/commits/335dd6dc89b535a4a31e9422c803199bb6b0a09a`,
+  );
+  await expect(page.getByText("Binary file")).toBeVisible();
+});
+
 test("navigation to source tree at specific revision", async ({ page }) => {
   await page.goto(
     `${sourceBrowsingUrl}/commits/0801aceeab500033f8d608778218657bd626ef73`,


### PR DESCRIPTION
libgit2 optimizes around not loading the content, when there's no content callbacks configured.

So we aren't able to get a clear answer from radicle-surf if a file in a diff is a binary or not.

A simple way without doing additional API requests is to check if the file type is a executable and if there are no hunks (since we don't get any deltas in binaries), this is a strong
indicator for a binary.

References:
https://github.com/libgit2/libgit2/issues/6637#issuecomment-1733118686
https://github.com/rust-lang/git2-rs/issues/991

Closes #1039 